### PR TITLE
fix(input): drive keyboard lock LEDs from XKB state


### DIFF
--- a/crates/yserver/src/input/context.rs
+++ b/crates/yserver/src/input/context.rs
@@ -23,7 +23,7 @@ use std::{
 use crate::seat::{DeviceKind, LibseatInner};
 
 use input::{
-    Device, Event, Libinput, LibinputInterface,
+    Device, DeviceCapability, Event, Led, Libinput, LibinputInterface,
     event::{
         EventTrait,
         keyboard::{KeyState, KeyboardEvent, KeyboardEventTrait},
@@ -85,6 +85,17 @@ pub struct Context {
     /// drops its borrow, and the entry's eventual `remove(...)` drops
     /// the last ref.
     touchpad_devices: HashMap<String, Device>,
+    /// Live handles for keyboard-capability devices, same keying and
+    /// refcount semantics as `touchpad_devices`. Consumed by
+    /// [`Context::update_leds`] — the XKB lock state (Caps/Num/Scroll)
+    /// lives in the server core, so the server must push LED changes
+    /// down to the hardware via `libinput_device_led_update`; nothing
+    /// else will (this is the KMS server, there is no other driver).
+    keyboard_devices: HashMap<String, Device>,
+    /// Last LED mask applied — re-applied to keyboards that appear
+    /// later (hotplug, VT-switch re-acquire re-adds devices with their
+    /// LEDs reset).
+    last_leds: Led,
 }
 
 /// Newtype wrapper around `Context` that implements `Send`.
@@ -104,6 +115,10 @@ impl SendContext {
 
     pub fn dispatch(&mut self) -> io::Result<Vec<InputEvent>> {
         self.0.dispatch()
+    }
+
+    pub fn update_leds(&mut self, leds: Led) {
+        self.0.update_leds(leds);
     }
 }
 
@@ -126,6 +141,8 @@ impl Context {
         Ok(Self {
             libinput,
             touchpad_devices: HashMap::new(),
+            keyboard_devices: HashMap::new(),
+            last_leds: Led::empty(),
         })
     }
 
@@ -190,6 +207,23 @@ impl Context {
                         self.touchpad_devices
                             .insert(device_node.clone(), dev.clone());
                     }
+                    // Keyboard-capability devices are stashed for LED
+                    // writes (update_leds). Re-apply the current lock-
+                    // LED mask to a newly-appearing keyboard: hotplug
+                    // and VT-switch re-acquire re-add devices with
+                    // their LEDs reset, but the X-side lock state
+                    // persists.
+                    if dev.has_capability(DeviceCapability::Keyboard) {
+                        // Force the device to the current lock state
+                        // unconditionally — including all-off — so a
+                        // keyboard that appears with a stale firmware
+                        // LED (e.g. a BIOS-lit NumLock) is corrected to
+                        // match the server, not just keyboards added
+                        // while a lock happens to be active.
+                        dev.led_update(self.last_leds);
+                        self.keyboard_devices
+                            .insert(device_node.clone(), dev.clone());
+                    }
                     let info = DeviceInfo {
                         name,
                         device_node,
@@ -214,6 +248,7 @@ impl Context {
                     // T4: drop the stashed handle (libinput unref via Drop).
                     // No-op if the device wasn't a touchpad (never inserted).
                     self.touchpad_devices.remove(&device_node);
+                    self.keyboard_devices.remove(&device_node);
                     out.push(InputEvent::DeviceRemoved { device_node });
                 }
                 _ => {}
@@ -223,6 +258,19 @@ impl Context {
             }
         }
         Ok(out)
+    }
+
+    /// Push the X-side lock-LED state (Caps/Num/Scroll) to every
+    /// keyboard device. Called on lock-state transitions — directly by
+    /// the libseat-mode backend (context lives on the core thread), or
+    /// from the input thread after a [`crate::input::LedRelay`] wakeup
+    /// in Direct mode. Also remembered for keyboards that appear later
+    /// (see the DeviceAdded arm).
+    pub fn update_leds(&mut self, leds: Led) {
+        self.last_leds = leds;
+        for dev in self.keyboard_devices.values_mut() {
+            dev.led_update(leds);
+        }
     }
 
     /// Route a decoded `xinput set-prop` write through to the live
@@ -335,6 +383,8 @@ impl Context {
         Ok(Self {
             libinput,
             touchpad_devices: HashMap::new(),
+            keyboard_devices: HashMap::new(),
+            last_leds: Led::empty(),
         })
     }
 

--- a/crates/yserver/src/input/leds.rs
+++ b/crates/yserver/src/input/leds.rs
@@ -1,0 +1,71 @@
+//! Core-thread → libinput-thread keyboard-LED relay (Direct mode).
+//!
+//! The XKB lock state (Caps/Num/Scroll) lives on the core thread in
+//! `KmsCore.xkb_state`; the libinput context that can write LEDs via
+//! `libinput_device_led_update` lives on the dedicated input thread in
+//! Direct mode. The relay carries the desired LED bitmask across:
+//! the core stores the mask and arms an eventfd that sits in the input
+//! thread's epoll set alongside the libinput fd; the thread drains the
+//! eventfd and applies the mask to every keyboard device.
+//!
+//! Libseat mode has no thread hop — the backend owns the libinput
+//! context on the core thread and calls `Context::update_leds`
+//! directly; the relay is unused there.
+
+use std::{
+    io,
+    os::fd::{AsFd, AsRawFd, RawFd},
+    sync::atomic::{AtomicU32, Ordering},
+};
+
+use nix::sys::eventfd::{EfdFlags, EventFd};
+
+pub struct LedRelay {
+    /// Desired LED state, `input::Led` bits.
+    mask: AtomicU32,
+    /// Wakes the input thread's epoll when the mask changes.
+    efd: EventFd,
+}
+
+impl LedRelay {
+    pub fn new() -> io::Result<Self> {
+        let efd = EventFd::from_value_and_flags(0, EfdFlags::EFD_NONBLOCK | EfdFlags::EFD_CLOEXEC)
+            .map_err(|e| io::Error::other(format!("LedRelay eventfd: {e}")))?;
+        Ok(Self {
+            mask: AtomicU32::new(0),
+            efd,
+        })
+    }
+
+    /// Core side: publish a new LED mask and wake the input thread.
+    pub fn set(&self, led_bits: u32) {
+        self.mask.store(led_bits, Ordering::Release);
+        // Wake the input thread. The LED apply is gated on this eventfd
+        // (the thread doesn't re-read the mask on ordinary input
+        // events), so a dropped wakeup would leave the LED stale until
+        // the NEXT lock transition. Retry on EINTR; log anything else.
+        loop {
+            match self.efd.write(1) {
+                Ok(_) => break,
+                Err(nix::errno::Errno::EINTR) => continue,
+                Err(e) => {
+                    log::warn!("LedRelay: eventfd wakeup write failed: {e}");
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Input-thread side: fd to register in the epoll set.
+    pub fn fd(&self) -> RawFd {
+        self.efd.as_fd().as_raw_fd()
+    }
+
+    /// Input-thread side: clear the wakeup and read the current mask.
+    /// EFD_NONBLOCK makes the read on an un-armed eventfd a harmless
+    /// EAGAIN.
+    pub fn drain(&self) -> u32 {
+        let _ = self.efd.read();
+        self.mask.load(Ordering::Acquire)
+    }
+}

--- a/crates/yserver/src/input/mod.rs
+++ b/crates/yserver/src/input/mod.rs
@@ -1,7 +1,9 @@
 pub mod context;
 pub mod event;
 pub mod hotkey;
+pub mod leds;
 pub mod libinput_config;
 
 pub use context::{Context, SendContext};
 pub use event::InputEvent;
+pub use leds::LedRelay;

--- a/crates/yserver/src/input_thread.rs
+++ b/crates/yserver/src/input_thread.rs
@@ -313,12 +313,24 @@ pub fn process_batch(
 /// and flushes any leftover pending motion at the end of each batch so
 /// the core never sees stale "latest motion" sitting in the channel.
 ///
+/// `led_relay` carries lock-LED updates from the core thread (which
+/// owns the XKB lock state) into this thread (which owns the libinput
+/// devices); its eventfd sits in the same epoll set as the libinput fd.
+///
 /// Returns only on a fatal send error (channel closed = core gone).
-pub fn run(input_ctx: SendContext, sender: CoreSender, fb_w: u32, fb_h: u32) -> io::Result<()> {
+pub fn run(
+    input_ctx: SendContext,
+    sender: CoreSender,
+    fb_w: u32,
+    fb_h: u32,
+    led_relay: std::sync::Arc<crate::input::LedRelay>,
+) -> io::Result<()> {
     let mut input_ctx = input_ctx;
     let mut state = LibinputThreadState::new(fb_w, fb_h);
     let mut pending_motion: Option<HostInputEvent> = None;
 
+    const EPOLL_DATA_LIBINPUT: u64 = 0;
+    const EPOLL_DATA_LEDS: u64 = 1;
     let input_epoll = Epoll::new(EpollCreateFlags::empty())
         .map_err(|err| io::Error::other(format!("input thread epoll_create: {err}")))?;
     let fd = input_ctx.fd();
@@ -326,8 +338,20 @@ pub fn run(input_ctx: SendContext, sender: CoreSender, fb_w: u32, fb_h: u32) -> 
     // the duration of `run`.
     let borrow = unsafe { BorrowedFd::borrow_raw(fd) };
     input_epoll
-        .add(borrow, EpollEvent::new(EpollFlags::EPOLLIN, 0))
+        .add(
+            borrow,
+            EpollEvent::new(EpollFlags::EPOLLIN, EPOLL_DATA_LIBINPUT),
+        )
         .map_err(|err| io::Error::other(format!("input thread epoll_add: {err}")))?;
+    // SAFETY: `led_relay` (Arc) outlives this borrow — held for the
+    // duration of `run`.
+    let led_borrow = unsafe { BorrowedFd::borrow_raw(led_relay.fd()) };
+    input_epoll
+        .add(
+            led_borrow,
+            EpollEvent::new(EpollFlags::EPOLLIN, EPOLL_DATA_LEDS),
+        )
+        .map_err(|err| io::Error::other(format!("input thread epoll_add (leds): {err}")))?;
 
     // Drain udev's initial device enumeration before waiting on
     // epoll. udev_assign_seat queues DeviceAdded events synchronously
@@ -355,7 +379,17 @@ pub fn run(input_ctx: SendContext, sender: CoreSender, fb_w: u32, fb_h: u32) -> 
     let mut buf = [EpollEvent::empty(); 4];
     loop {
         match input_epoll.wait(&mut buf, EpollTimeout::NONE) {
-            Ok(_) => {}
+            Ok(n) => {
+                // Core-thread lock-LED update: drain the eventfd and
+                // push the mask to every keyboard device. Falls through
+                // to the libinput dispatch below (harmless when the
+                // libinput fd wasn't the waker — dispatch just returns
+                // no events).
+                if buf[..n].iter().any(|e| e.data() == EPOLL_DATA_LEDS) {
+                    let leds = input::Led::from_bits_truncate(led_relay.drain());
+                    input_ctx.update_leds(leds);
+                }
+            }
             Err(nix::errno::Errno::EINTR) => continue,
             Err(err) => {
                 log::warn!("input thread: epoll_wait: {err}");

--- a/crates/yserver/src/kms/v2/backend.rs
+++ b/crates/yserver/src/kms/v2/backend.rs
@@ -348,6 +348,14 @@ pub struct KmsBackendV2 {
     /// Cached on-core libinput fd for `poll_fds` (`&self`). `-1` in
     /// Direct mode (the input thread owns the fd there).
     core_libinput_fd: std::os::fd::RawFd,
+    /// Direct-mode lock-LED sink: the input thread owns the libinput
+    /// devices, so LED changes cross via this relay (mask + eventfd in
+    /// the thread's epoll). `None` in libseat mode (LEDs go straight
+    /// through `core_libinput`) and on test fixtures.
+    led_relay: Option<std::sync::Arc<crate::input::LedRelay>>,
+    /// Last `input::Led` bits pushed — dedup so only lock-state
+    /// TRANSITIONS reach the hardware, not every key event.
+    leds_sent: u32,
     /// Core-channel sender for emitting Shutdown/Dump messages from the
     /// on-core hotkey path (libseat mode). Handed in via `set_input_sender`
     /// after the channel is created in `lib.rs`.
@@ -739,6 +747,8 @@ impl KmsBackendV2 {
             core_input_state: None,
             seat_fd: -1,
             core_libinput_fd: -1,
+            led_relay: None,
+            leds_sent: 0,
             input_sender: None,
             hotkey: crate::input::hotkey::HotkeyDetector::new(),
             exported_dmabufs: HashMap::new(),
@@ -867,6 +877,8 @@ impl KmsBackendV2 {
             )),
             seat_fd,
             core_libinput_fd,
+            led_relay: None,
+            leds_sent: 0,
             input_sender: None,
             hotkey: crate::input::hotkey::HotkeyDetector::new(),
             exported_dmabufs: HashMap::new(),
@@ -1651,6 +1663,8 @@ impl KmsBackendV2 {
             core_input_state: None,
             seat_fd: -1,
             core_libinput_fd: -1,
+            led_relay: None,
+            leds_sent: 0,
             input_sender: None,
             hotkey: crate::input::hotkey::HotkeyDetector::new(),
             exported_dmabufs: HashMap::new(),
@@ -4223,6 +4237,52 @@ impl KmsBackendV2 {
         mask
     }
 
+    /// Direct-mode wiring: hand over the relay the input thread ends
+    /// of which `input_thread::run` polls. Called from `lib.rs` when
+    /// spawning the libinput thread.
+    pub fn set_led_relay(&mut self, relay: std::sync::Arc<crate::input::LedRelay>) {
+        self.led_relay = Some(relay);
+    }
+
+    /// Current lock-LED state derived from `xkb_state`, as
+    /// `input::Led` bits. Split from [`Self::sync_keyboard_leds`] so
+    /// the no-Vk test fixture can pin the XKB→LED mapping without a
+    /// libinput device.
+    fn current_led_bits(&self) -> u32 {
+        let state = &self.core.xkb_state.0;
+        let mut leds = input::Led::empty();
+        if state.led_name_is_active(xkbcommon::xkb::LED_NAME_CAPS) {
+            leds |= input::Led::CAPSLOCK;
+        }
+        if state.led_name_is_active(xkbcommon::xkb::LED_NAME_NUM) {
+            leds |= input::Led::NUMLOCK;
+        }
+        if state.led_name_is_active(xkbcommon::xkb::LED_NAME_SCROLL) {
+            leds |= input::Led::SCROLLLOCK;
+        }
+        leds.bits()
+    }
+
+    /// Push the XKB lock-LED state (Caps/Num/Scroll) to the keyboards
+    /// when it changed. On a KMS server nothing else drives the LEDs —
+    /// Xorg's keyboard driver does this via the XKB indicator state;
+    /// we do it via `libinput_device_led_update`. Libseat mode calls
+    /// the on-core libinput context directly; Direct mode crosses to
+    /// the input thread via the `LedRelay` eventfd.
+    fn sync_keyboard_leds(&mut self) {
+        let bits = self.current_led_bits();
+        if bits == self.leds_sent {
+            return;
+        }
+        self.leds_sent = bits;
+        let leds = input::Led::from_bits_truncate(bits);
+        if let Some(ctx) = self.core_libinput.as_mut() {
+            ctx.update_leds(leds);
+        } else if let Some(relay) = self.led_relay.as_ref() {
+            relay.set(bits);
+        }
+    }
+
     /// Update xkb_state for `raw` then return a cooked
     /// `HostKeyEvent` with the post-update modifier state +
     /// cursor coords pre-filled. Direct v1 port.
@@ -4234,6 +4294,7 @@ impl KmsBackendV2 {
             xkbcommon::xkb::KeyDirection::Up
         };
         self.core.xkb_state.0.update_key(xkb_keycode, direction);
+        self.sync_keyboard_leds();
         HostKeyEvent {
             state: self.serialize_modifiers(),
             root_x: self.core.cursor_x as i16,
@@ -17901,6 +17962,40 @@ mod tests {
         // disagrees, lower this to >0 — the load-bearing check is
         // that `state` reflects the update, not zero.
         assert_ne!(cooked.state, 0, "Shift press must update mod state");
+    }
+
+    /// Lock-LED mask tracks the XKB lock state: a Caps Lock toggle
+    /// (press + release through `cook_host_key`) raises the CAPSLOCK
+    /// LED bit; a second toggle clears it. This mask is what
+    /// `sync_keyboard_leds` pushes to the keyboards via libinput —
+    /// the caps-LED-never-lights bug (typed the lock-screen password
+    /// wrong repeatedly because the LED gave no feedback).
+    #[test]
+    fn caps_lock_toggle_drives_led_bits() {
+        use yserver_core::host_x11::HostKeyEvent;
+        let mut b = KmsBackendV2::for_tests();
+        assert_eq!(b.current_led_bits(), 0, "fresh state: all lock LEDs off");
+        // 66 == X keycode for Caps Lock (evdev KEY_CAPSLOCK 58 + 8).
+        let key = |pressed| HostKeyEvent {
+            keycode: 66,
+            pressed,
+            state: 0,
+            root_x: 0,
+            root_y: 0,
+            event_x: 0,
+            event_y: 0,
+            time: 0,
+        };
+        let _ = b.cook_host_key(key(true));
+        let _ = b.cook_host_key(key(false));
+        assert_eq!(
+            b.current_led_bits(),
+            input::Led::CAPSLOCK.bits(),
+            "caps toggle must raise the CAPSLOCK LED bit",
+        );
+        let _ = b.cook_host_key(key(true));
+        let _ = b.cook_host_key(key(false));
+        assert_eq!(b.current_led_bits(), 0, "second toggle clears the LED bit");
     }
 
     /// Cinnamon alt-tab regression (2026-06-10): `query_pointer`'s

--- a/crates/yserver/src/lib.rs
+++ b/crates/yserver/src/lib.rs
@@ -282,13 +282,22 @@ pub fn run(display: u16) -> io::Result<()> {
         log::info!("yserver: libseat mode — libinput on core thread, no input thread spawned");
     } else if let Some(input_ctx) = backend.take_input_ctx() {
         let input_sender = sender.clone_handle();
+        // Lock-LED relay: the core thread owns the XKB lock state, the
+        // input thread owns the libinput devices; LED transitions
+        // cross via this eventfd-backed mask.
+        let led_relay = std::sync::Arc::new(crate::input::LedRelay::new()?);
+        backend.set_led_relay(std::sync::Arc::clone(&led_relay));
         log::info!("yserver: Direct mode — spawning libinput sender thread");
         thread::Builder::new()
             .name("yserver-libinput".into())
             .spawn(move || {
-                if let Err(err) =
-                    input_thread::run(input_ctx, input_sender, u32::from(fb_w), u32::from(fb_h))
-                {
+                if let Err(err) = input_thread::run(
+                    input_ctx,
+                    input_sender,
+                    u32::from(fb_w),
+                    u32::from(fb_h),
+                    led_relay,
+                ) {
                     log::warn!("yserver: libinput thread exited: {err}");
                 }
             })?;


### PR DESCRIPTION
fix(input): drive keyboard lock LEDs from XKB state

Caps/Num/Scroll Lock LEDs never lit: on a KMS server nothing else
drives them — Xorg's keyboard driver pushes the XKB indicator state to
the hardware, and yserver had no equivalent (zero led_update calls in
the tree). Typed lock-screen passwords went wrong with no feedback.

After every xkb_state key update (cook_host_key, the single mutation
site), compute the lock-LED mask via xkbcommon led_name_is_active and
push it on transitions only:

- libseat mode: libinput lives on the core thread — call the new
  Context::update_leds directly.
- Direct mode: the input thread owns the devices — a new LedRelay
  (AtomicU32 mask + eventfd) crosses threads; the eventfd sits in the
  input thread's epoll set next to the libinput fd.

Context now stashes keyboard-capability device handles (same pattern
as touchpad_devices) and re-applies the current mask to keyboards that
appear later — hotplug and VT-switch re-acquire reset hardware LEDs
while the X-side lock state persists.

Unit test pins the XKB→LED mapping (caps toggle raises/clears
Led::CAPSLOCK through cook_host_key on the no-Vk fixture).

NOTE: committed unsigned — the SSH agent refused signing (key needs
interactive confirm and nobody is at the desk). Re-sign or squash via
the PR merge.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>