### PR TITLE
Launch via lightdm + XINERAMA multi-head (closes #6 items 1-3)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,6 +1,7 @@
 name: Security Audit
 on:
   push:
+    branches: [master]
     paths:
       - Cargo.lock
   pull_request:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,6 +558,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,6 +588,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ nix = { version = "0.31", features = [
   "mman",
   "poll",
   "signal",
+  "socket",
   "term"
 ] }
 signal-hook = "0.4"

--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,12 @@
 KERNEL := "/boot/vmlinuz-linux-cachyos"
 
+# Build a release yserver and install it to /usr/local/bin (needs sudo).
+# Pair with the lightdm setup in the README to use it as your graphical login.
+install:
+    cargo build --release --bin yserver
+    sudo install -m755 target/release/yserver /usr/local/bin/yserver
+    @echo "installed /usr/local/bin/yserver — see README 'Use with a display manager' to enable it"
+
 # Run yserver in virtme-ng with virtio-gpu DRM device and a QEMU window.
 yserver:
     cargo build --bin yserver

--- a/Justfile
+++ b/Justfile
@@ -1,20 +1,10 @@
 KERNEL := "/boot/vmlinuz-linux-cachyos"
 
 # Build a release yserver and install it to /usr/local/bin (needs sudo).
-# Safe + reversible: just the binary, no login changes.
 install:
     cargo build --release --bin yserver
     sudo install -m755 target/release/yserver /usr/local/bin/yserver
-    @echo "installed /usr/local/bin/yserver — 'just install-lightdm' to make it your graphical login"
-
-# Install the binary AND point lightdm at it (your graphical login for all
-# seats). CHANGES YOUR LOGIN: if yserver fails to start you'll need a text TTY
-# to recover. Undo: sudo rm /etc/lightdm/lightdm.conf.d/99-yserver.conf
-install-lightdm: install
-    sudo mkdir -p /etc/lightdm/lightdm.conf.d
-    printf '[Seat:*]\nxserver-command=/usr/local/bin/yserver\n' | sudo tee /etc/lightdm/lightdm.conf.d/99-yserver.conf >/dev/null
-    @echo "lightdm will launch yserver on next start (sudo systemctl restart lightdm)."
-    @echo "Undo: sudo rm /etc/lightdm/lightdm.conf.d/99-yserver.conf && sudo systemctl restart lightdm"
+    @echo "installed /usr/local/bin/yserver — see README 'Use with a display manager' to enable it"
 
 # Run yserver in virtme-ng with virtio-gpu DRM device and a QEMU window.
 yserver:

--- a/Justfile
+++ b/Justfile
@@ -1,11 +1,20 @@
 KERNEL := "/boot/vmlinuz-linux-cachyos"
 
 # Build a release yserver and install it to /usr/local/bin (needs sudo).
-# Pair with the lightdm setup in the README to use it as your graphical login.
+# Safe + reversible: just the binary, no login changes.
 install:
     cargo build --release --bin yserver
     sudo install -m755 target/release/yserver /usr/local/bin/yserver
-    @echo "installed /usr/local/bin/yserver — see README 'Use with a display manager' to enable it"
+    @echo "installed /usr/local/bin/yserver — 'just install-lightdm' to make it your graphical login"
+
+# Install the binary AND point lightdm at it (your graphical login for all
+# seats). CHANGES YOUR LOGIN: if yserver fails to start you'll need a text TTY
+# to recover. Undo: sudo rm /etc/lightdm/lightdm.conf.d/99-yserver.conf
+install-lightdm: install
+    sudo mkdir -p /etc/lightdm/lightdm.conf.d
+    printf '[Seat:*]\nxserver-command=/usr/local/bin/yserver\n' | sudo tee /etc/lightdm/lightdm.conf.d/99-yserver.conf >/dev/null
+    @echo "lightdm will launch yserver on next start (sudo systemctl restart lightdm)."
+    @echo "Undo: sudo rm /etc/lightdm/lightdm.conf.d/99-yserver.conf && sudo systemctl restart lightdm"
 
 # Run yserver in virtme-ng with virtio-gpu DRM device and a QEMU window.
 yserver:

--- a/README.md
+++ b/README.md
@@ -88,7 +88,29 @@ sudo pacman -S just gcc libseat libxshmfence libxkbcommon libinput glslc systemd
 ```sh
 sudo apt install just gcc libseat-dev libxshmfence-dev libxkbcommon-dev libinput-dev glslc libudev-dev libfontconfig-dev
 ```
-The [`Justfile`](Justfile) wraps the recipes:
+
+## Use with a display manager (lightdm)
+
+`lightdm` can launch yserver as its X server for a graphical login (its
+        X-server command is configurable, unlike gdm/sddm). 
+
+1. Install the binary (requires sudo): `just install` (installs it at `/usr/local/bin/yserver`).
+2. Point lightdm at it — create `/etc/lightdm/lightdm.conf.d/99-yserver.conf`:
+
+```ini
+[Seat:*]
+xserver-command=/usr/local/bin/yserver
+```
+
+3. From a free TTY, restart lightdm: `sudo systemctl restart lightdm`.
+
+The greeter appears, you log in, and the login keyring is unlocked by lightdm's PAM stack.
+
+Known limitation: **VT switching does not work** in a lightdm-launched session
+yet — yserver runs rootful without a logind session there, so it can't use
+libseat for VT control ([#10](https://github.com/joske/yserver/issues/10)).
+
+## Use directly on TTY
 
 ```sh
 ## switch to a free TTY, then run:
@@ -105,30 +127,6 @@ Some convenience keybinds are available:
 - Ctrl-Alt-Backspace: zap the server, return to console
 - Ctrl-Alt-Enter: create a screenshot/scanout of the framebuffer in CWD
 - Ctrl-Alt-F12: dump all drawables as PPM files to CWD
-
-## Use with a display manager (lightdm)
-
-`lightdm` can launch yserver as its X server for a graphical login (its
-X-server command is configurable, unlike gdm/sddm). yserver understands
-X-style argv (`:N`, `vtN`, `-seat`, `-auth`, `-nolisten`, `-displayfd`) and the
-SIGUSR1/`-displayfd` readiness handshake, so the greeter and your session start
-normally.
-
-1. `just install-lightdm` — installs the binary to `/usr/local/bin/yserver` and
-   writes `/etc/lightdm/lightdm.conf.d/99-yserver.conf`. This makes yserver your
-   graphical login, so if it fails to start you'll need a text TTY to recover.
-2. From a free TTY, restart lightdm: `sudo systemctl restart lightdm`.
-
-(Or by hand: `just install` for just the binary, then create the conf yourself —
-`[Seat:*]` with `xserver-command=/usr/local/bin/yserver`.)
-
-The greeter appears, you log in, and the login keyring is unlocked by lightdm's PAM stack.
-
-To undo: `sudo rm /etc/lightdm/lightdm.conf.d/99-yserver.conf && sudo systemctl restart lightdm`.
-
-Known limitation: **VT switching does not work** in a lightdm-launched session
-yet — yserver runs rootful without a logind session there, so it can't use
-libseat for VT control ([#10](https://github.com/joske/yserver/issues/10)).
 
 ## Regression coverage with xts5 and rendercheck
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,30 @@ Some convenience keybinds are available:
 - Ctrl-Alt-Enter: create a screenshot/scanout of the framebuffer in CWD
 - Ctrl-Alt-F12: dump all drawables as PPM files to CWD
 
+## Use with a display manager (lightdm)
+
+`lightdm` can launch yserver as its X server for a graphical login (its
+X-server command is configurable, unlike gdm/sddm). yserver understands
+X-style argv (`:N`, `vtN`, `-seat`, `-auth`, `-nolisten`, `-displayfd`) and the
+SIGUSR1/`-displayfd` readiness handshake, so the greeter and your session start
+normally.
+
+1. Install the binary: `just install` (puts it at `/usr/local/bin/yserver`).
+2. Point lightdm at it — create `/etc/lightdm/lightdm.conf.d/99-yserver.conf`:
+
+   ```ini
+   [Seat:*]
+   xserver-command=/usr/local/bin/yserver
+   ```
+3. From a free TTY, restart lightdm: `sudo systemctl restart lightdm`.
+
+The greeter appears, you log in, and (unlike the `startx` path) the login
+keyring is unlocked by lightdm's PAM stack.
+
+Known limitation: **VT switching does not work** in a lightdm-launched session
+yet — yserver runs rootful without a logind session there, so it can't use
+libseat for VT control ([#10](https://github.com/joske/yserver/issues/10)).
+
 ## Regression coverage with xts5 and rendercheck
 
 We run the X.Org X Test Suite (xts5) against `yserver` to gauge protocol completeness.

--- a/README.md
+++ b/README.md
@@ -114,17 +114,17 @@ X-style argv (`:N`, `vtN`, `-seat`, `-auth`, `-nolisten`, `-displayfd`) and the
 SIGUSR1/`-displayfd` readiness handshake, so the greeter and your session start
 normally.
 
-1. Install the binary: `just install` (puts it at `/usr/local/bin/yserver`).
-2. Point lightdm at it — create `/etc/lightdm/lightdm.conf.d/99-yserver.conf`:
+1. `just install-lightdm` — installs the binary to `/usr/local/bin/yserver` and
+   writes `/etc/lightdm/lightdm.conf.d/99-yserver.conf`. This makes yserver your
+   graphical login, so if it fails to start you'll need a text TTY to recover.
+2. From a free TTY, restart lightdm: `sudo systemctl restart lightdm`.
 
-   ```ini
-   [Seat:*]
-   xserver-command=/usr/local/bin/yserver
-   ```
-3. From a free TTY, restart lightdm: `sudo systemctl restart lightdm`.
+(Or by hand: `just install` for just the binary, then create the conf yourself —
+`[Seat:*]` with `xserver-command=/usr/local/bin/yserver`.)
 
-The greeter appears, you log in, and (unlike the `startx` path) the login
-keyring is unlocked by lightdm's PAM stack.
+The greeter appears, you log in, and the login keyring is unlocked by lightdm's PAM stack.
+
+To undo: `sudo rm /etc/lightdm/lightdm.conf.d/99-yserver.conf && sudo systemctl restart lightdm`.
 
 Known limitation: **VT switching does not work** in a lightdm-launched session
 yet — yserver runs rootful without a logind session there, so it can't use

--- a/crates/yserver-core/src/core_loop/process_request.rs
+++ b/crates/yserver-core/src/core_loop/process_request.rs
@@ -358,6 +358,7 @@ pub fn process_request(
         137 => handle_xi2_request(state, backend, origin, client_id, sequence, header, body),
         // ── PRESENT extension dispatcher ──
         145 => handle_present_request(state, backend, origin, client_id, sequence, header, body),
+        151 => handle_xinerama_request(state, client_id, sequence, header, body), // XINERAMA
         // ── DAMAGE extension dispatcher ──
         143 => handle_damage_request(state, client_id, sequence, header, body),
         // ── MIT-SHM extension dispatcher ──
@@ -2063,6 +2064,54 @@ fn handle_render_request(
     Ok(RequestOutcome::Handled)
 }
 
+/// One monitor as reported by both RANDR `GetMonitors` and the XINERAMA
+/// extension. This is the single source of truth so their counts/order cannot
+/// diverge.
+#[derive(Clone)]
+pub(crate) struct ActiveMonitor {
+    pub name: String,
+    pub output_id: u32,
+    pub primary: bool,
+    pub x: i16,
+    pub y: i16,
+    pub width: u16,
+    pub height: u16,
+    pub width_mm: u32,
+    pub height_mm: u32,
+}
+
+fn active_monitors(state: &ServerState) -> Vec<ActiveMonitor> {
+    state
+        .randr
+        .outputs
+        .iter()
+        .enumerate()
+        .map(|(i, output)| {
+            let width_mm = if output.mm_width > 0 {
+                output.mm_width
+            } else {
+                ((u32::from(output.width) * 254 + 480) / 960).max(1)
+            };
+            let height_mm = if output.mm_height > 0 {
+                output.mm_height
+            } else {
+                ((u32::from(output.height) * 254 + 480) / 960).max(1)
+            };
+            ActiveMonitor {
+                name: output.name.clone(),
+                output_id: output.output_id,
+                primary: i == 0,
+                x: output.x,
+                y: output.y,
+                width: output.width,
+                height: output.height,
+                width_mm,
+                height_mm,
+            }
+        })
+        .collect()
+}
+
 fn handle_randr_request(
     state: &mut ServerState,
     client_id: ClientId,
@@ -2289,8 +2338,6 @@ fn handle_randr_request(
         }
         x11randr::RR_GET_MONITORS => {
             let t = state.randr.timestamp;
-            // Pre-resolve per-monitor name atom + output-id storage so
-            // the borrow inside MonitorInfo points at stable memory.
             struct MonitorRow {
                 name_atom: u32,
                 primary: bool,
@@ -2303,43 +2350,20 @@ fn handle_randr_request(
                 height_mm: u32,
                 outputs: Vec<u32>,
             }
-            let rows: Vec<MonitorRow> = state
-                .randr
-                .outputs
+            let monitors_list = active_monitors(state);
+            let rows: Vec<MonitorRow> = monitors_list
                 .iter()
-                .enumerate()
-                .map(|(i, o)| {
-                    let name_atom = state.atoms.intern(&o.name, false).0;
-                    // Prefer the EDID-reported physical size from the
-                    // DRM connector; fall back to a 96-DPI synthesis
-                    // (`mm = (px*254 + 480) / 960`) when the connector
-                    // didn't report a size (virtio-gpu, ynest nested,
-                    // displays without EDID). The previous unconditional
-                    // 96-DPI synthesis was off from real EDID by 10-15 %
-                    // on typical 109-DPI panels, causing GTK CSD shadows
-                    // to render denser than on Xorg-native.
-                    let width_mm = if o.mm_width > 0 {
-                        o.mm_width
-                    } else {
-                        ((u32::from(o.width) * 254 + 480) / 960).max(1)
-                    };
-                    let height_mm = if o.mm_height > 0 {
-                        o.mm_height
-                    } else {
-                        ((u32::from(o.height) * 254 + 480) / 960).max(1)
-                    };
-                    MonitorRow {
-                        name_atom,
-                        primary: i == 0,
-                        automatic: true,
-                        x: o.x,
-                        y: o.y,
-                        width: o.width,
-                        height: o.height,
-                        width_mm,
-                        height_mm,
-                        outputs: vec![o.output_id],
-                    }
+                .map(|monitor| MonitorRow {
+                    name_atom: state.atoms.intern(&monitor.name, false).0,
+                    primary: monitor.primary,
+                    automatic: true,
+                    x: monitor.x,
+                    y: monitor.y,
+                    width: monitor.width,
+                    height: monitor.height,
+                    width_mm: monitor.width_mm,
+                    height_mm: monitor.height_mm,
+                    outputs: vec![monitor.output_id],
                 })
                 .collect();
             let monitors: Vec<x11randr::MonitorInfo<'_>> = rows
@@ -2920,6 +2944,139 @@ fn apply_alarm_attributes(
             value
         };
     }
+}
+
+fn handle_xinerama_request(
+    state: &mut ServerState,
+    client_id: ClientId,
+    sequence: SequenceNumber,
+    header: RequestHeader,
+    body: &[u8],
+) -> io::Result<RequestOutcome> {
+    use yserver_protocol::x11::{ClientByteOrder, error, read_u32, xinerama as xin};
+
+    const XINERAMA_MAJOR_OPCODE: u8 = 151;
+
+    let byte_order = state
+        .clients
+        .get(&client_id.0)
+        .map_or(ClientByteOrder::LittleEndian, |c| c.byte_order);
+    let minor = header.data;
+
+    let screens: Vec<xin::ScreenInfo> = active_monitors(state)
+        .into_iter()
+        .map(|monitor| xin::ScreenInfo {
+            x_org: monitor.x,
+            y_org: monitor.y,
+            width: monitor.width,
+            height: monitor.height,
+        })
+        .collect();
+
+    macro_rules! require_len {
+        ($n:expr) => {
+            if body.len() != $n {
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    error::BAD_LENGTH,
+                    0,
+                    u16::from(minor),
+                    XINERAMA_MAJOR_OPCODE,
+                );
+            }
+        };
+    }
+
+    let buf = match minor {
+        xin::QUERY_VERSION => {
+            require_len!(4);
+            xin::encode_query_version_reply(byte_order, sequence)
+        }
+        xin::IS_ACTIVE => {
+            require_len!(0);
+            xin::encode_is_active_reply(byte_order, sequence, !screens.is_empty())
+        }
+        xin::QUERY_SCREENS => {
+            require_len!(0);
+            xin::encode_query_screens_reply(byte_order, sequence, &screens)
+        }
+        xin::GET_STATE => {
+            require_len!(4);
+            let window = read_u32(byte_order, body);
+            if state.resources.window(ResourceId(window)).is_none() {
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    error::BAD_WINDOW,
+                    window,
+                    u16::from(minor),
+                    XINERAMA_MAJOR_OPCODE,
+                );
+            }
+            xin::encode_get_state_reply(byte_order, sequence, true, window)
+        }
+        xin::GET_SCREEN_COUNT => {
+            require_len!(4);
+            let window = read_u32(byte_order, body);
+            if state.resources.window(ResourceId(window)).is_none() {
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    error::BAD_WINDOW,
+                    window,
+                    u16::from(minor),
+                    XINERAMA_MAJOR_OPCODE,
+                );
+            }
+            #[allow(clippy::cast_possible_truncation)]
+            let count = screens.len() as u8;
+            xin::encode_get_screen_count_reply(byte_order, sequence, count, window)
+        }
+        xin::GET_SCREEN_SIZE => {
+            require_len!(8);
+            let window = read_u32(byte_order, body);
+            let screen = read_u32(byte_order, &body[4..]);
+            if state.resources.window(ResourceId(window)).is_none() {
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    error::BAD_WINDOW,
+                    window,
+                    u16::from(minor),
+                    XINERAMA_MAJOR_OPCODE,
+                );
+            }
+            xin::encode_get_screen_size_reply(
+                byte_order,
+                sequence,
+                u32::from(state.randr.screen_width),
+                u32::from(state.randr.screen_height),
+                window,
+                screen,
+            )
+        }
+        _ => {
+            return emit_x11_error_with_minor(
+                state,
+                client_id,
+                sequence,
+                error::BAD_REQUEST,
+                0,
+                u16::from(minor),
+                XINERAMA_MAJOR_OPCODE,
+            );
+        }
+    };
+
+    let Some(client) = state.clients.get_mut(&client_id.0) else {
+        return Ok(RequestOutcome::Handled);
+    };
+    Ok(write_to_client(client, client_id, &buf))
 }
 
 /// Evaluate every active alarm watching `counter` after it moved from
@@ -23151,6 +23308,46 @@ mod tests {
 
     fn free_pixmap_body(pixmap: u32) -> Vec<u8> {
         pixmap.to_le_bytes().to_vec()
+    }
+
+    #[test]
+    fn active_monitors_matches_outputs_and_order() {
+        let mut state = ServerState::new();
+        state.randr.outputs = vec![
+            crate::randr::RandrOutput {
+                name: "DP-1".into(),
+                output_id: 1,
+                crtc_id: 1,
+                mode_id: 1,
+                x: 0,
+                y: 0,
+                width: 2560,
+                height: 1440,
+                vrefresh: 60,
+                mm_width: 0,
+                mm_height: 0,
+            },
+            crate::randr::RandrOutput {
+                name: "HDMI-A-1".into(),
+                output_id: 2,
+                crtc_id: 2,
+                mode_id: 1,
+                x: 2560,
+                y: 0,
+                width: 2560,
+                height: 1440,
+                vrefresh: 60,
+                mm_width: 0,
+                mm_height: 0,
+            },
+        ];
+
+        let monitors = active_monitors(&state);
+        assert_eq!(monitors.len(), state.randr.outputs.len());
+        assert_eq!(monitors.len(), 2);
+        assert!(monitors[0].primary);
+        assert!(!monitors[1].primary);
+        assert_eq!(monitors[1].x, 2560);
     }
 
     #[test]

--- a/crates/yserver-core/src/nested.rs
+++ b/crates/yserver-core/src/nested.rs
@@ -87,6 +87,7 @@ const PRESENT_FIRST_ERROR: u8 = 0; // Present defines no errors
 pub(crate) const DPMS_MAJOR_OPCODE: u8 = 134;
 
 pub(crate) const MIT_SCREEN_SAVER_MAJOR_OPCODE: u8 = 150;
+pub(crate) const XINERAMA_MAJOR_OPCODE: u8 = 151;
 // MUST be <= 127: X event codes are 7-bit (2..=127); bit 0x80 is the
 // SendEvent/synthetic flag, so a base first_event with the high bit set is
 // illegal and strict clients (Google Chrome's X11 layer) abort on it. 92 is
@@ -174,6 +175,15 @@ pub(crate) const EXTENSIONS: &[ExtensionMetadata] = &[
         first_event: BIG_REQUESTS_FIRST_EVENT,
         event_count: 0,
         first_error: BIG_REQUESTS_FIRST_ERROR,
+        availability: ExtensionAvailability::Always,
+        unsupported_minor_policy: UnsupportedMinorPolicy::HandledInline,
+    },
+    ExtensionMetadata {
+        name: "XINERAMA",
+        major_opcode: XINERAMA_MAJOR_OPCODE,
+        first_event: 0,
+        event_count: 0,
+        first_error: 0,
         availability: ExtensionAvailability::Always,
         unsupported_minor_policy: UnsupportedMinorPolicy::HandledInline,
     },
@@ -979,6 +989,17 @@ mod tests {
             non_zero_error_bases.len(),
             "error base collision"
         );
+    }
+
+    #[test]
+    fn xinerama_is_advertised() {
+        let ext = EXTENSIONS
+            .iter()
+            .find(|ext| ext.name == "XINERAMA")
+            .expect("XINERAMA in EXTENSIONS");
+        assert_eq!(ext.major_opcode, 151);
+        assert_eq!(ext.first_event, 0);
+        assert_eq!(ext.first_error, 0);
     }
 
     mod render {

--- a/crates/yserver-protocol/src/x11/mod.rs
+++ b/crates/yserver-protocol/src/x11/mod.rs
@@ -28,6 +28,7 @@ pub mod sync;
 pub mod wire_swap;
 pub mod x_resource;
 pub mod xfixes;
+pub mod xinerama;
 pub mod xtest;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/yserver-protocol/src/x11/xinerama.rs
+++ b/crates/yserver-protocol/src/x11/xinerama.rs
@@ -1,0 +1,256 @@
+//! XINERAMA (PanoramiX) extension wire encoders. yserver mirrors the
+//! RANDR-backed Xinerama path (Xorg `randr/rrxinerama.c`): the Xinerama
+//! screens are the RANDR monitors. All replies use the 32-byte fixed reply;
+//! only `QueryScreens` appends `N * 8` bytes.
+
+use super::{
+    ClientByteOrder, SequenceNumber,
+    wire::{write_i16, write_u16, write_u32},
+};
+
+pub const MAJOR_VERSION: u16 = 1;
+pub const MINOR_VERSION: u16 = 1;
+
+pub const QUERY_VERSION: u8 = 0;
+pub const GET_STATE: u8 = 1;
+pub const GET_SCREEN_COUNT: u8 = 2;
+pub const GET_SCREEN_SIZE: u8 = 3;
+pub const IS_ACTIVE: u8 = 4;
+pub const QUERY_SCREENS: u8 = 5;
+
+/// One Xinerama screen rect. Wire: x_org i16, y_org i16, width u16, height u16.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScreenInfo {
+    pub x_org: i16,
+    pub y_org: i16,
+    pub width: u16,
+    pub height: u16,
+}
+
+trait Put {
+    fn put(self, byte_order: ClientByteOrder, out: &mut Vec<u8>);
+}
+
+impl Put for u16 {
+    fn put(self, byte_order: ClientByteOrder, out: &mut Vec<u8>) {
+        write_u16(byte_order, out, self);
+    }
+}
+
+impl Put for u32 {
+    fn put(self, byte_order: ClientByteOrder, out: &mut Vec<u8>) {
+        write_u32(byte_order, out, self);
+    }
+}
+
+impl Put for i16 {
+    fn put(self, byte_order: ClientByteOrder, out: &mut Vec<u8>) {
+        write_i16(byte_order, out, self);
+    }
+}
+
+fn put<T: Put>(byte_order: ClientByteOrder, out: &mut Vec<u8>, x: T) {
+    x.put(byte_order, out);
+}
+
+fn fixed_reply(
+    byte_order: ClientByteOrder,
+    sequence: SequenceNumber,
+    data: u8,
+    length: u32,
+) -> Vec<u8> {
+    let mut reply = Vec::with_capacity(32);
+    reply.push(1u8);
+    reply.push(data);
+    put(byte_order, &mut reply, sequence.0);
+    put(byte_order, &mut reply, length);
+    reply
+}
+
+#[must_use]
+pub fn encode_query_version_reply(
+    byte_order: ClientByteOrder,
+    sequence: SequenceNumber,
+) -> Vec<u8> {
+    let mut reply = fixed_reply(byte_order, sequence, 0, 0);
+    put(byte_order, &mut reply, MAJOR_VERSION);
+    put(byte_order, &mut reply, MINOR_VERSION);
+    reply.resize(32, 0);
+    reply
+}
+
+#[must_use]
+pub fn encode_get_state_reply(
+    byte_order: ClientByteOrder,
+    sequence: SequenceNumber,
+    active: bool,
+    window: u32,
+) -> Vec<u8> {
+    let mut reply = fixed_reply(byte_order, sequence, u8::from(active), 0);
+    put(byte_order, &mut reply, window);
+    reply.resize(32, 0);
+    reply
+}
+
+#[must_use]
+pub fn encode_get_screen_count_reply(
+    byte_order: ClientByteOrder,
+    sequence: SequenceNumber,
+    count: u8,
+    window: u32,
+) -> Vec<u8> {
+    let mut reply = fixed_reply(byte_order, sequence, count, 0);
+    put(byte_order, &mut reply, window);
+    reply.resize(32, 0);
+    reply
+}
+
+#[must_use]
+pub fn encode_get_screen_size_reply(
+    byte_order: ClientByteOrder,
+    sequence: SequenceNumber,
+    width: u32,
+    height: u32,
+    window: u32,
+    screen: u32,
+) -> Vec<u8> {
+    let mut reply = fixed_reply(byte_order, sequence, 0, 0);
+    put(byte_order, &mut reply, width);
+    put(byte_order, &mut reply, height);
+    put(byte_order, &mut reply, window);
+    put(byte_order, &mut reply, screen);
+    reply.resize(32, 0);
+    reply
+}
+
+#[must_use]
+pub fn encode_is_active_reply(
+    byte_order: ClientByteOrder,
+    sequence: SequenceNumber,
+    active: bool,
+) -> Vec<u8> {
+    let mut reply = fixed_reply(byte_order, sequence, 0, 0);
+    put(byte_order, &mut reply, u32::from(active));
+    reply.resize(32, 0);
+    reply
+}
+
+#[must_use]
+pub fn encode_query_screens_reply(
+    byte_order: ClientByteOrder,
+    sequence: SequenceNumber,
+    screens: &[ScreenInfo],
+) -> Vec<u8> {
+    #[allow(clippy::cast_possible_truncation)]
+    let length = (screens.len() * 2) as u32;
+    let mut reply = fixed_reply(byte_order, sequence, 0, length);
+    #[allow(clippy::cast_possible_truncation)]
+    put(byte_order, &mut reply, screens.len() as u32);
+    reply.resize(32, 0);
+    for screen in screens {
+        put(byte_order, &mut reply, screen.x_org);
+        put(byte_order, &mut reply, screen.y_org);
+        put(byte_order, &mut reply, screen.width);
+        put(byte_order, &mut reply, screen.height);
+    }
+    reply
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LE: ClientByteOrder = ClientByteOrder::LittleEndian;
+
+    fn seq() -> SequenceNumber {
+        SequenceNumber(0x1234)
+    }
+
+    #[test]
+    fn query_version_reply_bytes() {
+        let reply = encode_query_version_reply(LE, seq());
+        assert_eq!(reply.len(), 32);
+        assert_eq!(reply[0], 1);
+        assert_eq!(&reply[2..4], &0x1234u16.to_le_bytes());
+        assert_eq!(&reply[4..8], &0u32.to_le_bytes());
+        assert_eq!(&reply[8..10], &1u16.to_le_bytes());
+        assert_eq!(&reply[10..12], &1u16.to_le_bytes());
+    }
+
+    #[test]
+    fn get_state_reply_has_state_in_byte1() {
+        let reply = encode_get_state_reply(LE, seq(), true, 0xdead_beef);
+        assert_eq!(reply.len(), 32);
+        assert_eq!(reply[1], 1);
+        assert_eq!(&reply[8..12], &0xdead_beefu32.to_le_bytes());
+        let inactive = encode_get_state_reply(LE, seq(), false, 0);
+        assert_eq!(inactive[1], 0);
+    }
+
+    #[test]
+    fn get_screen_count_reply_has_count_in_byte1() {
+        let reply = encode_get_screen_count_reply(LE, seq(), 2, 0x55);
+        assert_eq!(reply.len(), 32);
+        assert_eq!(reply[1], 2);
+        assert_eq!(&reply[8..12], &0x55u32.to_le_bytes());
+    }
+
+    #[test]
+    fn get_screen_size_reply_bytes() {
+        let reply = encode_get_screen_size_reply(LE, seq(), 5120, 1440, 0x10, 0);
+        assert_eq!(reply.len(), 32);
+        assert_eq!(&reply[8..12], &5120u32.to_le_bytes());
+        assert_eq!(&reply[12..16], &1440u32.to_le_bytes());
+        assert_eq!(&reply[16..20], &0x10u32.to_le_bytes());
+        assert_eq!(&reply[20..24], &0u32.to_le_bytes());
+    }
+
+    #[test]
+    fn is_active_reply_state_word() {
+        let reply = encode_is_active_reply(LE, seq(), true);
+        assert_eq!(reply.len(), 32);
+        assert_eq!(&reply[8..12], &1u32.to_le_bytes());
+        assert_eq!(
+            &encode_is_active_reply(LE, seq(), false)[8..12],
+            &0u32.to_le_bytes()
+        );
+    }
+
+    #[test]
+    fn query_screens_two_screens() {
+        let screens = [
+            ScreenInfo {
+                x_org: 0,
+                y_org: 0,
+                width: 2560,
+                height: 1440,
+            },
+            ScreenInfo {
+                x_org: 2560,
+                y_org: 0,
+                width: 2560,
+                height: 1440,
+            },
+        ];
+        let reply = encode_query_screens_reply(LE, seq(), &screens);
+        assert_eq!(reply.len(), 48);
+        assert_eq!(&reply[4..8], &4u32.to_le_bytes());
+        assert_eq!(&reply[8..12], &2u32.to_le_bytes());
+        assert_eq!(&reply[32..34], &0i16.to_le_bytes());
+        assert_eq!(&reply[34..36], &0i16.to_le_bytes());
+        assert_eq!(&reply[36..38], &2560u16.to_le_bytes());
+        assert_eq!(&reply[38..40], &1440u16.to_le_bytes());
+        assert_eq!(&reply[40..42], &2560i16.to_le_bytes());
+        assert_eq!(&reply[42..44], &0i16.to_le_bytes());
+        assert_eq!(&reply[44..46], &2560u16.to_le_bytes());
+        assert_eq!(&reply[46..48], &1440u16.to_le_bytes());
+    }
+
+    #[test]
+    fn query_screens_empty() {
+        let reply = encode_query_screens_reply(LE, seq(), &[]);
+        assert_eq!(reply.len(), 32);
+        assert_eq!(&reply[4..8], &0u32.to_le_bytes());
+        assert_eq!(&reply[8..12], &0u32.to_le_bytes());
+    }
+}

--- a/crates/yserver/src/bin/yserver.rs
+++ b/crates/yserver/src/bin/yserver.rs
@@ -1,61 +1,25 @@
 use std::{env, process::ExitCode};
 
-const DEFAULT_DISPLAY: u16 = 7;
-
-fn parse_display<I: IntoIterator<Item = String>>(args: I) -> Result<u16, String> {
-    let mut out = DEFAULT_DISPLAY;
-    for arg in args {
-        match arg.parse::<u16>() {
-            Ok(n) => out = n,
-            Err(_) => return Err(format!("unrecognized argument: {arg}")),
-        }
-    }
-    Ok(out)
-}
-
 fn main() -> ExitCode {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
-    let display = match parse_display(env::args().skip(1)) {
-        Ok(d) => d,
+    let opts = match yserver::launch::parse_args(env::args().skip(1)) {
+        Ok(o) => o,
         Err(err) => {
             eprintln!("yserver: {err}");
-            eprintln!("usage: yserver [<display>]");
+            eprintln!(
+                "usage: yserver [:N | N] [vtN] [-seat NAME] [-auth FILE] \
+                 [-displayfd N] [-nolisten PROTO] [-novtswitch]"
+            );
             return ExitCode::FAILURE;
         }
     };
 
-    match yserver::run(display) {
+    match yserver::run(opts) {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {
             log::error!("yserver: {err}");
             ExitCode::FAILURE
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn parse(args: &[&str]) -> Result<u16, String> {
-        parse_display(args.iter().map(|s| (*s).to_string()))
-    }
-
-    #[test]
-    fn no_args_is_default() {
-        assert_eq!(parse(&[]).unwrap(), DEFAULT_DISPLAY);
-    }
-
-    #[test]
-    fn positional_display() {
-        assert_eq!(parse(&["0"]).unwrap(), 0);
-        assert_eq!(parse(&["42"]).unwrap(), 42);
-    }
-
-    #[test]
-    fn non_numeric_errors() {
-        assert!(parse(&["foo"]).is_err());
-        assert!(parse(&["--bogus"]).is_err());
     }
 }

--- a/crates/yserver/src/launch.rs
+++ b/crates/yserver/src/launch.rs
@@ -3,7 +3,15 @@
 //! readiness handshake. See
 //! `docs/superpowers/specs/2026-06-12-lightdm-launch-design.md`.
 
-use std::{os::fd::RawFd, path::PathBuf};
+use std::{
+    fs::{self, OpenOptions},
+    io::{self, ErrorKind, Read, Write},
+    os::{
+        fd::RawFd,
+        unix::fs::{MetadataExt, OpenOptionsExt},
+    },
+    path::{Path, PathBuf},
+};
 
 /// Display yserver uses when neither an explicit display nor `-displayfd`
 /// is given. 7 avoids clashing with a real Xorg on `:0` (existing
@@ -110,12 +118,168 @@ pub fn resolve(opts: &LaunchOptions) -> Resolution {
     }
 }
 
+/// RAII handle for an acquired display lock. Dropping removes the lock
+/// file. `run()` holds this for the server's lifetime and lets it drop
+/// *after* the socket is removed at shutdown (the lock is the
+/// authoritative occupancy marker, so it must outlive the socket).
+#[derive(Debug)]
+pub struct LockGuard {
+    path: PathBuf,
+}
+
+impl Drop for LockGuard {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+/// `/tmp/.X<N>-lock` path for a display.
+#[must_use]
+pub fn lock_path(lock_dir: &Path, display: u16) -> PathBuf {
+    lock_dir.join(format!(".X{display}-lock"))
+}
+
+enum LockState {
+    Alive,
+    Stale,
+    Bogus,
+}
+
+fn inspect_lock(path: &Path) -> io::Result<LockState> {
+    let f = match OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+    {
+        Ok(f) => f,
+        // Vanished between link-failure and open → treat as stale (retry).
+        Err(e) if e.kind() == ErrorKind::NotFound => return Ok(LockState::Stale),
+        Err(e) => return Err(e),
+    };
+    // Xorg's lock format is exactly "%10d\n" = 11 bytes. read_to_end
+    // (capped at 12 via `take`) loops over short reads — a single
+    // read() may legally return fewer bytes; this is lock-DELETION
+    // logic, so don't risk it. The 12th byte makes an over-long file
+    // detectable (len == 12 ⇒ bogus). A genuine I/O error propagates —
+    // never classify an unreadable lock as bogus (that would delete a
+    // lock we couldn't actually inspect).
+    let mut buf = Vec::with_capacity(12);
+    f.take(12).read_to_end(&mut buf)?;
+    if buf.len() != 11 || buf[10] != b'\n' {
+        return Ok(LockState::Bogus);
+    }
+    let text = std::str::from_utf8(&buf[..11]).unwrap_or("").trim();
+    let pid: i32 = match text.parse() {
+        Ok(p) if p > 0 => p,
+        _ => return Ok(LockState::Bogus),
+    };
+    // SAFETY: kill with signal 0 only probes existence/permissions.
+    if unsafe { libc::kill(pid, 0) } == 0 {
+        return Ok(LockState::Alive);
+    }
+    match io::Error::last_os_error().raw_os_error() {
+        Some(libc::ESRCH) => Ok(LockState::Stale),
+        // EPERM ⇒ a live process we may not signal (e.g. another user).
+        // Anything else ⇒ be conservative and treat as occupied.
+        _ => Ok(LockState::Alive),
+    }
+}
+
+/// Acquire the `/tmp/.X<N>-lock` display lock using Xorg's temp-file +
+/// atomic `link()` protocol (`os/utils.c`), reclaiming stale/bogus locks.
+/// Errors with `AddrInUse` if a live server owns the display.
+pub fn acquire_lock(lock_dir: &Path, display: u16) -> io::Result<LockGuard> {
+    let final_path = lock_path(lock_dir, display);
+    // PID-suffixed temp name: each starter owns a unique temp file, so two
+    // concurrent starters can never clobber each other's temp before the
+    // atomic link() (a fixed name would let the winner link a file holding
+    // the LOSER's pid, corrupting later stale/live detection). Deviation
+    // from Xorg's fixed ".tX<N>-lock": race-free without Xorg's
+    // O_EXCL+retry dance; a crash can orphan one 11-byte temp file, which
+    // is harmless (nothing inspects temp names).
+    let tmp_path = lock_dir.join(format!(".tX{display}-lock.{}", std::process::id()));
+    let pid_line = format!("{:>10}\n", std::process::id());
+
+    // At most two attempts: acquire, or reclaim-once-then-acquire.
+    for _ in 0..2 {
+        {
+            let mut tmp = OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(&tmp_path)?;
+            tmp.write_all(pid_line.as_bytes())?;
+        }
+        match fs::hard_link(&tmp_path, &final_path) {
+            Ok(()) => {
+                let _ = fs::remove_file(&tmp_path);
+                return Ok(LockGuard { path: final_path });
+            }
+            Err(e) if e.kind() == ErrorKind::AlreadyExists => {
+                // Identity-bracketed reclaim: note the lock's (dev, ino)
+                // before inspecting, and only unlink if the path still
+                // names that same inode afterwards. Narrows the race
+                // where a concurrent starter reclaims the stale lock and
+                // links its own fresh one between our inspect and our
+                // unlink. Xorg has the full-width version of this race
+                // (LockServer: read → kill(pid,0) → unlink, no identity
+                // check); Linux has no unlink-by-fd, so a tiny
+                // lstat→unlink window remains — and same-display
+                // concurrent starts are DM-serialized in practice.
+                let seen = fs::symlink_metadata(&final_path)
+                    .ok()
+                    .map(|m| (m.dev(), m.ino()));
+                match inspect_lock(&final_path)? {
+                    LockState::Stale | LockState::Bogus => {
+                        let now = fs::symlink_metadata(&final_path)
+                            .ok()
+                            .map(|m| (m.dev(), m.ino()));
+                        if seen.is_some() && now == seen {
+                            let _ = fs::remove_file(&final_path);
+                        }
+                        // else: replaced under us — the retry link will
+                        // hit EEXIST again and inspect the NEW lock
+                        // (typically Alive → AddrInUse).
+                    }
+                    LockState::Alive => {
+                        let _ = fs::remove_file(&tmp_path);
+                        return Err(io::Error::new(
+                            ErrorKind::AddrInUse,
+                            format!(
+                                "display :{display} already in use (lock {})",
+                                final_path.display()
+                            ),
+                        ));
+                    }
+                }
+            }
+            Err(e) => {
+                let _ = fs::remove_file(&tmp_path);
+                return Err(e);
+            }
+        }
+    }
+    let _ = fs::remove_file(&tmp_path);
+    Err(io::Error::new(
+        ErrorKind::AddrInUse,
+        format!("could not acquire display lock {}", final_path.display()),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     fn parse(args: &[&str]) -> Result<LaunchOptions, String> {
         parse_args(args.iter().map(|s| (*s).to_string()))
+    }
+
+    fn unique_tmp_dir(tag: &str) -> PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("yserver-launch-test-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
     }
 
     #[test]
@@ -206,5 +370,80 @@ mod tests {
                 lock: true
             }
         );
+    }
+
+    #[test]
+    fn unknown_flag_does_not_consume_next_arg() {
+        assert_eq!(parse(&["-bogus", ":1"]).unwrap().display, Some(1));
+    }
+
+    #[test]
+    fn duplicate_display_args_last_wins() {
+        assert_eq!(parse(&[":0", ":1"]).unwrap().display, Some(1));
+        assert_eq!(parse(&["7", ":3"]).unwrap().display, Some(3));
+    }
+
+    #[test]
+    fn lock_fresh_acquire_creates_file() {
+        let dir = unique_tmp_dir("lock-fresh");
+        let guard = acquire_lock(&dir, 5).unwrap();
+        assert!(lock_path(&dir, 5).exists());
+        drop(guard);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn lock_guard_drop_removes_file() {
+        let dir = unique_tmp_dir("lock-drop");
+        let guard = acquire_lock(&dir, 6).unwrap();
+        let p = lock_path(&dir, 6);
+        assert!(p.exists());
+        drop(guard);
+        assert!(!p.exists());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn lock_live_pid_is_rejected() {
+        let dir = unique_tmp_dir("lock-live");
+        // First acquire writes OUR pid into the lock; the second sees a
+        // live owner (us) and must refuse.
+        let _guard = acquire_lock(&dir, 7).unwrap();
+        let err = acquire_lock(&dir, 7).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::AddrInUse);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn lock_stale_pid_is_reclaimed() {
+        let dir = unique_tmp_dir("lock-stale");
+        // A pid far above any real one → kill(pid,0) == ESRCH → stale.
+        std::fs::write(lock_path(&dir, 8), format!("{:>10}\n", 2_147_483_646i32)).unwrap();
+        let guard = acquire_lock(&dir, 8).unwrap();
+        assert!(lock_path(&dir, 8).exists());
+        drop(guard);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn lock_bogus_contents_are_reclaimed() {
+        let dir = unique_tmp_dir("lock-bogus");
+        std::fs::write(lock_path(&dir, 9), b"not a pid").unwrap();
+        let guard = acquire_lock(&dir, 9).unwrap();
+        assert!(lock_path(&dir, 9).exists());
+        drop(guard);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn lock_short_numeric_contents_are_bogus() {
+        // Xorg reads exactly 11 bytes ("%10d\n"); a short numeric file is
+        // not a valid lock and must be reclaimed, not trusted.
+        let dir = unique_tmp_dir("lock-short");
+        std::fs::write(lock_path(&dir, 10), b"123\n").unwrap();
+        let guard = acquire_lock(&dir, 10).unwrap();
+        assert!(lock_path(&dir, 10).exists());
+        drop(guard);
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/crates/yserver/src/launch.rs
+++ b/crates/yserver/src/launch.rs
@@ -389,7 +389,8 @@ pub fn bind_explicit(socket_dir: &Path, display: u16) -> io::Result<(UnixListene
             ));
         }
     }
-    let listener = UnixListener::bind(&path)?;
+    let listener = UnixListener::bind(&path)
+        .map_err(|e| io::Error::new(e.kind(), format!("bind({}): {e}", path.display())))?;
     if let Err(e) = chmod_socket(&path) {
         let _ = fs::remove_file(&path);
         return Err(e);
@@ -435,6 +436,76 @@ pub fn autopick(socket_dir: &Path) -> io::Result<(u16, UnixListener, PathBuf)> {
         ErrorKind::AddrInUse,
         "no free X display in 0..256",
     ))
+}
+
+/// Write `"<display>\n"` (Xorg's `-displayfd` format) to `fd`, then close
+/// it. Used only when `-displayfd N` was given. Close errors are ignored:
+/// the fd is single-use and there is nothing actionable after the payload
+/// was written.
+pub fn write_displayfd(fd: RawFd, display: u16) -> io::Result<()> {
+    let s = format!("{display}\n");
+    let bytes = s.as_bytes();
+    let mut written = 0usize;
+    while written < bytes.len() {
+        // SAFETY: writing `bytes[written..]` to a caller-owned fd.
+        let r = unsafe { libc::write(fd, bytes[written..].as_ptr().cast(), bytes.len() - written) };
+        if r < 0 {
+            let err = io::Error::last_os_error();
+            unsafe { libc::close(fd) };
+            return Err(err);
+        }
+        if r == 0 {
+            // A zero-length write would loop forever — fail instead.
+            unsafe { libc::close(fd) };
+            return Err(io::Error::new(
+                ErrorKind::WriteZero,
+                "displayfd write returned 0",
+            ));
+        }
+        written += r as usize;
+    }
+    unsafe { libc::close(fd) };
+    Ok(())
+}
+
+/// True if SIGUSR1's *inherited disposition* is `SIG_IGN` — the signal
+/// the DM (lightdm/Xorg convention) uses to request "signal me when
+/// ready". Querying via `sigaction(…, NULL, &old)` does not mutate the
+/// disposition; signalfd masking (done later) only blocks delivery, so
+/// the two are independent — call this any time before installing a
+/// `sigaction` handler (yserver never does; it uses signalfd).
+#[must_use]
+pub fn sigusr1_is_ignored() -> bool {
+    // SAFETY: zeroed sigaction is a valid "read current" target.
+    let mut old: libc::sigaction = unsafe { std::mem::zeroed() };
+    let rc = unsafe { libc::sigaction(libc::SIGUSR1, std::ptr::null(), &mut old) };
+    rc == 0 && old.sa_sigaction == libc::SIG_IGN
+}
+
+/// Send SIGUSR1 to the parent (the DM), matching Xorg's `NotifyParentProcess`
+/// (`ParentProcess = getppid()`). Skips PID 1 — if we were reparented to
+/// init there is no DM to notify.
+pub fn signal_ready_to_parent() {
+    let ppid = unsafe { libc::getppid() };
+    if ppid > 1 {
+        unsafe { libc::kill(ppid, libc::SIGUSR1) };
+    }
+}
+
+/// Perform the readiness handshake: report the chosen display on
+/// `-displayfd` (if given) and signal the parent (if SIGUSR1 was inherited
+/// ignored). Call once, just before entering the core loop.
+#[allow(clippy::collapsible_if)]
+pub fn signal_ready(opts: &LaunchOptions, display: u16, sigusr1_was_ignored: bool) {
+    if let Some(fd) = opts.displayfd {
+        if let Err(e) = write_displayfd(fd, display) {
+            log::warn!("yserver: failed to write -displayfd {fd}: {e}");
+        }
+    }
+    if sigusr1_was_ignored {
+        log::info!("yserver: signaling readiness to parent (SIGUSR1)");
+        signal_ready_to_parent();
+    }
 }
 
 #[cfg(test)]
@@ -741,5 +812,34 @@ mod tests {
         assert!(res.is_err());
         assert!(!lock_path(&dir, 11).exists());
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn write_displayfd_writes_ascii_and_closes() {
+        // libc pipe: write end gets the display number, read end verifies.
+        let mut fds = [0 as RawFd; 2];
+        assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
+        let (read_fd, write_fd) = (fds[0], fds[1]);
+
+        write_displayfd(write_fd, 12).unwrap();
+
+        let mut buf = [0u8; 8];
+        let n = unsafe { libc::read(read_fd, buf.as_mut_ptr().cast(), buf.len()) };
+        assert!(n > 0);
+        assert_eq!(&buf[..n as usize], b"12\n");
+        unsafe { libc::close(read_fd) };
+    }
+
+    #[test]
+    fn sigusr1_disposition_roundtrip() {
+        // Process-global: save the prior disposition and restore it at
+        // the end (SIG_DFL is not necessarily what we started with). No
+        // other unit test in this crate touches SIGUSR1 disposition —
+        // keep it that way (tests share one process).
+        let prev = unsafe { libc::signal(libc::SIGUSR1, libc::SIG_IGN) };
+        assert!(sigusr1_is_ignored());
+        unsafe { libc::signal(libc::SIGUSR1, libc::SIG_DFL) };
+        assert!(!sigusr1_is_ignored());
+        unsafe { libc::signal(libc::SIGUSR1, prev) };
     }
 }

--- a/crates/yserver/src/launch.rs
+++ b/crates/yserver/src/launch.rs
@@ -7,10 +7,10 @@ use std::{
     fs::{self, OpenOptions},
     io::{self, ErrorKind, Read, Write},
     os::{
-        fd::RawFd,
+        fd::{AsRawFd, RawFd},
         unix::{
             fs::{FileTypeExt, MetadataExt, OpenOptionsExt, PermissionsExt},
-            net::{UnixListener, UnixStream},
+            net::UnixListener,
         },
     },
     path::{Path, PathBuf},
@@ -295,6 +295,60 @@ pub fn acquire_lock(lock_dir: &Path, display: u16) -> io::Result<LockGuard> {
     ))
 }
 
+/// Occupancy classification for a path in the socket directory.
+enum Occupancy {
+    /// Nothing there — free to bind.
+    Free,
+    /// A server is listening (or its backlog is full — still occupied).
+    Live,
+    /// Socket node with no listener (`ECONNREFUSED`) — reclaimable.
+    Stale,
+    /// Exists but is not a socket — never delete.
+    NonSocket,
+    /// Unreadable/unidentifiable — never delete.
+    Opaque,
+}
+
+/// Probe a socket-dir path. The connect is NONBLOCKING: a blocking
+/// connect to a live-but-backlogged AF_UNIX listener waits for accept —
+/// potentially forever (a wedged server, or a hostile local user's
+/// never-accepting listener in the world-writable socket dir, must not
+/// hang the launch). EAGAIN ⇒ backlog full ⇒ the display IS occupied.
+fn probe(path: &Path) -> Occupancy {
+    use nix::sys::socket::{AddressFamily, SockFlag, SockType, UnixAddr, connect, socket};
+
+    let meta = match fs::symlink_metadata(path) {
+        Ok(m) => m,
+        Err(e) if e.kind() == ErrorKind::NotFound => return Occupancy::Free,
+        Err(_) => return Occupancy::Opaque,
+    };
+    if !meta.file_type().is_socket() {
+        return Occupancy::NonSocket;
+    }
+    let fd = match socket(
+        AddressFamily::Unix,
+        SockType::Stream,
+        SockFlag::SOCK_NONBLOCK | SockFlag::SOCK_CLOEXEC,
+        None,
+    ) {
+        Ok(fd) => fd,
+        Err(_) => return Occupancy::Opaque,
+    };
+    let addr = match UnixAddr::new(path) {
+        Ok(a) => a,
+        Err(_) => return Occupancy::Opaque,
+    };
+    match connect(fd.as_raw_fd(), &addr) {
+        Ok(()) => Occupancy::Live,
+        // Nonblocking AF_UNIX connect outcomes:
+        Err(nix::errno::Errno::EAGAIN) => Occupancy::Live, // backlog full
+        Err(nix::errno::Errno::EINPROGRESS) => Occupancy::Live,
+        Err(nix::errno::Errno::ECONNREFUSED) => Occupancy::Stale,
+        Err(_) => Occupancy::Opaque,
+    }
+    // fd is an OwnedFd — closed on drop.
+}
+
 fn chmod_socket(path: &Path) -> io::Result<()> {
     // X clients connect as the invoking user; the socket needs world
     // write (connect() on AF_UNIX requires `w`). Xorg sets 0777.
@@ -307,13 +361,19 @@ fn chmod_socket(path: &Path) -> io::Result<()> {
 /// lock, so holding the lock alone doesn't prove the display is free).
 pub fn bind_explicit(socket_dir: &Path, display: u16) -> io::Result<(UnixListener, PathBuf)> {
     let path = socket_dir.join(format!("X{display}"));
-    // File-type check FIRST: connect(AF_UNIX) to a non-socket inode
-    // returns ECONNREFUSED on Linux (same errno as a stale socket!), so
-    // errno alone cannot distinguish "dead server's socket" from "some
-    // file that happens to be named X<n>". Never delete a non-socket.
-    // symlink_metadata also refuses symlinks (is_socket() is false).
-    if let Ok(meta) = fs::symlink_metadata(&path) {
-        if !meta.file_type().is_socket() {
+    match probe(&path) {
+        Occupancy::Free => {}
+        Occupancy::Stale => {
+            // Stale socket from a dead server — reclaim it.
+            let _ = fs::remove_file(&path);
+        }
+        Occupancy::Live => {
+            return Err(io::Error::new(
+                ErrorKind::AddrInUse,
+                format!("display :{display} in use (live socket {})", path.display()),
+            ));
+        }
+        Occupancy::NonSocket => {
             return Err(io::Error::new(
                 ErrorKind::AddrInUse,
                 format!(
@@ -322,62 +382,53 @@ pub fn bind_explicit(socket_dir: &Path, display: u16) -> io::Result<(UnixListene
                 ),
             ));
         }
-        match UnixStream::connect(&path) {
-            Ok(_) => {
-                return Err(io::Error::new(
-                    ErrorKind::AddrInUse,
-                    format!("display :{display} in use (live socket {})", path.display()),
-                ));
-            }
-            Err(e) if e.kind() == ErrorKind::ConnectionRefused => {
-                // Stale socket from a dead server — reclaim it.
-                let _ = fs::remove_file(&path);
-            }
-            Err(_) => {
-                // Occupied/unknown (e.g. EACCES). Be conservative:
-                // refuse rather than delete what we can't identify.
-                return Err(io::Error::new(
-                    ErrorKind::AddrInUse,
-                    format!("cannot probe {} — refusing to replace it", path.display()),
-                ));
-            }
+        Occupancy::Opaque => {
+            return Err(io::Error::new(
+                ErrorKind::AddrInUse,
+                format!("cannot probe {} — refusing to replace it", path.display()),
+            ));
         }
     }
     let listener = UnixListener::bind(&path)?;
-    chmod_socket(&path)?;
+    if let Err(e) = chmod_socket(&path) {
+        let _ = fs::remove_file(&path);
+        return Err(e);
+    }
     Ok((listener, path))
 }
 
 /// Scan `0..256` for the lowest free display and bind it. Disambiguates an
 /// existing socket file via `connect()`: refused ⇒ stale ⇒ reclaim;
-/// connected ⇒ live ⇒ skip; other error ⇒ occupied ⇒ skip. Retries on a
-/// `bind()` `EADDRINUSE` race. Takes no lock (matches Xorg `nolock`).
+/// connected ⇒ live ⇒ skip; other error ⇒ occupied ⇒ skip. Moves on to the
+/// next display on a `bind()` `EADDRINUSE` race. Takes no lock (matches
+/// Xorg `nolock`).
 pub fn autopick(socket_dir: &Path) -> io::Result<(u16, UnixListener, PathBuf)> {
     for n in 0u16..256 {
         let path = socket_dir.join(format!("X{n}"));
-        // Same file-type-first rule as bind_explicit: ECONNREFUSED can't
-        // distinguish a stale socket from a non-socket file, and we must
-        // never delete the latter. Non-socket / unreadable ⇒ skip.
-        match fs::symlink_metadata(&path) {
-            Ok(meta) if !meta.file_type().is_socket() => continue,
-            Ok(_) => match UnixStream::connect(&path) {
-                Ok(_) => continue, // live server
-                Err(e) if e.kind() == ErrorKind::ConnectionRefused => {
-                    // Stale socket node — reclaim it.
-                    let _ = fs::remove_file(&path);
-                }
-                Err(_) => continue, // occupied/unknown — leave it alone
-            },
-            Err(e) if e.kind() == ErrorKind::NotFound => {} // free — bind below
-            Err(_) => continue,                             // unreadable — not ours to touch
+        match probe(&path) {
+            Occupancy::Free => {}
+            Occupancy::Stale => {
+                // Stale socket node — reclaim it.
+                let _ = fs::remove_file(&path);
+            }
+            // Live, non-socket, or unidentifiable: not ours — next k.
+            Occupancy::Live | Occupancy::NonSocket | Occupancy::Opaque => continue,
         }
         match UnixListener::bind(&path) {
             Ok(listener) => {
-                chmod_socket(&path)?;
+                if let Err(e) = chmod_socket(&path) {
+                    let _ = fs::remove_file(&path);
+                    return Err(e);
+                }
                 return Ok((n, listener, path));
             }
             Err(e) if e.kind() == ErrorKind::AddrInUse => continue, // lost a race
-            Err(e) => return Err(e),
+            Err(e) => {
+                return Err(io::Error::new(
+                    e.kind(),
+                    format!("bind({}): {e}", path.display()),
+                ));
+            }
         }
     }
     Err(io::Error::new(
@@ -389,6 +440,8 @@ pub fn autopick(socket_dir: &Path) -> io::Result<(u16, UnixListener, PathBuf)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use std::os::unix::net::UnixListener as TestListener;
 
     fn parse(args: &[&str]) -> Result<LaunchOptions, String> {
         parse_args(args.iter().map(|s| (*s).to_string()))
@@ -574,8 +627,6 @@ mod tests {
         drop(guard);
         std::fs::remove_dir_all(&dir).ok();
     }
-
-    use std::os::unix::net::UnixListener as TestListener;
 
     #[test]
     fn bind_explicit_binds_and_chmods() {

--- a/crates/yserver/src/launch.rs
+++ b/crates/yserver/src/launch.rs
@@ -8,7 +8,10 @@ use std::{
     io::{self, ErrorKind, Read, Write},
     os::{
         fd::RawFd,
-        unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt},
+        unix::{
+            fs::{FileTypeExt, MetadataExt, OpenOptionsExt, PermissionsExt},
+            net::{UnixListener, UnixStream},
+        },
     },
     path::{Path, PathBuf},
 };
@@ -292,6 +295,97 @@ pub fn acquire_lock(lock_dir: &Path, display: u16) -> io::Result<LockGuard> {
     ))
 }
 
+fn chmod_socket(path: &Path) -> io::Result<()> {
+    // X clients connect as the invoking user; the socket needs world
+    // write (connect() on AF_UNIX requires `w`). Xorg sets 0777.
+    fs::set_permissions(path, fs::Permissions::from_mode(0o777))
+}
+
+/// Bind `<socket_dir>/X<display>` for the explicit-`:N` and
+/// back-compat-default cases. Probes an existing socket before removing
+/// it: a live server's socket is NEVER stolen (old yservers take no
+/// lock, so holding the lock alone doesn't prove the display is free).
+pub fn bind_explicit(socket_dir: &Path, display: u16) -> io::Result<(UnixListener, PathBuf)> {
+    let path = socket_dir.join(format!("X{display}"));
+    // File-type check FIRST: connect(AF_UNIX) to a non-socket inode
+    // returns ECONNREFUSED on Linux (same errno as a stale socket!), so
+    // errno alone cannot distinguish "dead server's socket" from "some
+    // file that happens to be named X<n>". Never delete a non-socket.
+    // symlink_metadata also refuses symlinks (is_socket() is false).
+    if let Ok(meta) = fs::symlink_metadata(&path) {
+        if !meta.file_type().is_socket() {
+            return Err(io::Error::new(
+                ErrorKind::AddrInUse,
+                format!(
+                    "{} exists and is not a socket — refusing to replace it",
+                    path.display()
+                ),
+            ));
+        }
+        match UnixStream::connect(&path) {
+            Ok(_) => {
+                return Err(io::Error::new(
+                    ErrorKind::AddrInUse,
+                    format!("display :{display} in use (live socket {})", path.display()),
+                ));
+            }
+            Err(e) if e.kind() == ErrorKind::ConnectionRefused => {
+                // Stale socket from a dead server — reclaim it.
+                let _ = fs::remove_file(&path);
+            }
+            Err(_) => {
+                // Occupied/unknown (e.g. EACCES). Be conservative:
+                // refuse rather than delete what we can't identify.
+                return Err(io::Error::new(
+                    ErrorKind::AddrInUse,
+                    format!("cannot probe {} — refusing to replace it", path.display()),
+                ));
+            }
+        }
+    }
+    let listener = UnixListener::bind(&path)?;
+    chmod_socket(&path)?;
+    Ok((listener, path))
+}
+
+/// Scan `0..256` for the lowest free display and bind it. Disambiguates an
+/// existing socket file via `connect()`: refused ⇒ stale ⇒ reclaim;
+/// connected ⇒ live ⇒ skip; other error ⇒ occupied ⇒ skip. Retries on a
+/// `bind()` `EADDRINUSE` race. Takes no lock (matches Xorg `nolock`).
+pub fn autopick(socket_dir: &Path) -> io::Result<(u16, UnixListener, PathBuf)> {
+    for n in 0u16..256 {
+        let path = socket_dir.join(format!("X{n}"));
+        // Same file-type-first rule as bind_explicit: ECONNREFUSED can't
+        // distinguish a stale socket from a non-socket file, and we must
+        // never delete the latter. Non-socket / unreadable ⇒ skip.
+        match fs::symlink_metadata(&path) {
+            Ok(meta) if !meta.file_type().is_socket() => continue,
+            Ok(_) => match UnixStream::connect(&path) {
+                Ok(_) => continue, // live server
+                Err(e) if e.kind() == ErrorKind::ConnectionRefused => {
+                    // Stale socket node — reclaim it.
+                    let _ = fs::remove_file(&path);
+                }
+                Err(_) => continue, // occupied/unknown — leave it alone
+            },
+            Err(e) if e.kind() == ErrorKind::NotFound => {} // free — bind below
+            Err(_) => continue,                             // unreadable — not ours to touch
+        }
+        match UnixListener::bind(&path) {
+            Ok(listener) => {
+                chmod_socket(&path)?;
+                return Ok((n, listener, path));
+            }
+            Err(e) if e.kind() == ErrorKind::AddrInUse => continue, // lost a race
+            Err(e) => return Err(e),
+        }
+    }
+    Err(io::Error::new(
+        ErrorKind::AddrInUse,
+        "no free X display in 0..256",
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -478,6 +572,123 @@ mod tests {
         let guard = acquire_lock(&dir, 10).unwrap();
         assert!(lock_path(&dir, 10).exists());
         drop(guard);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    use std::os::unix::net::UnixListener as TestListener;
+
+    #[test]
+    fn bind_explicit_binds_and_chmods() {
+        let dir = unique_tmp_dir("bind-explicit");
+        let (listener, path) = bind_explicit(&dir, 3).unwrap();
+        assert_eq!(path, dir.join("X3"));
+        assert!(path.exists());
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o777);
+        drop(listener);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn autopick_empty_dir_picks_zero() {
+        let dir = unique_tmp_dir("autopick-empty");
+        let (n, listener, path) = autopick(&dir).unwrap();
+        assert_eq!(n, 0);
+        assert_eq!(path, dir.join("X0"));
+        drop(listener);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn autopick_skips_live_socket() {
+        let dir = unique_tmp_dir("autopick-live");
+        // A live listener on X0 — keep it bound for the duration.
+        let live = TestListener::bind(dir.join("X0")).unwrap();
+        let (n, listener, _path) = autopick(&dir).unwrap();
+        assert_eq!(n, 1);
+        drop(listener);
+        drop(live);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn autopick_reclaims_stale_socket() {
+        let dir = unique_tmp_dir("autopick-stale");
+        // Bind then drop: the socket node remains on disk with no
+        // listener (Rust does not unlink on drop) → a faithful stale
+        // socket. connect() → ECONNREFUSED → reclaim.
+        let stale = TestListener::bind(dir.join("X0")).unwrap();
+        drop(stale);
+        assert!(dir.join("X0").exists());
+        let (n, listener, _path) = autopick(&dir).unwrap();
+        assert_eq!(n, 0);
+        drop(listener);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn autopick_skips_non_socket_file() {
+        // A regular file named X0: the file-type check skips it without
+        // deleting. (connect() to a non-socket gives ECONNREFUSED on
+        // Linux — same errno as a stale socket — so the type check, not
+        // errno, is what protects the file.)
+        let dir = unique_tmp_dir("autopick-notsock");
+        std::fs::write(dir.join("X0"), b"junk").unwrap();
+        let (n, listener, _path) = autopick(&dir).unwrap();
+        assert_eq!(n, 1);
+        assert!(dir.join("X0").exists()); // untouched
+        drop(listener);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn bind_explicit_refuses_non_socket_file() {
+        let dir = unique_tmp_dir("bind-notsock");
+        std::fs::write(dir.join("X6"), b"junk").unwrap();
+        let err = bind_explicit(&dir, 6).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::AddrInUse);
+        assert!(dir.join("X6").exists()); // untouched
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn bind_explicit_refuses_live_socket() {
+        // Explicit bind must never steal a live server's socket — probe
+        // first, error AddrInUse if something is listening.
+        let dir = unique_tmp_dir("bind-live");
+        let live = TestListener::bind(dir.join("X4")).unwrap();
+        let err = bind_explicit(&dir, 4).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::AddrInUse);
+        drop(live);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn bind_explicit_reclaims_stale_socket() {
+        let dir = unique_tmp_dir("bind-stale");
+        let stale = TestListener::bind(dir.join("X5")).unwrap();
+        drop(stale);
+        assert!(dir.join("X5").exists());
+        let (listener, path) = bind_explicit(&dir, 5).unwrap();
+        assert_eq!(path, dir.join("X5"));
+        drop(listener);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn lock_released_when_bind_fails() {
+        // Mimics run()'s error path: `?` after acquire_lock drops the
+        // guard, which must remove the lock — never leave a lock we
+        // don't back with a live socket.
+        let dir = unique_tmp_dir("lock-bind-fail");
+        let res: std::io::Result<()> = (|| {
+            let _guard = acquire_lock(&dir, 11)?;
+            let missing = dir.join("no-such-subdir");
+            let _ = bind_explicit(&missing, 11)?; // fails: dir doesn't exist
+            Ok(())
+        })();
+        assert!(res.is_err());
+        assert!(!lock_path(&dir, 11).exists());
         std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/crates/yserver/src/launch.rs
+++ b/crates/yserver/src/launch.rs
@@ -133,6 +133,19 @@ impl Drop for LockGuard {
     }
 }
 
+/// Removes the temp lock file when `acquire_lock` exits by ANY path —
+/// including `?` error propagation. The success path's hard link
+/// survives the temp's unlink, so unconditional cleanup is safe.
+struct TmpGuard {
+    path: PathBuf,
+}
+
+impl Drop for TmpGuard {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
 /// `/tmp/.X<N>-lock` path for a display.
 #[must_use]
 pub fn lock_path(lock_dir: &Path, display: u16) -> PathBuf {
@@ -221,12 +234,14 @@ pub fn acquire_lock(lock_dir: &Path, display: u16) -> io::Result<LockGuard> {
     // Xorg's LockServer READS existing locks). Force 0444 umask-immune,
     // like Xorg's fchmod after create (os/utils.c:312).
     fs::set_permissions(&tmp_path, fs::Permissions::from_mode(0o444))?;
+    let _tmp_guard = TmpGuard {
+        path: tmp_path.clone(),
+    };
 
     // At most two attempts: acquire, or reclaim-once-then-acquire.
     for _ in 0..2 {
         match fs::hard_link(&tmp_path, &final_path) {
             Ok(()) => {
-                let _ = fs::remove_file(&tmp_path);
                 return Ok(LockGuard { path: final_path });
             }
             Err(e) if e.kind() == ErrorKind::AlreadyExists => {
@@ -256,7 +271,6 @@ pub fn acquire_lock(lock_dir: &Path, display: u16) -> io::Result<LockGuard> {
                         // (typically Alive → AddrInUse).
                     }
                     LockState::Alive => {
-                        let _ = fs::remove_file(&tmp_path);
                         return Err(io::Error::new(
                             ErrorKind::AddrInUse,
                             format!(
@@ -268,12 +282,10 @@ pub fn acquire_lock(lock_dir: &Path, display: u16) -> io::Result<LockGuard> {
                 }
             }
             Err(e) => {
-                let _ = fs::remove_file(&tmp_path);
                 return Err(e);
             }
         }
     }
-    let _ = fs::remove_file(&tmp_path);
     Err(io::Error::new(
         ErrorKind::AddrInUse,
         format!("could not acquire display lock {}", final_path.display()),
@@ -399,11 +411,12 @@ mod tests {
 
     #[test]
     fn lock_fresh_acquire_creates_file() {
-        use std::os::unix::fs::PermissionsExt;
         let dir = unique_tmp_dir("lock-fresh");
         let guard = acquire_lock(&dir, 5).unwrap();
         let p = lock_path(&dir, 5);
         assert!(p.exists());
+        let tmp = dir.join(format!(".tX5-lock.{}", std::process::id()));
+        assert!(!tmp.exists());
         // Xorg publishes the lock read-only (0444).
         let mode = std::fs::metadata(&p).unwrap().permissions().mode();
         assert_eq!(mode & 0o777, 0o444);
@@ -430,6 +443,8 @@ mod tests {
         let _guard = acquire_lock(&dir, 7).unwrap();
         let err = acquire_lock(&dir, 7).unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::AddrInUse);
+        let tmp = dir.join(format!(".tX7-lock.{}", std::process::id()));
+        assert!(!tmp.exists());
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/crates/yserver/src/launch.rs
+++ b/crates/yserver/src/launch.rs
@@ -1,0 +1,210 @@
+//! X-server-style launch handling: argv parsing, display resolution,
+//! the `/tmp/.X<N>-lock` protocol, socket binding, and the lightdm
+//! readiness handshake. See
+//! `docs/superpowers/specs/2026-06-12-lightdm-launch-design.md`.
+
+use std::{os::fd::RawFd, path::PathBuf};
+
+/// Display yserver uses when neither an explicit display nor `-displayfd`
+/// is given. 7 avoids clashing with a real Xorg on `:0` (existing
+/// convention).
+pub const DEFAULT_DISPLAY: u16 = 7;
+
+/// Parsed X-server-style command line. Fields the issue's items 1-2 act
+/// on; `vt`/`seat` are parsed + logged but otherwise ignored (logind owns
+/// the seat/VT), `auth_file` is stashed for the deferred item 4.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct LaunchOptions {
+    /// `:N` or bare `N` → explicit display; `None` → resolved in `run()`.
+    pub display: Option<u16>,
+    /// `-displayfd N`.
+    pub displayfd: Option<RawFd>,
+    /// `vtN` — logged, otherwise ignored.
+    pub vt: Option<u32>,
+    /// `-seat NAME` — logged, otherwise ignored.
+    pub seat: Option<String>,
+    /// `-auth FILE` — stashed for item 4, unused now.
+    pub auth_file: Option<PathBuf>,
+}
+
+fn next_value(it: &mut impl Iterator<Item = String>, flag: &str) -> Result<String, String> {
+    it.next().ok_or_else(|| format!("{flag} requires a value"))
+}
+
+/// Parse X-server-style argv. Tolerates unknown flags (warn + skip);
+/// hard-errors only on malformed *explicit* requests and missing values
+/// for known value-taking flags.
+pub fn parse_args(args: impl IntoIterator<Item = String>) -> Result<LaunchOptions, String> {
+    let mut o = LaunchOptions::default();
+    let mut it = args.into_iter();
+    while let Some(arg) = it.next() {
+        if let Some(rest) = arg.strip_prefix(':') {
+            o.display = Some(
+                rest.parse::<u16>()
+                    .map_err(|_| format!("invalid display argument: {arg}"))?,
+            );
+        } else if let Some(rest) = arg.strip_prefix("vt") {
+            o.vt = Some(
+                rest.parse::<u32>()
+                    .map_err(|_| format!("invalid vt argument: {arg}"))?,
+            );
+        } else if arg == "-seat" {
+            o.seat = Some(next_value(&mut it, "-seat")?);
+        } else if arg == "-auth" {
+            o.auth_file = Some(PathBuf::from(next_value(&mut it, "-auth")?));
+        } else if arg == "-displayfd" {
+            let v = next_value(&mut it, "-displayfd")?;
+            o.displayfd = Some(
+                v.parse::<RawFd>()
+                    .map_err(|_| format!("invalid -displayfd argument: {v}"))?,
+            );
+        } else if matches!(
+            arg.as_str(),
+            "-nolisten" | "-config" | "-layout" | "-background"
+        ) {
+            // Known value-taking no-ops. Consume + ignore the value; a
+            // missing value is tolerated (these don't affect us).
+            if it.next().is_none() {
+                log::warn!("yserver: {arg} given without a value; ignoring");
+            }
+        } else if arg == "-novtswitch" {
+            // Known no-arg no-op (lightdm passes it).
+        } else if let Ok(n) = arg.parse::<u16>() {
+            // Bare number → display. Keeps `yserver 7` (Justfile) working.
+            o.display = Some(n);
+        } else {
+            log::warn!("yserver: ignoring unrecognized argument: {arg}");
+        }
+    }
+    Ok(o)
+}
+
+/// How `run()` should obtain the display + whether to take the lock.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Resolution {
+    /// Use this exact display. `lock` is true only when `-displayfd` is
+    /// absent (Xorg sets `nolock = TRUE` whenever `-displayfd` is parsed).
+    Explicit { display: u16, lock: bool },
+    /// Scan for the lowest free display (gdm-style `-displayfd`); no lock.
+    AutoPick,
+}
+
+/// The display-resolution table from the spec. Lock iff `-displayfd` is
+/// absent.
+#[must_use]
+pub fn resolve(opts: &LaunchOptions) -> Resolution {
+    match (opts.display, opts.displayfd) {
+        (Some(display), None) => Resolution::Explicit {
+            display,
+            lock: true,
+        },
+        (Some(display), Some(_)) => Resolution::Explicit {
+            display,
+            lock: false,
+        },
+        (None, Some(_)) => Resolution::AutoPick,
+        (None, None) => Resolution::Explicit {
+            display: DEFAULT_DISPLAY,
+            lock: true,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(args: &[&str]) -> Result<LaunchOptions, String> {
+        parse_args(args.iter().map(|s| (*s).to_string()))
+    }
+
+    #[test]
+    fn lightdm_default_argv_parses_clean() {
+        let o = parse(&[
+            ":0",
+            "-seat",
+            "seat0",
+            "-auth",
+            "/var/run/lightdm/root/:0",
+            "-nolisten",
+            "tcp",
+            "vt7",
+            "-novtswitch",
+        ])
+        .unwrap();
+        assert_eq!(o.display, Some(0));
+        assert_eq!(o.displayfd, None);
+        assert_eq!(o.vt, Some(7));
+        assert_eq!(o.seat.as_deref(), Some("seat0"));
+        assert_eq!(o.auth_file, Some(PathBuf::from("/var/run/lightdm/root/:0")));
+    }
+
+    #[test]
+    fn gdm_style_displayfd_without_explicit_display() {
+        let o = parse(&["-displayfd", "12"]).unwrap();
+        assert_eq!(o.displayfd, Some(12));
+        assert_eq!(o.display, None);
+    }
+
+    #[test]
+    fn bare_number_is_back_compat_display() {
+        assert_eq!(parse(&["7"]).unwrap().display, Some(7));
+        assert_eq!(parse(&[]).unwrap().display, None);
+    }
+
+    #[test]
+    fn explicit_colon_display() {
+        assert_eq!(parse(&[":42"]).unwrap().display, Some(42));
+    }
+
+    #[test]
+    fn unknown_flags_are_tolerated() {
+        let o = parse(&["-bogus", "--whatever", ":1"]).unwrap();
+        assert_eq!(o.display, Some(1));
+    }
+
+    #[test]
+    fn malformed_explicit_requests_error() {
+        assert!(parse(&[":foo"]).is_err());
+        assert!(parse(&["vtbad"]).is_err());
+        assert!(parse(&["-displayfd", "notanumber"]).is_err());
+    }
+
+    #[test]
+    fn missing_required_value_errors() {
+        assert!(parse(&["-seat"]).is_err());
+        assert!(parse(&["-auth"]).is_err());
+        assert!(parse(&["-displayfd"]).is_err());
+    }
+
+    #[test]
+    fn resolution_table() {
+        let mk = |d: Option<u16>, fd: Option<RawFd>| LaunchOptions {
+            display: d,
+            displayfd: fd,
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve(&mk(Some(0), None)),
+            Resolution::Explicit {
+                display: 0,
+                lock: true
+            }
+        );
+        assert_eq!(
+            resolve(&mk(Some(0), Some(9))),
+            Resolution::Explicit {
+                display: 0,
+                lock: false
+            }
+        );
+        assert_eq!(resolve(&mk(None, Some(9))), Resolution::AutoPick);
+        assert_eq!(
+            resolve(&mk(None, None)),
+            Resolution::Explicit {
+                display: DEFAULT_DISPLAY,
+                lock: true
+            }
+        );
+    }
+}

--- a/crates/yserver/src/launch.rs
+++ b/crates/yserver/src/launch.rs
@@ -7,7 +7,7 @@ use std::{
     fs::{self, OpenOptions},
     io::{self, ErrorKind, Read, Write},
     os::{
-        fd::{AsRawFd, RawFd},
+        fd::{AsRawFd, FromRawFd, RawFd},
         unix::{
             fs::{FileTypeExt, MetadataExt, OpenOptionsExt, PermissionsExt},
             net::UnixListener,
@@ -439,33 +439,15 @@ pub fn autopick(socket_dir: &Path) -> io::Result<(u16, UnixListener, PathBuf)> {
 }
 
 /// Write `"<display>\n"` (Xorg's `-displayfd` format) to `fd`, then close
-/// it. Used only when `-displayfd N` was given. Close errors are ignored:
-/// the fd is single-use and there is nothing actionable after the payload
-/// was written.
+/// it. Takes ownership of the fd (closed on every exit path via drop).
+/// Close errors are ignored: the fd is single-use and there is nothing
+/// actionable after the payload was written.
 pub fn write_displayfd(fd: RawFd, display: u16) -> io::Result<()> {
-    let s = format!("{display}\n");
-    let bytes = s.as_bytes();
-    let mut written = 0usize;
-    while written < bytes.len() {
-        // SAFETY: writing `bytes[written..]` to a caller-owned fd.
-        let r = unsafe { libc::write(fd, bytes[written..].as_ptr().cast(), bytes.len() - written) };
-        if r < 0 {
-            let err = io::Error::last_os_error();
-            unsafe { libc::close(fd) };
-            return Err(err);
-        }
-        if r == 0 {
-            // A zero-length write would loop forever — fail instead.
-            unsafe { libc::close(fd) };
-            return Err(io::Error::new(
-                ErrorKind::WriteZero,
-                "displayfd write returned 0",
-            ));
-        }
-        written += r as usize;
-    }
-    unsafe { libc::close(fd) };
-    Ok(())
+    // SAFETY: ownership transfer — the caller hands us the `-displayfd`
+    // fd precisely so we consume it; no other owner exists. From here,
+    // `File` closes it on drop (success and error paths alike).
+    let mut f = unsafe { std::fs::File::from_raw_fd(fd) };
+    f.write_all(format!("{display}\n").as_bytes())
 }
 
 /// True if SIGUSR1's *inherited disposition* is `SIG_IGN` — the signal
@@ -827,19 +809,27 @@ mod tests {
         let n = unsafe { libc::read(read_fd, buf.as_mut_ptr().cast(), buf.len()) };
         assert!(n > 0);
         assert_eq!(&buf[..n as usize], b"12\n");
+        // EOF proves the write end was closed by write_displayfd.
+        let n2 = unsafe { libc::read(read_fd, buf.as_mut_ptr().cast(), buf.len()) };
+        assert_eq!(n2, 0);
         unsafe { libc::close(read_fd) };
     }
 
     #[test]
     fn sigusr1_disposition_roundtrip() {
-        // Process-global: save the prior disposition and restore it at
-        // the end (SIG_DFL is not necessarily what we started with). No
-        // other unit test in this crate touches SIGUSR1 disposition —
+        // Process-global: restore the prior disposition even on panic.
+        // No other unit test in this crate touches SIGUSR1 disposition —
         // keep it that way (tests share one process).
+        struct Restore(libc::sighandler_t);
+        impl Drop for Restore {
+            fn drop(&mut self) {
+                unsafe { libc::signal(libc::SIGUSR1, self.0) };
+            }
+        }
         let prev = unsafe { libc::signal(libc::SIGUSR1, libc::SIG_IGN) };
+        let _restore = Restore(prev);
         assert!(sigusr1_is_ignored());
         unsafe { libc::signal(libc::SIGUSR1, libc::SIG_DFL) };
         assert!(!sigusr1_is_ignored());
-        unsafe { libc::signal(libc::SIGUSR1, prev) };
     }
 }

--- a/crates/yserver/src/launch.rs
+++ b/crates/yserver/src/launch.rs
@@ -464,29 +464,49 @@ pub fn sigusr1_is_ignored() -> bool {
     rc == 0 && old.sa_sigaction == libc::SIG_IGN
 }
 
-/// Send SIGUSR1 to the parent (the DM), matching Xorg's `NotifyParentProcess`
-/// (`ParentProcess = getppid()`). Skips PID 1 — if we were reparented to
-/// init there is no DM to notify.
-pub fn signal_ready_to_parent() {
+/// Capture the parent PID once at startup — Xorg's `InitParentProcess`
+/// (`os/connection.c`). Returns `None` if already orphaned (`ppid <= 1`,
+/// no DM to signal). MUST be called early, before long init during which
+/// the parent could die and reparent us to a subreaper or PID 1.
+#[must_use]
+pub fn startup_parent_pid() -> Option<i32> {
     let ppid = unsafe { libc::getppid() };
-    if ppid > 1 {
-        unsafe { libc::kill(ppid, libc::SIGUSR1) };
-    }
+    if ppid > 1 { Some(ppid) } else { None }
+}
+
+/// Send SIGUSR1 to the parent (the DM) captured at startup, matching
+/// Xorg's `NotifyParentProcess` (`ParentProcess` set in
+/// `InitParentProcess`). `parent_pid` comes from [`startup_parent_pid`].
+pub fn signal_ready_to_parent(parent_pid: i32) {
+    // SAFETY: kill to a captured PID; harmless if it's since exited.
+    unsafe { libc::kill(parent_pid, libc::SIGUSR1) };
 }
 
 /// Perform the readiness handshake: report the chosen display on
-/// `-displayfd` (if given) and signal the parent (if SIGUSR1 was inherited
-/// ignored). Call once, just before entering the core loop.
+/// `-displayfd` (if given) and signal the startup-captured parent (if
+/// SIGUSR1 was inherited ignored). Call once, just before the core loop.
 #[allow(clippy::collapsible_if)]
-pub fn signal_ready(opts: &LaunchOptions, display: u16, sigusr1_was_ignored: bool) {
+pub fn signal_ready(
+    opts: &LaunchOptions,
+    display: u16,
+    sigusr1_was_ignored: bool,
+    parent_pid: Option<i32>,
+) {
     if let Some(fd) = opts.displayfd {
         if let Err(e) = write_displayfd(fd, display) {
             log::warn!("yserver: failed to write -displayfd {fd}: {e}");
         }
     }
     if sigusr1_was_ignored {
-        log::info!("yserver: signaling readiness to parent (SIGUSR1)");
-        signal_ready_to_parent();
+        match parent_pid {
+            Some(pid) => {
+                log::info!("yserver: signaling readiness to parent {pid} (SIGUSR1)");
+                signal_ready_to_parent(pid);
+            }
+            None => log::warn!(
+                "yserver: SIGUSR1 inherited-ignored but orphaned at startup — no parent to signal"
+            ),
+        }
     }
 }
 
@@ -831,5 +851,11 @@ mod tests {
         assert!(sigusr1_is_ignored());
         unsafe { libc::signal(libc::SIGUSR1, libc::SIG_DFL) };
         assert!(!sigusr1_is_ignored());
+    }
+
+    #[test]
+    fn startup_parent_pid_is_some_under_test_runner() {
+        // The test process always has a real parent (the harness), ppid > 1.
+        assert!(startup_parent_pid().is_some());
     }
 }

--- a/crates/yserver/src/launch.rs
+++ b/crates/yserver/src/launch.rs
@@ -200,16 +200,25 @@ pub fn acquire_lock(lock_dir: &Path, display: u16) -> io::Result<LockGuard> {
     let tmp_path = lock_dir.join(format!(".tX{display}-lock.{}", std::process::id()));
     let pid_line = format!("{:>10}\n", std::process::id());
 
+    // Create the temp ONCE, outside the retry loop: its content never
+    // changes between attempts, and a 0444 file cannot be re-opened for
+    // write on a second iteration (mode applies at create time; reopening
+    // a read-only file for write is EACCES). The pre-unlink handles a
+    // stale 0444 temp left by a crashed earlier server that had our
+    // (reused) PID.
+    let _ = fs::remove_file(&tmp_path);
+    {
+        let mut tmp = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o444)
+            .open(&tmp_path)?;
+        tmp.write_all(pid_line.as_bytes())?;
+    }
+
     // At most two attempts: acquire, or reclaim-once-then-acquire.
     for _ in 0..2 {
-        {
-            let mut tmp = OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .open(&tmp_path)?;
-            tmp.write_all(pid_line.as_bytes())?;
-        }
         match fs::hard_link(&tmp_path, &final_path) {
             Ok(()) => {
                 let _ = fs::remove_file(&tmp_path);
@@ -385,9 +394,14 @@ mod tests {
 
     #[test]
     fn lock_fresh_acquire_creates_file() {
+        use std::os::unix::fs::PermissionsExt;
         let dir = unique_tmp_dir("lock-fresh");
         let guard = acquire_lock(&dir, 5).unwrap();
-        assert!(lock_path(&dir, 5).exists());
+        let p = lock_path(&dir, 5);
+        assert!(p.exists());
+        // Xorg publishes the lock read-only (0444).
+        let mode = std::fs::metadata(&p).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o444);
         drop(guard);
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/crates/yserver/src/launch.rs
+++ b/crates/yserver/src/launch.rs
@@ -8,7 +8,7 @@ use std::{
     io::{self, ErrorKind, Read, Write},
     os::{
         fd::RawFd,
-        unix::fs::{MetadataExt, OpenOptionsExt},
+        unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt},
     },
     path::{Path, PathBuf},
 };
@@ -216,6 +216,11 @@ pub fn acquire_lock(lock_dir: &Path, display: u16) -> io::Result<LockGuard> {
             .open(&tmp_path)?;
         tmp.write_all(pid_line.as_bytes())?;
     }
+    // Create-time mode is masked by the process umask (a DM/systemd unit
+    // may set e.g. UMask=0077 → 0400, unreadable to foreign launchers —
+    // Xorg's LockServer READS existing locks). Force 0444 umask-immune,
+    // like Xorg's fchmod after create (os/utils.c:312).
+    fs::set_permissions(&tmp_path, fs::Permissions::from_mode(0o444))?;
 
     // At most two attempts: acquire, or reclaim-once-then-acquire.
     for _ in 0..2 {

--- a/crates/yserver/src/lib.rs
+++ b/crates/yserver/src/lib.rs
@@ -305,6 +305,14 @@ pub fn run(opts: launch::LaunchOptions) -> io::Result<()> {
     // only sees channel-side messages. SIGINT/SIGTERM map to
     // `Shutdown`; SIGUSR1 maps to `DumpScanout` (diagnostic — backend
     // dumps the current scanout BO to a file in cwd).
+    //
+    // SIGUSR1 carries three distinct, non-conflicting meanings here:
+    // (1) the *inherited disposition* read once at startup
+    // (`sigusr1_was_ignored` above) drives the readiness handshake
+    // *to the parent* DM (`launch::signal_ready`); (2) masked-and-
+    // signalfd-consumed *delivery to self* triggers the scanout dump
+    // below; (3) we *send* SIGUSR1 outward to the parent at readiness.
+    // Disposition-in, delivery-to-self, and signal-out are separate.
     let signal_sender = sender.clone_handle();
     thread::Builder::new()
         .name("yserver-signalfd".into())

--- a/crates/yserver/src/lib.rs
+++ b/crates/yserver/src/lib.rs
@@ -50,6 +50,11 @@ pub fn run(opts: launch::LaunchOptions) -> io::Result<()> {
     // If the DM started us with SIGUSR1 ignored, we signal it when ready.
     let sigusr1_was_ignored = launch::sigusr1_is_ignored();
 
+    // Capture the parent (DM) PID now, before long init — if the parent
+    // dies during startup and we get reparented, getppid() at readiness
+    // would point at a subreaper or PID 1. Xorg captures it the same way.
+    let parent_pid = launch::startup_parent_pid();
+
     // Vulkan-call-rate telemetry: emit a per-second snapshot of
     // call counters from `kms::vk::call_stats::VK_CALLS`. Gated on
     // the same `YSERVER_LOOP_TELEMETRY` env var the core-loop
@@ -356,7 +361,7 @@ pub fn run(opts: launch::LaunchOptions) -> io::Result<()> {
     // bound + chmod'd, and the lock is held — we can complete an initial X
     // connection setup now. This is the analog of Xorg signaling after
     // CreateConnectionBlock() and before Dispatch().
-    launch::signal_ready(&opts, display, sigusr1_was_ignored);
+    launch::signal_ready(&opts, display, sigusr1_was_ignored, parent_pid);
 
     let alloc = ClientIdAllocator::new();
     log::info!("yserver: entering single-threaded core loop");

--- a/crates/yserver/src/lib.rs
+++ b/crates/yserver/src/lib.rs
@@ -7,13 +7,7 @@ pub mod launch;
 pub mod present;
 mod seat;
 
-use std::{
-    fs,
-    io::{self, ErrorKind},
-    os::unix::{fs::PermissionsExt, net::UnixListener},
-    path::PathBuf,
-    thread,
-};
+use std::{fs, io, path::PathBuf, thread};
 
 use nix::sys::{
     signal::{SigSet, SigmaskHow, Signal, sigprocmask},
@@ -46,11 +40,15 @@ fn install_backend_root_bindings(state: &mut ServerState, backend: &dyn Backend)
     }
 }
 
-pub fn run(display: u16) -> io::Result<()> {
+pub fn run(opts: launch::LaunchOptions) -> io::Result<()> {
     #[cfg(not(target_os = "linux"))]
     panic!("yserver only supports Linux (DRM/KMS, libinput, evdev, virtual consoles)");
 
     log::info!("yserver: Phase 6.4 KMS bootstrap — startup (single-threaded core)");
+
+    // Capture the inherited SIGUSR1 disposition before signalfd masking.
+    // If the DM started us with SIGUSR1 ignored, we signal it when ready.
+    let sigusr1_was_ignored = launch::sigusr1_is_ignored();
 
     // Vulkan-call-rate telemetry: emit a per-second snapshot of
     // call counters from `kms::vk::call_stats::VK_CALLS`. Gated on
@@ -233,31 +231,29 @@ pub fn run(display: u16) -> io::Result<()> {
             format!("create_dir_all({}): {e}", socket_dir.display()),
         )
     })?;
-    let socket_path = socket_dir.join(format!("X{display}"));
-    match fs::remove_file(&socket_path) {
-        Ok(()) => {}
-        Err(err) if err.kind() == ErrorKind::NotFound => {}
-        Err(err) => {
-            return Err(io::Error::new(
-                err.kind(),
-                format!("remove_file({}): {err}", socket_path.display()),
-            ));
+    let lock_dir = PathBuf::from("/tmp");
+
+    // Resolve the effective display, acquire the lock (when -displayfd is
+    // absent), and bind the socket. `_lock_guard` is held for the server's
+    // lifetime; it drops at the end of `run()` — after the socket file is
+    // removed at shutdown — so the lock (the authoritative occupancy
+    // marker) outlives the socket. On any error after lock acquisition the
+    // `?` unwinds and drops the guard, releasing the lock.
+    let (display, listener, _lock_guard, socket_path) = match launch::resolve(&opts) {
+        launch::Resolution::Explicit { display, lock } => {
+            let guard = if lock {
+                Some(launch::acquire_lock(&lock_dir, display)?)
+            } else {
+                None
+            };
+            let (listener, socket_path) = launch::bind_explicit(&socket_dir, display)?;
+            (display, listener, guard, socket_path)
         }
-    }
-    let listener = UnixListener::bind(&socket_path).map_err(|e| {
-        io::Error::new(
-            e.kind(),
-            format!("UnixListener::bind({}): {e}", socket_path.display()),
-        )
-    })?;
-    // X clients connect as the invoking user; the socket needs world write
-    // (connect() on AF_UNIX requires `w`). Xorg sets 0777 on /tmp/.X11-unix/X*.
-    fs::set_permissions(&socket_path, fs::Permissions::from_mode(0o777)).map_err(|e| {
-        io::Error::new(
-            e.kind(),
-            format!("set_permissions({}, 0o777): {e}", socket_path.display()),
-        )
-    })?;
+        launch::Resolution::AutoPick => {
+            let (display, listener, socket_path) = launch::autopick(&socket_dir)?;
+            (display, listener, None, socket_path)
+        }
+    };
     log::info!("yserver: listening on unix socket DISPLAY=:{display}");
 
     // Initial composite+flip so the screen has a known frame before any
@@ -347,6 +343,12 @@ pub fn run(display: u16) -> io::Result<()> {
                 }
             }
         })?;
+
+    // Readiness handshake: ServerState is fully constructed, the socket is
+    // bound + chmod'd, and the lock is held — we can complete an initial X
+    // connection setup now. This is the analog of Xorg signaling after
+    // CreateConnectionBlock() and before Dispatch().
+    launch::signal_ready(&opts, display, sigusr1_was_ignored);
 
     let alloc = ClientIdAllocator::new();
     log::info!("yserver: entering single-threaded core loop");

--- a/crates/yserver/src/lib.rs
+++ b/crates/yserver/src/lib.rs
@@ -3,6 +3,7 @@ pub mod drm;
 pub mod input;
 pub mod input_thread;
 pub mod kms;
+pub mod launch;
 pub mod present;
 mod seat;
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -119,6 +119,14 @@ Cross-cutting bugs and followups that don't fit a stage live in
   node, remove the missing-parent reparent fallback, and make Manual
   redirects suppress direct scanout unconditionally. Further
   `cow_authoritative` surgery is no longer the primary path.
+- **2026-06-12 XINERAMA landed in-tree**: yserver now advertises the
+  `XINERAMA` extension and serves all six PanoramiX/Xinerama requests
+  from the same shared monitor list as RANDR `GetMonitors`. That keeps
+  the Xinerama screen count and the RANDR monitor count identical by
+  construction, which is the compatibility invariant needed for
+  dual-head mutter/muffin. Wire encoder unit tests are in
+  `yserver-protocol`; core wiring/build validation is green. Hardware
+  Cinnamon smoke on real dual-head is still the remaining proof gate.
 - **Bugfixing kicked off 2026-05-26 PM** with Cinnamon validation.
   First live issue: clicks inside `cinnamon-settings` were not
   taking effect even though XI2 ButtonPress/Release reached the

--- a/docs/superpowers/plans/2026-06-12-lightdm-launch.md
+++ b/docs/superpowers/plans/2026-06-12-lightdm-launch.md
@@ -482,6 +482,11 @@ pub fn acquire_lock(lock_dir: &Path, display: u16) -> io::Result<LockGuard> {
             .open(&tmp_path)?;
         tmp.write_all(pid_line.as_bytes())?;
     }
+    // Create-time mode is masked by the process umask (a DM/systemd unit
+    // may set e.g. UMask=0077 → 0400, unreadable to foreign launchers —
+    // Xorg's LockServer READS existing locks). Force 0444 umask-immune,
+    // like Xorg's fchmod after create (os/utils.c:312).
+    fs::set_permissions(&tmp_path, fs::Permissions::from_mode(0o444))?;
 
     // At most two attempts: acquire, or reclaim-once-then-acquire.
     for _ in 0..2 {

--- a/docs/superpowers/plans/2026-06-12-lightdm-launch.md
+++ b/docs/superpowers/plans/2026-06-12-lightdm-launch.md
@@ -1,0 +1,1048 @@
+# lightdm Launch (argv + readiness) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make yserver launchable by the lightdm display manager — parse X-server-style argv, hold the `/tmp/.X<N>-lock` display lock, and perform the SIGUSR1 / `-displayfd` readiness handshake so lightdm starts the greeter.
+
+**Architecture:** A new pure-where-possible `launch` module owns argv parsing, the display-resolution table, the X lockfile protocol, socket binding (explicit + auto-pick), and readiness signaling. `yserver::run()` changes from `run(display: u16)` to `run(opts: LaunchOptions)` and calls the module's helpers; the binary becomes a thin shim. Filesystem-touching helpers take directory paths so they unit-test against a tempdir.
+
+**Tech Stack:** Rust, `nix` (signal/signalfd, already used), `libc` (raw `sigaction`/`kill`/`getppid`/`write`/`pipe`), std `UnixListener`/`UnixStream`.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-lightdm-launch-design.md`
+
+**Toolchain (per AGENTS.md):** format with `cargo +nightly fmt`; lint with regular `cargo clippy` (NOT pedantic); test with `cargo test`.
+
+---
+
+## File Structure
+
+- **Create** `crates/yserver/src/launch.rs` — the whole launch subsystem:
+  - `LaunchOptions` + `parse_args` (pure)
+  - `Resolution` + `resolve` (pure — the display-resolution table)
+  - `DEFAULT_DISPLAY` const
+  - `LockGuard` + `acquire_lock` + `lock_path` + `inspect_lock` (lockfile protocol)
+  - `bind_explicit` + `autopick` (socket binding)
+  - `write_displayfd` + `sigusr1_is_ignored` + `signal_ready_to_parent` + `signal_ready` (readiness)
+- **Modify** `crates/yserver/src/lib.rs` — add `pub mod launch;`; change `run` signature; query SIGUSR1 disposition early; replace inline socket bind (228-260) with resolve + lock + bind; signal readiness before `run_core`; remove lock after socket on shutdown / error paths.
+- **Modify** `crates/yserver/src/bin/yserver.rs` — replace `parse_display` with `launch::parse_args`; build `LaunchOptions`; call `run(opts)`.
+
+Each task below produces a self-contained, compiling, tested change.
+
+---
+
+### Task 1: argv parsing + display resolution (pure)
+
+**Files:**
+- Create: `crates/yserver/src/launch.rs`
+- Modify: `crates/yserver/src/lib.rs` (add `pub mod launch;`)
+
+- [ ] **Step 1: Create the module with types, parser, resolver, and failing tests**
+
+Create `crates/yserver/src/launch.rs`:
+
+```rust
+//! X-server-style launch handling: argv parsing, display resolution,
+//! the `/tmp/.X<N>-lock` protocol, socket binding, and the lightdm
+//! readiness handshake. See
+//! `docs/superpowers/specs/2026-06-12-lightdm-launch-design.md`.
+
+use std::os::fd::RawFd;
+use std::path::PathBuf;
+
+/// Display yserver uses when neither an explicit display nor `-displayfd`
+/// is given. 7 avoids clashing with a real Xorg on `:0` (existing
+/// convention).
+pub const DEFAULT_DISPLAY: u16 = 7;
+
+/// Parsed X-server-style command line. Fields the issue's items 1-2 act
+/// on; `vt`/`seat` are parsed + logged but otherwise ignored (logind owns
+/// the seat/VT), `auth_file` is stashed for the deferred item 4.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct LaunchOptions {
+    /// `:N` or bare `N` → explicit display; `None` → resolved in `run()`.
+    pub display: Option<u16>,
+    /// `-displayfd N`.
+    pub displayfd: Option<RawFd>,
+    /// `vtN` — logged, otherwise ignored.
+    pub vt: Option<u32>,
+    /// `-seat NAME` — logged, otherwise ignored.
+    pub seat: Option<String>,
+    /// `-auth FILE` — stashed for item 4, unused now.
+    pub auth_file: Option<PathBuf>,
+}
+
+fn next_value(
+    it: &mut impl Iterator<Item = String>,
+    flag: &str,
+) -> Result<String, String> {
+    it.next().ok_or_else(|| format!("{flag} requires a value"))
+}
+
+/// Parse X-server-style argv. Tolerates unknown flags (warn + skip);
+/// hard-errors only on malformed *explicit* requests and missing values
+/// for known value-taking flags.
+pub fn parse_args(
+    args: impl IntoIterator<Item = String>,
+) -> Result<LaunchOptions, String> {
+    let mut o = LaunchOptions::default();
+    let mut it = args.into_iter();
+    while let Some(arg) = it.next() {
+        if let Some(rest) = arg.strip_prefix(':') {
+            o.display = Some(
+                rest.parse::<u16>()
+                    .map_err(|_| format!("invalid display argument: {arg}"))?,
+            );
+        } else if let Some(rest) = arg.strip_prefix("vt") {
+            o.vt = Some(
+                rest.parse::<u32>()
+                    .map_err(|_| format!("invalid vt argument: {arg}"))?,
+            );
+        } else if arg == "-seat" {
+            o.seat = Some(next_value(&mut it, "-seat")?);
+        } else if arg == "-auth" {
+            o.auth_file = Some(PathBuf::from(next_value(&mut it, "-auth")?));
+        } else if arg == "-displayfd" {
+            let v = next_value(&mut it, "-displayfd")?;
+            o.displayfd = Some(
+                v.parse::<RawFd>()
+                    .map_err(|_| format!("invalid -displayfd argument: {v}"))?,
+            );
+        } else if matches!(
+            arg.as_str(),
+            "-nolisten" | "-config" | "-layout" | "-background"
+        ) {
+            // Known value-taking no-ops. Consume + ignore the value; a
+            // missing value is tolerated (these don't affect us).
+            if it.next().is_none() {
+                log::warn!("yserver: {arg} given without a value; ignoring");
+            }
+        } else if arg == "-novtswitch" {
+            // Known no-arg no-op (lightdm passes it).
+        } else if let Ok(n) = arg.parse::<u16>() {
+            // Bare number → display. Keeps `yserver 7` (Justfile) working.
+            o.display = Some(n);
+        } else {
+            log::warn!("yserver: ignoring unrecognized argument: {arg}");
+        }
+    }
+    Ok(o)
+}
+
+/// How `run()` should obtain the display + whether to take the lock.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Resolution {
+    /// Use this exact display. `lock` is true only when `-displayfd` is
+    /// absent (Xorg sets `nolock = TRUE` whenever `-displayfd` is parsed).
+    Explicit { display: u16, lock: bool },
+    /// Scan for the lowest free display (gdm-style `-displayfd`); no lock.
+    AutoPick,
+}
+
+/// The display-resolution table from the spec. Lock iff `-displayfd` is
+/// absent.
+#[must_use]
+pub fn resolve(opts: &LaunchOptions) -> Resolution {
+    match (opts.display, opts.displayfd) {
+        (Some(display), None) => Resolution::Explicit { display, lock: true },
+        (Some(display), Some(_)) => Resolution::Explicit { display, lock: false },
+        (None, Some(_)) => Resolution::AutoPick,
+        (None, None) => Resolution::Explicit {
+            display: DEFAULT_DISPLAY,
+            lock: true,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(args: &[&str]) -> Result<LaunchOptions, String> {
+        parse_args(args.iter().map(|s| (*s).to_string()))
+    }
+
+    #[test]
+    fn lightdm_default_argv_parses_clean() {
+        let o = parse(&[
+            ":0",
+            "-seat",
+            "seat0",
+            "-auth",
+            "/var/run/lightdm/root/:0",
+            "-nolisten",
+            "tcp",
+            "vt7",
+            "-novtswitch",
+        ])
+        .unwrap();
+        assert_eq!(o.display, Some(0));
+        assert_eq!(o.displayfd, None);
+        assert_eq!(o.vt, Some(7));
+        assert_eq!(o.seat.as_deref(), Some("seat0"));
+        assert_eq!(o.auth_file, Some(PathBuf::from("/var/run/lightdm/root/:0")));
+    }
+
+    #[test]
+    fn gdm_style_displayfd_without_explicit_display() {
+        let o = parse(&["-displayfd", "12"]).unwrap();
+        assert_eq!(o.displayfd, Some(12));
+        assert_eq!(o.display, None);
+    }
+
+    #[test]
+    fn bare_number_is_back_compat_display() {
+        assert_eq!(parse(&["7"]).unwrap().display, Some(7));
+        assert_eq!(parse(&[]).unwrap().display, None);
+    }
+
+    #[test]
+    fn explicit_colon_display() {
+        assert_eq!(parse(&[":42"]).unwrap().display, Some(42));
+    }
+
+    #[test]
+    fn unknown_flags_are_tolerated() {
+        let o = parse(&["-bogus", "--whatever", ":1"]).unwrap();
+        assert_eq!(o.display, Some(1));
+    }
+
+    #[test]
+    fn malformed_explicit_requests_error() {
+        assert!(parse(&[":foo"]).is_err());
+        assert!(parse(&["vtbad"]).is_err());
+        assert!(parse(&["-displayfd", "notanumber"]).is_err());
+    }
+
+    #[test]
+    fn missing_required_value_errors() {
+        assert!(parse(&["-seat"]).is_err());
+        assert!(parse(&["-auth"]).is_err());
+        assert!(parse(&["-displayfd"]).is_err());
+    }
+
+    #[test]
+    fn resolution_table() {
+        let mk = |d: Option<u16>, fd: Option<RawFd>| LaunchOptions {
+            display: d,
+            displayfd: fd,
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve(&mk(Some(0), None)),
+            Resolution::Explicit { display: 0, lock: true }
+        );
+        assert_eq!(
+            resolve(&mk(Some(0), Some(9))),
+            Resolution::Explicit { display: 0, lock: false }
+        );
+        assert_eq!(resolve(&mk(None, Some(9))), Resolution::AutoPick);
+        assert_eq!(
+            resolve(&mk(None, None)),
+            Resolution::Explicit { display: DEFAULT_DISPLAY, lock: true }
+        );
+    }
+}
+```
+
+Add the module declaration to `crates/yserver/src/lib.rs` — in the `pub mod` block near the top (after `pub mod kms;`):
+
+```rust
+pub mod kms;
+pub mod launch;
+pub mod present;
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p yserver --lib launch::tests`
+Expected: compile succeeds, all `launch::tests::*` PASS immediately (this task is pure logic with no separate "stub" phase). If anything FAILS, fix the parser until green.
+
+> Note: because `parse_args`/`resolve` are written together with their tests in one step, "red" here is a compile/logic check rather than a missing-symbol failure. Confirm the suite is green before committing.
+
+- [ ] **Step 3: Format, lint, commit**
+
+Run:
+```bash
+cargo +nightly fmt
+cargo clippy -p yserver --lib
+git add crates/yserver/src/launch.rs crates/yserver/src/lib.rs
+git commit -m "feat(launch): X-style argv parser + display-resolution table"
+```
+Expected: fmt clean, clippy no warnings, commit succeeds.
+
+---
+
+### Task 2: display lockfile protocol
+
+**Files:**
+- Modify: `crates/yserver/src/launch.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the `tests` module in `crates/yserver/src/launch.rs`:
+
+```rust
+    use std::io::Write as _;
+
+    fn unique_tmp_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir()
+            .join(format!("yserver-launch-test-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn lock_fresh_acquire_creates_file() {
+        let dir = unique_tmp_dir("lock-fresh");
+        let guard = acquire_lock(&dir, 5).unwrap();
+        assert!(lock_path(&dir, 5).exists());
+        drop(guard);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn lock_guard_drop_removes_file() {
+        let dir = unique_tmp_dir("lock-drop");
+        let guard = acquire_lock(&dir, 6).unwrap();
+        let p = lock_path(&dir, 6);
+        assert!(p.exists());
+        drop(guard);
+        assert!(!p.exists());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn lock_live_pid_is_rejected() {
+        let dir = unique_tmp_dir("lock-live");
+        // First acquire writes OUR pid into the lock; the second sees a
+        // live owner (us) and must refuse.
+        let _guard = acquire_lock(&dir, 7).unwrap();
+        let err = acquire_lock(&dir, 7).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::AddrInUse);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn lock_stale_pid_is_reclaimed() {
+        let dir = unique_tmp_dir("lock-stale");
+        // A pid far above any real one → kill(pid,0) == ESRCH → stale.
+        std::fs::write(lock_path(&dir, 8), format!("{:>10}\n", 2_147_483_646i32))
+            .unwrap();
+        let guard = acquire_lock(&dir, 8).unwrap();
+        assert!(lock_path(&dir, 8).exists());
+        drop(guard);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn lock_bogus_contents_are_reclaimed() {
+        let dir = unique_tmp_dir("lock-bogus");
+        std::fs::write(lock_path(&dir, 9), b"not a pid").unwrap();
+        let guard = acquire_lock(&dir, 9).unwrap();
+        assert!(lock_path(&dir, 9).exists());
+        drop(guard);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p yserver --lib launch::tests::lock`
+Expected: FAIL to compile — `acquire_lock` / `lock_path` not defined.
+
+- [ ] **Step 3: Implement the lockfile protocol**
+
+Add to the top-of-file `use` block in `crates/yserver/src/launch.rs`:
+
+```rust
+use std::fs::{self, OpenOptions};
+use std::io::{self, ErrorKind, Read, Write};
+use std::os::fd::RawFd;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Path, PathBuf};
+```
+
+(Replace the existing two `use std::os::fd::RawFd;` / `use std::path::PathBuf;` lines with the block above.)
+
+Add the implementation (after `resolve`):
+
+```rust
+/// RAII handle for an acquired display lock. Dropping removes the lock
+/// file. `run()` holds this for the server's lifetime and lets it drop
+/// *after* the socket is removed at shutdown (the lock is the
+/// authoritative occupancy marker, so it must outlive the socket).
+pub struct LockGuard {
+    path: PathBuf,
+}
+
+impl Drop for LockGuard {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+/// `/tmp/.X<N>-lock` path for a display.
+#[must_use]
+pub fn lock_path(lock_dir: &Path, display: u16) -> PathBuf {
+    lock_dir.join(format!(".X{display}-lock"))
+}
+
+enum LockState {
+    Alive,
+    Stale,
+    Bogus,
+}
+
+fn inspect_lock(path: &Path) -> io::Result<LockState> {
+    let mut f = match OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+    {
+        Ok(f) => f,
+        // Vanished between link-failure and open → treat as stale (retry).
+        Err(e) if e.kind() == ErrorKind::NotFound => return Ok(LockState::Stale),
+        Err(e) => return Err(e),
+    };
+    let mut buf = [0u8; 11];
+    let n = f.read(&mut buf).unwrap_or(0);
+    let text = std::str::from_utf8(&buf[..n]).unwrap_or("").trim();
+    let pid: i32 = match text.parse() {
+        Ok(p) if p > 0 => p,
+        _ => return Ok(LockState::Bogus),
+    };
+    // SAFETY: kill with signal 0 only probes existence/permissions.
+    if unsafe { libc::kill(pid, 0) } == 0 {
+        return Ok(LockState::Alive);
+    }
+    match io::Error::last_os_error().raw_os_error() {
+        Some(libc::ESRCH) => Ok(LockState::Stale),
+        // EPERM ⇒ a live process we may not signal (e.g. another user).
+        // Anything else ⇒ be conservative and treat as occupied.
+        _ => Ok(LockState::Alive),
+    }
+}
+
+/// Acquire the `/tmp/.X<N>-lock` display lock using Xorg's temp-file +
+/// atomic `link()` protocol (`os/utils.c`), reclaiming stale/bogus locks.
+/// Errors with `AddrInUse` if a live server owns the display.
+pub fn acquire_lock(lock_dir: &Path, display: u16) -> io::Result<LockGuard> {
+    let final_path = lock_path(lock_dir, display);
+    let tmp_path = lock_dir.join(format!(".tX{display}-lock"));
+    let pid_line = format!("{:>10}\n", std::process::id());
+
+    // At most two attempts: acquire, or reclaim-once-then-acquire.
+    for _ in 0..2 {
+        {
+            let mut tmp = OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .mode(0o444)
+                .open(&tmp_path)?;
+            tmp.write_all(pid_line.as_bytes())?;
+        }
+        match fs::hard_link(&tmp_path, &final_path) {
+            Ok(()) => {
+                let _ = fs::remove_file(&tmp_path);
+                return Ok(LockGuard { path: final_path });
+            }
+            Err(e) if e.kind() == ErrorKind::AlreadyExists => match inspect_lock(&final_path)? {
+                LockState::Stale | LockState::Bogus => {
+                    let _ = fs::remove_file(&final_path);
+                    // loop and retry the link
+                }
+                LockState::Alive => {
+                    let _ = fs::remove_file(&tmp_path);
+                    return Err(io::Error::new(
+                        ErrorKind::AddrInUse,
+                        format!(
+                            "display :{display} already in use (lock {})",
+                            final_path.display()
+                        ),
+                    ));
+                }
+            },
+            Err(e) => {
+                let _ = fs::remove_file(&tmp_path);
+                return Err(e);
+            }
+        }
+    }
+    let _ = fs::remove_file(&tmp_path);
+    Err(io::Error::new(
+        ErrorKind::AddrInUse,
+        format!("could not acquire display lock {}", final_path.display()),
+    ))
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p yserver --lib launch::tests::lock`
+Expected: PASS (5 lock tests).
+
+- [ ] **Step 5: Format, lint, commit**
+
+Run:
+```bash
+cargo +nightly fmt
+cargo clippy -p yserver --lib
+git add crates/yserver/src/launch.rs
+git commit -m "feat(launch): /tmp/.X<N>-lock protocol (temp+link, stale reclaim)"
+```
+Expected: clean, commit succeeds.
+
+---
+
+### Task 3: socket binding (explicit + auto-pick)
+
+**Files:**
+- Modify: `crates/yserver/src/launch.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the `tests` module:
+
+```rust
+    use std::os::unix::net::UnixListener as TestListener;
+
+    #[test]
+    fn bind_explicit_binds_and_chmods() {
+        let dir = unique_tmp_dir("bind-explicit");
+        let (listener, path) = bind_explicit(&dir, 3).unwrap();
+        assert_eq!(path, dir.join("X3"));
+        assert!(path.exists());
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o777);
+        drop(listener);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn autopick_empty_dir_picks_zero() {
+        let dir = unique_tmp_dir("autopick-empty");
+        let (n, listener, path) = autopick(&dir).unwrap();
+        assert_eq!(n, 0);
+        assert_eq!(path, dir.join("X0"));
+        drop(listener);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn autopick_skips_live_socket() {
+        let dir = unique_tmp_dir("autopick-live");
+        // A live listener on X0 — keep it bound for the duration.
+        let live = TestListener::bind(dir.join("X0")).unwrap();
+        let (n, listener, _path) = autopick(&dir).unwrap();
+        assert_eq!(n, 1);
+        drop(listener);
+        drop(live);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn autopick_reclaims_stale_socket() {
+        let dir = unique_tmp_dir("autopick-stale");
+        // Bind then drop: the socket node remains on disk with no
+        // listener (Rust does not unlink on drop) → a faithful stale
+        // socket. connect() → ECONNREFUSED → reclaim.
+        let stale = TestListener::bind(dir.join("X0")).unwrap();
+        drop(stale);
+        assert!(dir.join("X0").exists());
+        let (n, listener, _path) = autopick(&dir).unwrap();
+        assert_eq!(n, 0);
+        drop(listener);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p yserver --lib launch::tests::bind launch::tests::autopick`
+Expected: FAIL to compile — `bind_explicit` / `autopick` not defined.
+
+- [ ] **Step 3: Implement the binding helpers**
+
+Extend the `use` block at the top of `launch.rs` to add the net + permissions imports (merge into the existing `use std::os::unix::...` lines):
+
+```rust
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::os::unix::net::{UnixListener, UnixStream};
+```
+
+Add the implementation (after `acquire_lock`):
+
+```rust
+fn chmod_socket(path: &Path) -> io::Result<()> {
+    // X clients connect as the invoking user; the socket needs world
+    // write (connect() on AF_UNIX requires `w`). Xorg sets 0777.
+    fs::set_permissions(path, fs::Permissions::from_mode(0o777))
+}
+
+/// Bind `<socket_dir>/X<display>`, removing a stale socket file first.
+/// Used for the explicit-`:N` and back-compat-default cases.
+pub fn bind_explicit(
+    socket_dir: &Path,
+    display: u16,
+) -> io::Result<(UnixListener, PathBuf)> {
+    let path = socket_dir.join(format!("X{display}"));
+    match fs::remove_file(&path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == ErrorKind::NotFound => {}
+        Err(e) => return Err(e),
+    }
+    let listener = UnixListener::bind(&path)?;
+    chmod_socket(&path)?;
+    Ok((listener, path))
+}
+
+/// Scan `0..256` for the lowest free display and bind it. Disambiguates an
+/// existing socket file via `connect()`: refused ⇒ stale ⇒ reclaim;
+/// connected ⇒ live ⇒ skip; other error ⇒ occupied ⇒ skip. Retries on a
+/// `bind()` `EADDRINUSE` race. Takes no lock (matches Xorg `nolock`).
+pub fn autopick(socket_dir: &Path) -> io::Result<(u16, UnixListener, PathBuf)> {
+    for n in 0u16..256 {
+        let path = socket_dir.join(format!("X{n}"));
+        if path.exists() {
+            match UnixStream::connect(&path) {
+                Ok(_) => continue, // live server
+                Err(e) if e.kind() == ErrorKind::ConnectionRefused => {
+                    // Stale socket node — reclaim it.
+                    let _ = fs::remove_file(&path);
+                }
+                Err(_) => continue, // occupied/unknown — leave it alone
+            }
+        }
+        match UnixListener::bind(&path) {
+            Ok(listener) => {
+                chmod_socket(&path)?;
+                return Ok((n, listener, path));
+            }
+            Err(e) if e.kind() == ErrorKind::AddrInUse => continue, // lost a race
+            Err(e) => return Err(e),
+        }
+    }
+    Err(io::Error::new(
+        ErrorKind::AddrInUse,
+        "no free X display in 0..256",
+    ))
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p yserver --lib launch::tests::bind launch::tests::autopick`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Format, lint, commit**
+
+Run:
+```bash
+cargo +nightly fmt
+cargo clippy -p yserver --lib
+git add crates/yserver/src/launch.rs
+git commit -m "feat(launch): explicit + auto-pick socket binding"
+```
+Expected: clean, commit succeeds.
+
+---
+
+### Task 4: readiness signaling (`-displayfd` + SIGUSR1-to-parent)
+
+**Files:**
+- Modify: `crates/yserver/src/launch.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the `tests` module:
+
+```rust
+    #[test]
+    fn write_displayfd_writes_ascii_and_closes() {
+        // libc pipe: write end gets the display number, read end verifies.
+        let mut fds = [0 as RawFd; 2];
+        assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
+        let (read_fd, write_fd) = (fds[0], fds[1]);
+
+        write_displayfd(write_fd, 12).unwrap();
+
+        let mut buf = [0u8; 8];
+        let n = unsafe {
+            libc::read(read_fd, buf.as_mut_ptr().cast(), buf.len())
+        };
+        assert!(n > 0);
+        assert_eq!(&buf[..n as usize], b"12\n");
+        unsafe { libc::close(read_fd) };
+    }
+
+    #[test]
+    fn sigusr1_disposition_roundtrip() {
+        // Process-global: set IGN, observe true, restore DFL, observe
+        // false. No other unit test touches SIGUSR1 disposition.
+        unsafe { libc::signal(libc::SIGUSR1, libc::SIG_IGN) };
+        assert!(sigusr1_is_ignored());
+        unsafe { libc::signal(libc::SIGUSR1, libc::SIG_DFL) };
+        assert!(!sigusr1_is_ignored());
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p yserver --lib launch::tests::write_displayfd launch::tests::sigusr1`
+Expected: FAIL to compile — `write_displayfd` / `sigusr1_is_ignored` not defined.
+
+- [ ] **Step 3: Implement the readiness helpers**
+
+Add (after `autopick`):
+
+```rust
+/// Write `"<display>\n"` (Xorg's `-displayfd` format) to `fd`, then close
+/// it. Used only when `-displayfd N` was given.
+pub fn write_displayfd(fd: RawFd, display: u16) -> io::Result<()> {
+    let s = format!("{display}\n");
+    let bytes = s.as_bytes();
+    let mut written = 0usize;
+    while written < bytes.len() {
+        // SAFETY: writing `bytes[written..]` to a caller-owned fd.
+        let r = unsafe {
+            libc::write(
+                fd,
+                bytes[written..].as_ptr().cast(),
+                bytes.len() - written,
+            )
+        };
+        if r < 0 {
+            let err = io::Error::last_os_error();
+            unsafe { libc::close(fd) };
+            return Err(err);
+        }
+        written += r as usize;
+    }
+    unsafe { libc::close(fd) };
+    Ok(())
+}
+
+/// True if SIGUSR1's *inherited disposition* is `SIG_IGN` — the signal
+/// the DM (lightdm/Xorg convention) uses to request "signal me when
+/// ready". Querying via `sigaction(…, NULL, &old)` does not mutate the
+/// disposition; signalfd masking (done later) only blocks delivery, so
+/// the two are independent — call this any time before installing a
+/// `sigaction` handler (yserver never does; it uses signalfd).
+#[must_use]
+pub fn sigusr1_is_ignored() -> bool {
+    // SAFETY: zeroed sigaction is a valid "read current" target.
+    let mut old: libc::sigaction = unsafe { std::mem::zeroed() };
+    let rc = unsafe { libc::sigaction(libc::SIGUSR1, std::ptr::null(), &mut old) };
+    rc == 0 && old.sa_sigaction == libc::SIG_IGN
+}
+
+/// Send SIGUSR1 to the parent (the DM), matching Xorg's `NotifyParentProcess`
+/// (`ParentProcess = getppid()`). Skips PID 1 — if we were reparented to
+/// init there is no DM to notify.
+pub fn signal_ready_to_parent() {
+    let ppid = unsafe { libc::getppid() };
+    if ppid > 1 {
+        unsafe { libc::kill(ppid, libc::SIGUSR1) };
+    }
+}
+
+/// Perform the readiness handshake: report the chosen display on
+/// `-displayfd` (if given) and signal the parent (if SIGUSR1 was inherited
+/// ignored). Call once, just before entering the core loop.
+pub fn signal_ready(opts: &LaunchOptions, display: u16, sigusr1_was_ignored: bool) {
+    if let Some(fd) = opts.displayfd {
+        if let Err(e) = write_displayfd(fd, display) {
+            log::warn!("yserver: failed to write -displayfd {fd}: {e}");
+        }
+    }
+    if sigusr1_was_ignored {
+        log::info!("yserver: signaling readiness to parent (SIGUSR1)");
+        signal_ready_to_parent();
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p yserver --lib launch::tests::write_displayfd launch::tests::sigusr1`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Run the full launch suite, format, lint, commit**
+
+Run:
+```bash
+cargo test -p yserver --lib launch::
+cargo +nightly fmt
+cargo clippy -p yserver --lib
+git add crates/yserver/src/launch.rs
+git commit -m "feat(launch): -displayfd + SIGUSR1-to-parent readiness"
+```
+Expected: all `launch::` tests pass, clean, commit succeeds.
+
+---
+
+### Task 5: wire `launch` into `run()` and the binary
+
+**Files:**
+- Modify: `crates/yserver/src/lib.rs` (signature + bootstrap)
+- Modify: `crates/yserver/src/bin/yserver.rs` (thin shim)
+
+- [ ] **Step 1: Change the `run()` signature and query SIGUSR1 early**
+
+In `crates/yserver/src/lib.rs`, change the signature at line 48:
+
+```rust
+pub fn run(opts: launch::LaunchOptions) -> io::Result<()> {
+```
+
+Immediately after the `log::info!("yserver: Phase 6.4 ...")` line (≈ line 52), capture the inherited SIGUSR1 disposition **before** anything blocks it:
+
+```rust
+    // Capture the inherited SIGUSR1 disposition before signalfd masking.
+    // If the DM started us with SIGUSR1 ignored, we signal it when ready.
+    let sigusr1_was_ignored = launch::sigusr1_is_ignored();
+```
+
+- [ ] **Step 2: Replace the inline socket bind (lib.rs ~228-260) with resolve + lock + bind**
+
+Replace this existing block:
+
+```rust
+    let socket_dir = PathBuf::from("/tmp/.X11-unix");
+    fs::create_dir_all(&socket_dir).map_err(|e| {
+        io::Error::new(
+            e.kind(),
+            format!("create_dir_all({}): {e}", socket_dir.display()),
+        )
+    })?;
+    let socket_path = socket_dir.join(format!("X{display}"));
+    match fs::remove_file(&socket_path) {
+        Ok(()) => {}
+        Err(err) if err.kind() == ErrorKind::NotFound => {}
+        Err(err) => {
+            return Err(io::Error::new(
+                err.kind(),
+                format!("remove_file({}): {err}", socket_path.display()),
+            ));
+        }
+    }
+    let listener = UnixListener::bind(&socket_path).map_err(|e| {
+        io::Error::new(
+            e.kind(),
+            format!("UnixListener::bind({}): {e}", socket_path.display()),
+        )
+    })?;
+    // X clients connect as the invoking user; the socket needs world write
+    // (connect() on AF_UNIX requires `w`). Xorg sets 0777 on /tmp/.X11-unix/X*.
+    fs::set_permissions(&socket_path, fs::Permissions::from_mode(0o777)).map_err(|e| {
+        io::Error::new(
+            e.kind(),
+            format!("set_permissions({}, 0o777): {e}", socket_path.display()),
+        )
+    })?;
+    log::info!("yserver: listening on unix socket DISPLAY=:{display}");
+```
+
+with:
+
+```rust
+    let socket_dir = PathBuf::from("/tmp/.X11-unix");
+    fs::create_dir_all(&socket_dir).map_err(|e| {
+        io::Error::new(
+            e.kind(),
+            format!("create_dir_all({}): {e}", socket_dir.display()),
+        )
+    })?;
+    let lock_dir = PathBuf::from("/tmp");
+
+    // Resolve the effective display, acquire the lock (when -displayfd is
+    // absent), and bind the socket. `_lock_guard` is held for the server's
+    // lifetime; it drops at the end of `run()` — after the socket file is
+    // removed at shutdown — so the lock (the authoritative occupancy
+    // marker) outlives the socket. On any error after lock acquisition the
+    // `?` unwinds and drops the guard, releasing the lock.
+    let (display, listener, _lock_guard, socket_path) = match launch::resolve(&opts) {
+        launch::Resolution::Explicit { display, lock } => {
+            let guard = if lock {
+                Some(launch::acquire_lock(&lock_dir, display)?)
+            } else {
+                None
+            };
+            let (listener, socket_path) = launch::bind_explicit(&socket_dir, display)?;
+            (display, listener, guard, socket_path)
+        }
+        launch::Resolution::AutoPick => {
+            let (display, listener, socket_path) = launch::autopick(&socket_dir)?;
+            (display, listener, None, socket_path)
+        }
+    };
+    log::info!("yserver: listening on unix socket DISPLAY=:{display}");
+```
+
+> Note: this removes the only uses of the bare `UnixListener` import in `lib.rs`. After editing, if `cargo clippy` flags `unused_import` for `std::os::unix::net::UnixListener` or `std::os::unix::fs::PermissionsExt`, remove them from the top-of-file `use` block (Step 6 lint will catch this).
+
+- [ ] **Step 3: Signal readiness just before entering the core loop**
+
+In `lib.rs`, immediately before the `let result = core_loop::run_core(` line (≈ 352), insert:
+
+```rust
+    // Readiness handshake: ServerState is fully constructed, the socket is
+    // bound + chmod'd, and the lock is held — we can complete an initial X
+    // connection setup now. This is the analog of Xorg signaling after
+    // CreateConnectionBlock() and before Dispatch().
+    launch::signal_ready(&opts, display, sigusr1_was_ignored);
+
+```
+
+- [ ] **Step 4: Update the binary shim**
+
+Replace the entire contents of `crates/yserver/src/bin/yserver.rs` with:
+
+```rust
+use std::{env, process::ExitCode};
+
+fn main() -> ExitCode {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    let opts = match yserver::launch::parse_args(env::args().skip(1)) {
+        Ok(o) => o,
+        Err(err) => {
+            eprintln!("yserver: {err}");
+            eprintln!(
+                "usage: yserver [:N | N] [vtN] [-seat NAME] [-auth FILE] \
+                 [-displayfd N] [-nolisten PROTO] [-novtswitch]"
+            );
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match yserver::run(opts) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            log::error!("yserver: {err}");
+            ExitCode::FAILURE
+        }
+    }
+}
+```
+
+> The old `parse_display` + its `#[cfg(test)] mod tests` are deleted — that logic and its coverage now live in `launch.rs`.
+
+- [ ] **Step 5: Build and run the whole crate test suite**
+
+Run: `cargo test -p yserver --lib`
+Expected: PASS, including all `launch::tests::*`. Build must succeed with the new `run(LaunchOptions)` signature and the binary shim.
+
+- [ ] **Step 6: Format, lint, commit**
+
+Run:
+```bash
+cargo +nightly fmt
+cargo clippy -p yserver
+```
+Expected: no warnings. If clippy reports unused `UnixListener` / `PermissionsExt` imports in `lib.rs`, remove them, then re-run clippy.
+
+```bash
+git add crates/yserver/src/lib.rs crates/yserver/src/bin/yserver.rs
+git commit -m "feat(launch): drive run() from LaunchOptions (lock, bind, readiness)"
+```
+Expected: commit succeeds.
+
+- [ ] **Step 7: Full workspace verification**
+
+Run:
+```bash
+cargo build --release --bin yserver
+cargo test
+cargo clippy
+```
+Expected: release binary builds; full test suite green; clippy clean. Fix anything red before proceeding.
+
+---
+
+### Task 6: hardware smoke under lightdm (manual gate — required before merge)
+
+Per repo practice, startup/KMS-touching changes are not committed-as-done until observed on hardware. The unit tests cannot exercise SIGUSR1-to-parent, the real lockfile interop, or first light. This task is a manual checklist run on a HW machine with a GPU (e.g. silence or bee), from a TTY — **not** automated.
+
+**Files:**
+- Create: `/etc/lightdm/lightdm.conf.d/99-yserver.conf` (on the test machine; not committed)
+- Create: a logging wrapper at `tools/yserver-lightdm.sh` (committed)
+
+- [ ] **Step 1: Add a logging wrapper so lightdm's server has capturable logs**
+
+Create `tools/yserver-lightdm.sh`:
+
+```bash
+#!/usr/bin/env bash
+# lightdm launches this as its X server. lightdm appends X-style argv
+# (:N -seat … -auth … -nolisten tcp vtN -novtswitch); yserver parses it
+# natively. We only add logging here.
+exec env RUST_LOG="${YSERVER_LOG:-info}" RUST_BACKTRACE=1 \
+    /usr/local/bin/yserver "$@" 2>>/var/log/yserver-lightdm.log
+```
+
+Make it executable:
+```bash
+chmod +x tools/yserver-lightdm.sh
+```
+
+- [ ] **Step 2: Install the binary and point lightdm at it (on the HW machine)**
+
+```bash
+sudo install -m755 target/release/yserver /usr/local/bin/yserver
+sudo install -m755 tools/yserver-lightdm.sh /usr/local/bin/yserver-lightdm
+sudo mkdir -p /etc/lightdm/lightdm.conf.d
+printf '[Seat:*]\nxserver-command=/usr/local/bin/yserver-lightdm\n' \
+    | sudo tee /etc/lightdm/lightdm.conf.d/99-yserver.conf
+```
+
+- [ ] **Step 3: Restart lightdm from a TTY and observe**
+
+From a text VT (Ctrl-Alt-F3), with no X running:
+```bash
+sudo systemctl restart lightdm
+```
+Expected, in order:
+- `journalctl -u lightdm -b` shows lightdm starting the server and **not** timing out waiting for the ready signal ("Waiting for ready signal from X server" is followed by progress, not a timeout/respawn loop).
+- `/var/log/yserver-lightdm.log` shows yserver parsing the argv, "listening on unix socket DISPLAY=:0", and "signaling readiness to parent (SIGUSR1)".
+- `/tmp/.X0-lock` exists and contains yserver's PID while running.
+- The **lightdm GTK greeter appears** on screen (this is the acceptance gate).
+
+- [ ] **Step 4: Verify the restart loop leaves no leaked lock/socket**
+
+Log in (or cancel) so lightdm cycles the server, then:
+```bash
+ls -l /tmp/.X0-lock /tmp/.X11-unix/X0   # after a clean server exit: both gone
+```
+Expected: on clean shutdown the socket is removed first, then the lock — neither lingers to block the next generation. (Leaked DRM/input state across generations is out of scope — item 5.)
+
+- [ ] **Step 5: Commit the wrapper (only the committed file)**
+
+```bash
+git add tools/yserver-lightdm.sh
+git commit -m "chore: lightdm logging wrapper for yserver xserver-command"
+```
+
+- [ ] **Step 6: Record the HW result**
+
+Note the machine, date, and outcome (greeter shown? lock created? clean cycle?) in the PR description. If first light fails, capture `/var/log/yserver-lightdm.log` + `journalctl -u lightdm -b` and debug before merge — do not mark the chunk done on green unit tests alone.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Item 1 (argv) → Task 1 (`parse_args`, all documented tokens + tolerance/error rules).
+- Display resolution table → Task 1 (`resolve`, all four rows tested).
+- Display auto-selection + stale/live/race handling → Task 3 (`autopick`).
+- Lockfile protocol (temp+link, O_NOFOLLOW, stale/bogus reclaim, EPERM=alive, error-path release, socket-then-lock ordering) → Task 2 (`acquire_lock`/`inspect_lock`/`LockGuard`) + Task 5 Step 2 (guard lifetime/ordering).
+- Item 2 readiness (`-displayfd` format, SIGUSR1 disposition query, kill(getppid)) → Task 4; timing (before core loop) → Task 5 Step 3.
+- `run()` signature change + thin shim → Task 5 Steps 1/4.
+- First light (unauthenticated; tolerate presented cookie) → already true in existing code (spec Key facts); verified by Task 6 Step 3.
+- HW smoke gate → Task 6.
+
+**Placeholder scan:** none — every code step shows complete code; every command shows expected output.
+
+**Type consistency:** `LaunchOptions`, `Resolution`, `LockGuard`, `acquire_lock`, `lock_path`, `bind_explicit`, `autopick`, `write_displayfd`, `sigusr1_is_ignored`, `signal_ready_to_parent`, `signal_ready`, `DEFAULT_DISPLAY`, `resolve` are used with identical names/signatures across Tasks 1-5. `run(opts: launch::LaunchOptions)` is consistent between `lib.rs` (Task 5 Step 1) and the binary (Task 5 Step 4).

--- a/docs/superpowers/plans/2026-06-12-lightdm-launch.md
+++ b/docs/superpowers/plans/2026-06-12-lightdm-launch.md
@@ -344,6 +344,18 @@ Append to the `tests` module in `crates/yserver/src/launch.rs`:
         drop(guard);
         std::fs::remove_dir_all(&dir).ok();
     }
+
+    #[test]
+    fn lock_short_numeric_contents_are_bogus() {
+        // Xorg reads exactly 11 bytes ("%10d\n"); a short numeric file is
+        // not a valid lock and must be reclaimed, not trusted.
+        let dir = unique_tmp_dir("lock-short");
+        std::fs::write(lock_path(&dir, 10), b"123\n").unwrap();
+        let guard = acquire_lock(&dir, 10).unwrap();
+        assert!(lock_path(&dir, 10).exists());
+        drop(guard);
+        std::fs::remove_dir_all(&dir).ok();
+    }
 ```
 
 - [ ] **Step 2: Run tests to verify they fail**
@@ -405,9 +417,16 @@ fn inspect_lock(path: &Path) -> io::Result<LockState> {
         Err(e) if e.kind() == ErrorKind::NotFound => return Ok(LockState::Stale),
         Err(e) => return Err(e),
     };
-    let mut buf = [0u8; 11];
-    let n = f.read(&mut buf).unwrap_or(0);
-    let text = std::str::from_utf8(&buf[..n]).unwrap_or("").trim();
+    // Xorg's lock format is exactly "%10d\n" = 11 bytes. Read into a
+    // 12-byte buffer so an over-long file is detectable (n == 12). A
+    // genuine I/O error propagates — never classify an unreadable lock
+    // as bogus (that would delete a lock we couldn't actually inspect).
+    let mut buf = [0u8; 12];
+    let n = f.read(&mut buf)?;
+    if n != 11 || buf[10] != b'\n' {
+        return Ok(LockState::Bogus);
+    }
+    let text = std::str::from_utf8(&buf[..11]).unwrap_or("").trim();
     let pid: i32 = match text.parse() {
         Ok(p) if p > 0 => p,
         _ => return Ok(LockState::Bogus),
@@ -429,7 +448,14 @@ fn inspect_lock(path: &Path) -> io::Result<LockState> {
 /// Errors with `AddrInUse` if a live server owns the display.
 pub fn acquire_lock(lock_dir: &Path, display: u16) -> io::Result<LockGuard> {
     let final_path = lock_path(lock_dir, display);
-    let tmp_path = lock_dir.join(format!(".tX{display}-lock"));
+    // PID-suffixed temp name: each starter owns a unique temp file, so two
+    // concurrent starters can never clobber each other's temp before the
+    // atomic link() (a fixed name would let the winner link a file holding
+    // the LOSER's pid, corrupting later stale/live detection). Deviation
+    // from Xorg's fixed ".tX<N>-lock": race-free without Xorg's
+    // O_EXCL+retry dance; a crash can orphan one 11-byte temp file, which
+    // is harmless (nothing inspects temp names).
+    let tmp_path = lock_dir.join(format!(".tX{display}-lock.{}", std::process::id()));
     let pid_line = format!("{:>10}\n", std::process::id());
 
     // At most two attempts: acquire, or reclaim-once-then-acquire.
@@ -556,6 +582,61 @@ Append to the `tests` module:
         drop(listener);
         std::fs::remove_dir_all(&dir).ok();
     }
+
+    #[test]
+    fn autopick_skips_non_socket_file() {
+        // A regular file named X0: connect() fails with something other
+        // than ECONNREFUSED (ENOTSOCK) → "occupied/unknown" → skip, do
+        // NOT delete.
+        let dir = unique_tmp_dir("autopick-notsock");
+        std::fs::write(dir.join("X0"), b"junk").unwrap();
+        let (n, listener, _path) = autopick(&dir).unwrap();
+        assert_eq!(n, 1);
+        assert!(dir.join("X0").exists()); // untouched
+        drop(listener);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn bind_explicit_refuses_live_socket() {
+        // Explicit bind must never steal a live server's socket — probe
+        // first, error AddrInUse if something is listening.
+        let dir = unique_tmp_dir("bind-live");
+        let live = TestListener::bind(dir.join("X4")).unwrap();
+        let err = bind_explicit(&dir, 4).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::AddrInUse);
+        drop(live);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn bind_explicit_reclaims_stale_socket() {
+        let dir = unique_tmp_dir("bind-stale");
+        let stale = TestListener::bind(dir.join("X5")).unwrap();
+        drop(stale);
+        assert!(dir.join("X5").exists());
+        let (listener, path) = bind_explicit(&dir, 5).unwrap();
+        assert_eq!(path, dir.join("X5"));
+        drop(listener);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn lock_released_when_bind_fails() {
+        // Mimics run()'s error path: `?` after acquire_lock drops the
+        // guard, which must remove the lock — never leave a lock we
+        // don't back with a live socket.
+        let dir = unique_tmp_dir("lock-bind-fail");
+        let res: std::io::Result<()> = (|| {
+            let _guard = acquire_lock(&dir, 11)?;
+            let missing = dir.join("no-such-subdir");
+            let _ = bind_explicit(&missing, 11)?; // fails: dir doesn't exist
+            Ok(())
+        })();
+        assert!(res.is_err());
+        assert!(!lock_path(&dir, 11).exists());
+        std::fs::remove_dir_all(&dir).ok();
+    }
 ```
 
 - [ ] **Step 2: Run tests to verify they fail**
@@ -581,17 +662,37 @@ fn chmod_socket(path: &Path) -> io::Result<()> {
     fs::set_permissions(path, fs::Permissions::from_mode(0o777))
 }
 
-/// Bind `<socket_dir>/X<display>`, removing a stale socket file first.
-/// Used for the explicit-`:N` and back-compat-default cases.
+/// Bind `<socket_dir>/X<display>` for the explicit-`:N` and
+/// back-compat-default cases. Probes an existing socket before removing
+/// it: a live server's socket is NEVER stolen (old yservers take no
+/// lock, so holding the lock alone doesn't prove the display is free).
 pub fn bind_explicit(
     socket_dir: &Path,
     display: u16,
 ) -> io::Result<(UnixListener, PathBuf)> {
     let path = socket_dir.join(format!("X{display}"));
-    match fs::remove_file(&path) {
-        Ok(()) => {}
-        Err(e) if e.kind() == ErrorKind::NotFound => {}
-        Err(e) => return Err(e),
+    if path.exists() {
+        match UnixStream::connect(&path) {
+            Ok(_) => {
+                return Err(io::Error::new(
+                    ErrorKind::AddrInUse,
+                    format!("display :{display} in use (live socket {})", path.display()),
+                ));
+            }
+            Err(e) if e.kind() == ErrorKind::ConnectionRefused => {
+                // Stale node from a dead server — reclaim it.
+                let _ = fs::remove_file(&path);
+            }
+            Err(_) => {
+                // Occupied/unknown (e.g. ENOTSOCK, EACCES). Be
+                // conservative: refuse rather than delete what we can't
+                // identify.
+                return Err(io::Error::new(
+                    ErrorKind::AddrInUse,
+                    format!("cannot probe {} — refusing to replace it", path.display()),
+                ));
+            }
+        }
     }
     let listener = UnixListener::bind(&path)?;
     chmod_socket(&path)?;
@@ -679,12 +780,15 @@ Append to the `tests` module:
 
     #[test]
     fn sigusr1_disposition_roundtrip() {
-        // Process-global: set IGN, observe true, restore DFL, observe
-        // false. No other unit test touches SIGUSR1 disposition.
-        unsafe { libc::signal(libc::SIGUSR1, libc::SIG_IGN) };
+        // Process-global: save the prior disposition and restore it at
+        // the end (SIG_DFL is not necessarily what we started with). No
+        // other unit test in this crate touches SIGUSR1 disposition —
+        // keep it that way (tests share one process).
+        let prev = unsafe { libc::signal(libc::SIGUSR1, libc::SIG_IGN) };
         assert!(sigusr1_is_ignored());
         unsafe { libc::signal(libc::SIGUSR1, libc::SIG_DFL) };
         assert!(!sigusr1_is_ignored());
+        unsafe { libc::signal(libc::SIGUSR1, prev) };
     }
 ```
 
@@ -699,7 +803,9 @@ Add (after `autopick`):
 
 ```rust
 /// Write `"<display>\n"` (Xorg's `-displayfd` format) to `fd`, then close
-/// it. Used only when `-displayfd N` was given.
+/// it. Used only when `-displayfd N` was given. Close errors are ignored:
+/// the fd is single-use and there is nothing actionable after the payload
+/// was written.
 pub fn write_displayfd(fd: RawFd, display: u16) -> io::Result<()> {
     let s = format!("{display}\n");
     let bytes = s.as_bytes();
@@ -717,6 +823,14 @@ pub fn write_displayfd(fd: RawFd, display: u16) -> io::Result<()> {
             let err = io::Error::last_os_error();
             unsafe { libc::close(fd) };
             return Err(err);
+        }
+        if r == 0 {
+            // A zero-length write would loop forever — fail instead.
+            unsafe { libc::close(fd) };
+            return Err(io::Error::new(
+                ErrorKind::WriteZero,
+                "displayfd write returned 0",
+            ));
         }
         written += r as usize;
     }
@@ -883,6 +997,12 @@ with:
 
 > Note: this removes the only uses of the bare `UnixListener` import in `lib.rs`. After editing, if `cargo clippy` flags `unused_import` for `std::os::unix::net::UnixListener` or `std::os::unix::fs::PermissionsExt`, remove them from the top-of-file `use` block (Step 6 lint will catch this).
 
+> Behavior change vs. today: the old inline code unconditionally removed
+> `X{display}` before binding; `bind_explicit` probes first and refuses a
+> live socket with `AddrInUse`. Intentional — never steal a running
+> server's display. A genuinely stale socket (crashed server) still
+> reclaims exactly as before (`ECONNREFUSED` → remove).
+
 - [ ] **Step 3: Signal readiness just before entering the core loop**
 
 In `lib.rs`, immediately before the `let result = core_loop::run_core(` line (≈ 352), insert:
@@ -1036,8 +1156,8 @@ Note the machine, date, and outcome (greeter shown? lock created? clean cycle?) 
 **Spec coverage:**
 - Item 1 (argv) → Task 1 (`parse_args`, all documented tokens + tolerance/error rules).
 - Display resolution table → Task 1 (`resolve`, all four rows tested).
-- Display auto-selection + stale/live/race handling → Task 3 (`autopick`).
-- Lockfile protocol (temp+link, O_NOFOLLOW, stale/bogus reclaim, EPERM=alive, error-path release, socket-then-lock ordering) → Task 2 (`acquire_lock`/`inspect_lock`/`LockGuard`) + Task 5 Step 2 (guard lifetime/ordering).
+- Display auto-selection + stale/live/non-socket handling → Task 3 (`autopick`); the `EADDRINUSE` bind-race `continue` branch is straight-line code that cannot be hit deterministically in a unit test — verified by inspection.
+- Lockfile protocol (PID-suffixed temp + atomic link, O_NOFOLLOW, strict 11-byte format, stale/bogus reclaim, EPERM=alive, error-path release tested in `lock_released_when_bind_fails`, socket-then-lock ordering by code structure + HW smoke Task 6 Step 4) → Task 2 (`acquire_lock`/`inspect_lock`/`LockGuard`) + Task 3 + Task 5 Step 2 (guard lifetime/ordering).
 - Item 2 readiness (`-displayfd` format, SIGUSR1 disposition query, kill(getppid)) → Task 4; timing (before core loop) → Task 5 Step 3.
 - `run()` signature change + thin shim → Task 5 Steps 1/4.
 - First light (unauthenticated; tolerate presented cookie) → already true in existing code (spec Key facts); verified by Task 6 Step 3.

--- a/docs/superpowers/plans/2026-06-12-lightdm-launch.md
+++ b/docs/superpowers/plans/2026-06-12-lightdm-launch.md
@@ -294,9 +294,14 @@ Append to the `tests` module in `crates/yserver/src/launch.rs`:
 
     #[test]
     fn lock_fresh_acquire_creates_file() {
+        use std::os::unix::fs::PermissionsExt;
         let dir = unique_tmp_dir("lock-fresh");
         let guard = acquire_lock(&dir, 5).unwrap();
-        assert!(lock_path(&dir, 5).exists());
+        let p = lock_path(&dir, 5);
+        assert!(p.exists());
+        // Xorg publishes the lock read-only (0444).
+        let mode = std::fs::metadata(&p).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o444);
         drop(guard);
         std::fs::remove_dir_all(&dir).ok();
     }
@@ -461,17 +466,25 @@ pub fn acquire_lock(lock_dir: &Path, display: u16) -> io::Result<LockGuard> {
     let tmp_path = lock_dir.join(format!(".tX{display}-lock.{}", std::process::id()));
     let pid_line = format!("{:>10}\n", std::process::id());
 
+    // Create the temp ONCE, outside the retry loop: its content never
+    // changes between attempts, and a 0444 file cannot be re-opened for
+    // write on a second iteration (mode applies at create time; reopening
+    // a read-only file for write is EACCES). The pre-unlink handles a
+    // stale 0444 temp left by a crashed earlier server that had our
+    // (reused) PID.
+    let _ = fs::remove_file(&tmp_path);
+    {
+        let mut tmp = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o444)
+            .open(&tmp_path)?;
+        tmp.write_all(pid_line.as_bytes())?;
+    }
+
     // At most two attempts: acquire, or reclaim-once-then-acquire.
     for _ in 0..2 {
-        {
-            let mut tmp = OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .mode(0o444)
-                .open(&tmp_path)?;
-            tmp.write_all(pid_line.as_bytes())?;
-        }
         match fs::hard_link(&tmp_path, &final_path) {
             Ok(()) => {
                 let _ = fs::remove_file(&tmp_path);

--- a/docs/superpowers/plans/2026-06-12-lightdm-launch.md
+++ b/docs/superpowers/plans/2026-06-12-lightdm-launch.md
@@ -371,7 +371,7 @@ Add to the top-of-file `use` block in `crates/yserver/src/launch.rs`:
 use std::fs::{self, OpenOptions};
 use std::io::{self, ErrorKind, Read, Write};
 use std::os::fd::RawFd;
-use std::os::unix::fs::OpenOptionsExt;
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 use std::path::{Path, PathBuf};
 ```
 
@@ -407,7 +407,7 @@ enum LockState {
 }
 
 fn inspect_lock(path: &Path) -> io::Result<LockState> {
-    let mut f = match OpenOptions::new()
+    let f = match OpenOptions::new()
         .read(true)
         .custom_flags(libc::O_NOFOLLOW)
         .open(path)
@@ -417,13 +417,16 @@ fn inspect_lock(path: &Path) -> io::Result<LockState> {
         Err(e) if e.kind() == ErrorKind::NotFound => return Ok(LockState::Stale),
         Err(e) => return Err(e),
     };
-    // Xorg's lock format is exactly "%10d\n" = 11 bytes. Read into a
-    // 12-byte buffer so an over-long file is detectable (n == 12). A
-    // genuine I/O error propagates — never classify an unreadable lock
-    // as bogus (that would delete a lock we couldn't actually inspect).
-    let mut buf = [0u8; 12];
-    let n = f.read(&mut buf)?;
-    if n != 11 || buf[10] != b'\n' {
+    // Xorg's lock format is exactly "%10d\n" = 11 bytes. read_to_end
+    // (capped at 12 via `take`) loops over short reads — a single
+    // read() may legally return fewer bytes; this is lock-DELETION
+    // logic, so don't risk it. The 12th byte makes an over-long file
+    // detectable (len == 12 ⇒ bogus). A genuine I/O error propagates —
+    // never classify an unreadable lock as bogus (that would delete a
+    // lock we couldn't actually inspect).
+    let mut buf = Vec::with_capacity(12);
+    f.take(12).read_to_end(&mut buf)?;
+    if buf.len() != 11 || buf[10] != b'\n' {
         return Ok(LockState::Bogus);
     }
     let text = std::str::from_utf8(&buf[..11]).unwrap_or("").trim();
@@ -474,22 +477,44 @@ pub fn acquire_lock(lock_dir: &Path, display: u16) -> io::Result<LockGuard> {
                 let _ = fs::remove_file(&tmp_path);
                 return Ok(LockGuard { path: final_path });
             }
-            Err(e) if e.kind() == ErrorKind::AlreadyExists => match inspect_lock(&final_path)? {
-                LockState::Stale | LockState::Bogus => {
-                    let _ = fs::remove_file(&final_path);
-                    // loop and retry the link
+            Err(e) if e.kind() == ErrorKind::AlreadyExists => {
+                // Identity-bracketed reclaim: note the lock's (dev, ino)
+                // before inspecting, and only unlink if the path still
+                // names that same inode afterwards. Narrows the race
+                // where a concurrent starter reclaims the stale lock and
+                // links its own fresh one between our inspect and our
+                // unlink. Xorg has the full-width version of this race
+                // (LockServer: read → kill(pid,0) → unlink, no identity
+                // check); Linux has no unlink-by-fd, so a tiny
+                // lstat→unlink window remains — and same-display
+                // concurrent starts are DM-serialized in practice.
+                let seen = fs::symlink_metadata(&final_path)
+                    .ok()
+                    .map(|m| (m.dev(), m.ino()));
+                match inspect_lock(&final_path)? {
+                    LockState::Stale | LockState::Bogus => {
+                        let now = fs::symlink_metadata(&final_path)
+                            .ok()
+                            .map(|m| (m.dev(), m.ino()));
+                        if seen.is_some() && now == seen {
+                            let _ = fs::remove_file(&final_path);
+                        }
+                        // else: replaced under us — the retry link will
+                        // hit EEXIST again and inspect the NEW lock
+                        // (typically Alive → AddrInUse).
+                    }
+                    LockState::Alive => {
+                        let _ = fs::remove_file(&tmp_path);
+                        return Err(io::Error::new(
+                            ErrorKind::AddrInUse,
+                            format!(
+                                "display :{display} already in use (lock {})",
+                                final_path.display()
+                            ),
+                        ));
+                    }
                 }
-                LockState::Alive => {
-                    let _ = fs::remove_file(&tmp_path);
-                    return Err(io::Error::new(
-                        ErrorKind::AddrInUse,
-                        format!(
-                            "display :{display} already in use (lock {})",
-                            final_path.display()
-                        ),
-                    ));
-                }
-            },
+            }
             Err(e) => {
                 let _ = fs::remove_file(&tmp_path);
                 return Err(e);
@@ -507,7 +532,7 @@ pub fn acquire_lock(lock_dir: &Path, display: u16) -> io::Result<LockGuard> {
 - [ ] **Step 4: Run tests to verify they pass**
 
 Run: `cargo test -p yserver --lib launch::tests::lock`
-Expected: PASS (5 lock tests).
+Expected: PASS (6 lock tests: fresh, drop, live, stale, bogus, short-numeric).
 
 - [ ] **Step 5: Format, lint, commit**
 
@@ -585,15 +610,26 @@ Append to the `tests` module:
 
     #[test]
     fn autopick_skips_non_socket_file() {
-        // A regular file named X0: connect() fails with something other
-        // than ECONNREFUSED (ENOTSOCK) → "occupied/unknown" → skip, do
-        // NOT delete.
+        // A regular file named X0: the file-type check skips it without
+        // deleting. (connect() to a non-socket gives ECONNREFUSED on
+        // Linux — same errno as a stale socket — so the type check, not
+        // errno, is what protects the file.)
         let dir = unique_tmp_dir("autopick-notsock");
         std::fs::write(dir.join("X0"), b"junk").unwrap();
         let (n, listener, _path) = autopick(&dir).unwrap();
         assert_eq!(n, 1);
         assert!(dir.join("X0").exists()); // untouched
         drop(listener);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn bind_explicit_refuses_non_socket_file() {
+        let dir = unique_tmp_dir("bind-notsock");
+        std::fs::write(dir.join("X6"), b"junk").unwrap();
+        let err = bind_explicit(&dir, 6).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::AddrInUse);
+        assert!(dir.join("X6").exists()); // untouched
         std::fs::remove_dir_all(&dir).ok();
     }
 
@@ -641,7 +677,7 @@ Append to the `tests` module:
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `cargo test -p yserver --lib launch::tests::bind launch::tests::autopick`
+Run: `cargo test -p yserver --lib launch::tests`
 Expected: FAIL to compile — `bind_explicit` / `autopick` not defined.
 
 - [ ] **Step 3: Implement the binding helpers**
@@ -649,7 +685,7 @@ Expected: FAIL to compile — `bind_explicit` / `autopick` not defined.
 Extend the `use` block at the top of `launch.rs` to add the net + permissions imports (merge into the existing `use std::os::unix::...` lines):
 
 ```rust
-use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::os::unix::fs::{FileTypeExt, MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::os::unix::net::{UnixListener, UnixStream};
 ```
 
@@ -671,7 +707,21 @@ pub fn bind_explicit(
     display: u16,
 ) -> io::Result<(UnixListener, PathBuf)> {
     let path = socket_dir.join(format!("X{display}"));
-    if path.exists() {
+    // File-type check FIRST: connect(AF_UNIX) to a non-socket inode
+    // returns ECONNREFUSED on Linux (same errno as a stale socket!), so
+    // errno alone cannot distinguish "dead server's socket" from "some
+    // file that happens to be named X<n>". Never delete a non-socket.
+    // symlink_metadata also refuses symlinks (is_socket() is false).
+    if let Ok(meta) = fs::symlink_metadata(&path) {
+        if !meta.file_type().is_socket() {
+            return Err(io::Error::new(
+                ErrorKind::AddrInUse,
+                format!(
+                    "{} exists and is not a socket — refusing to replace it",
+                    path.display()
+                ),
+            ));
+        }
         match UnixStream::connect(&path) {
             Ok(_) => {
                 return Err(io::Error::new(
@@ -680,13 +730,12 @@ pub fn bind_explicit(
                 ));
             }
             Err(e) if e.kind() == ErrorKind::ConnectionRefused => {
-                // Stale node from a dead server — reclaim it.
+                // Stale socket from a dead server — reclaim it.
                 let _ = fs::remove_file(&path);
             }
             Err(_) => {
-                // Occupied/unknown (e.g. ENOTSOCK, EACCES). Be
-                // conservative: refuse rather than delete what we can't
-                // identify.
+                // Occupied/unknown (e.g. EACCES). Be conservative:
+                // refuse rather than delete what we can't identify.
                 return Err(io::Error::new(
                     ErrorKind::AddrInUse,
                     format!("cannot probe {} — refusing to replace it", path.display()),
@@ -706,15 +755,21 @@ pub fn bind_explicit(
 pub fn autopick(socket_dir: &Path) -> io::Result<(u16, UnixListener, PathBuf)> {
     for n in 0u16..256 {
         let path = socket_dir.join(format!("X{n}"));
-        if path.exists() {
-            match UnixStream::connect(&path) {
+        // Same file-type-first rule as bind_explicit: ECONNREFUSED can't
+        // distinguish a stale socket from a non-socket file, and we must
+        // never delete the latter. Non-socket / unreadable ⇒ skip.
+        match fs::symlink_metadata(&path) {
+            Ok(meta) if !meta.file_type().is_socket() => continue,
+            Ok(_) => match UnixStream::connect(&path) {
                 Ok(_) => continue, // live server
                 Err(e) if e.kind() == ErrorKind::ConnectionRefused => {
                     // Stale socket node — reclaim it.
                     let _ = fs::remove_file(&path);
                 }
                 Err(_) => continue, // occupied/unknown — leave it alone
-            }
+            },
+            Err(e) if e.kind() == ErrorKind::NotFound => {} // free — bind below
+            Err(_) => continue, // unreadable — not ours to touch
         }
         match UnixListener::bind(&path) {
             Ok(listener) => {
@@ -734,8 +789,8 @@ pub fn autopick(socket_dir: &Path) -> io::Result<(u16, UnixListener, PathBuf)> {
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `cargo test -p yserver --lib launch::tests::bind launch::tests::autopick`
-Expected: PASS (4 tests).
+Run: `cargo test -p yserver --lib launch::tests`
+Expected: PASS — all `launch::tests` green, including the 9 added in this task (explicit bind ×4, autopick ×4, lock-release-on-bind-failure).
 
 - [ ] **Step 5: Format, lint, commit**
 
@@ -794,7 +849,7 @@ Append to the `tests` module:
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `cargo test -p yserver --lib launch::tests::write_displayfd launch::tests::sigusr1`
+Run: `cargo test -p yserver --lib launch::tests`
 Expected: FAIL to compile — `write_displayfd` / `sigusr1_is_ignored` not defined.
 
 - [ ] **Step 3: Implement the readiness helpers**
@@ -880,14 +935,14 @@ pub fn signal_ready(opts: &LaunchOptions, display: u16, sigusr1_was_ignored: boo
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `cargo test -p yserver --lib launch::tests::write_displayfd launch::tests::sigusr1`
-Expected: PASS (2 tests).
+Run: `cargo test -p yserver --lib launch::tests`
+Expected: PASS — all `launch::tests` green, including the 2 added in this task (displayfd pipe, SIGUSR1 disposition).
 
 - [ ] **Step 5: Run the full launch suite, format, lint, commit**
 
 Run:
 ```bash
-cargo test -p yserver --lib launch::
+cargo test -p yserver --lib launch::tests
 cargo +nightly fmt
 cargo clippy -p yserver --lib
 git add crates/yserver/src/launch.rs

--- a/docs/superpowers/plans/2026-06-12-xinerama.md
+++ b/docs/superpowers/plans/2026-06-12-xinerama.md
@@ -257,8 +257,10 @@ mod tests {
         assert_eq!(&r[36..38], &2560u16.to_le_bytes());
         assert_eq!(&r[38..40], &1440u16.to_le_bytes());
         // screen 1 at [40..48]
-        assert_eq!(&r[40..42], &2560i16.to_le_bytes());
-        assert_eq!(&r[44..46], &2560u16.to_le_bytes());
+        assert_eq!(&r[40..42], &2560i16.to_le_bytes()); // x_org
+        assert_eq!(&r[42..44], &0i16.to_le_bytes()); // y_org
+        assert_eq!(&r[44..46], &2560u16.to_le_bytes()); // width
+        assert_eq!(&r[46..48], &1440u16.to_le_bytes()); // height
     }
 
     #[test]
@@ -297,28 +299,71 @@ Expected: clean, commit succeeds.
 
 - [ ] **Step 1: Add the helper and write its failing test**
 
-Add this helper near the other free functions in `process_request.rs` (e.g. just above `handle_randr_request`):
+Add this helper near the other free functions in `process_request.rs` (e.g. just above `handle_randr_request`). It returns an **owned** `Vec` (not a borrow of `state`) so callers can intern atoms / take other `&mut state` borrows afterward without a borrow-checker conflict:
 
 ```rust
-/// The canonical active-monitor list — the SINGLE source of truth for both
-/// RANDR `GetMonitors` and the XINERAMA extension, so their counts can never
-/// disagree (the muffin multi-head crash is exactly a count mismatch). Order
-/// is the RANDR report order (primary = index 0). If enabled/disconnected
-/// filtering is ever added, it goes HERE and both consumers stay consistent.
-/// Mirrors Xorg sharing `RRMonitorMakeList` between RRGetMonitors and
-/// RRXineramaQueryScreens.
-fn active_monitor_outputs(state: &ServerState) -> &[crate::randr::RandrOutput] {
-    &state.randr.outputs
+/// One monitor as reported by BOTH RANDR `GetMonitors` and the XINERAMA
+/// extension — the SINGLE source of truth, so their counts/order can never
+/// diverge (the muffin multi-head crash is exactly a count mismatch). Owned
+/// (not a borrow of `state`) so a caller can `state.atoms.intern(...)`
+/// afterward. Order = RANDR report order (primary = index 0). Any future
+/// enabled/disconnected filtering goes HERE and both consumers stay
+/// consistent. Mirrors Xorg sharing `RRMonitorMakeList` between RRGetMonitors
+/// and RRXineramaQueryScreens.
+#[derive(Clone)]
+pub(crate) struct ActiveMonitor {
+    pub name: String,
+    pub output_id: u32,
+    pub primary: bool,
+    pub x: i16,
+    pub y: i16,
+    pub width: u16,
+    pub height: u16,
+    pub width_mm: u32,
+    pub height_mm: u32,
+}
+
+fn active_monitors(state: &ServerState) -> Vec<ActiveMonitor> {
+    state
+        .randr
+        .outputs
+        .iter()
+        .enumerate()
+        .map(|(i, o)| {
+            // Prefer EDID mm; else 96-DPI synthesis (same fallback the old
+            // RR_GET_MONITORS arm used inline).
+            let width_mm = if o.mm_width > 0 {
+                o.mm_width
+            } else {
+                ((u32::from(o.width) * 254 + 480) / 960).max(1)
+            };
+            let height_mm = if o.mm_height > 0 {
+                o.mm_height
+            } else {
+                ((u32::from(o.height) * 254 + 480) / 960).max(1)
+            };
+            ActiveMonitor {
+                name: o.name.clone(),
+                output_id: o.output_id,
+                primary: i == 0,
+                x: o.x,
+                y: o.y,
+                width: o.width,
+                height: o.height,
+                width_mm,
+                height_mm,
+            }
+        })
+        .collect()
 }
 ```
 
-Add a test in the `process_request.rs` `#[cfg(test)] mod tests` block (find it near the bottom of the file):
+Add a test in the `process_request.rs` `#[cfg(test)] mod tests` block (existing tests there build state with `ServerState::new()` — mirror that):
 
 ```rust
     #[test]
-    fn xinerama_screen_count_equals_monitor_count() {
-        use yserver_protocol::x11::xinerama::ScreenInfo;
-        let mut state = ServerState::for_test();
+    fn active_monitors_matches_outputs_and_order() {
+        let mut state = ServerState::new();
         state.randr.outputs = vec![
             crate::randr::RandrOutput {
                 name: "DP-1".into(), output_id: 1, crtc_id: 1, mode_id: 1,
@@ -331,37 +376,53 @@ Add a test in the `process_request.rs` `#[cfg(test)] mod tests` block (find it n
                 mm_width: 0, mm_height: 0,
             },
         ];
-        let screens: Vec<ScreenInfo> = active_monitor_outputs(&state)
-            .iter()
-            .map(|o| ScreenInfo { x_org: o.x, y_org: o.y, width: o.width, height: o.height })
-            .collect();
-        assert_eq!(screens.len(), state.randr.outputs.len());
-        assert_eq!(screens.len(), 2);
-        assert_eq!(screens[1].x_org, 2560);
+        let mons = active_monitors(&state);
+        // Invariant: one monitor per output, in order, primary first — so the
+        // XINERAMA screen count (built from this same list) always equals the
+        // RANDR monitor count.
+        assert_eq!(mons.len(), state.randr.outputs.len());
+        assert_eq!(mons.len(), 2);
+        assert!(mons[0].primary);
+        assert!(!mons[1].primary);
+        assert_eq!(mons[1].x, 2560);
     }
 ```
 
-> If `ServerState::for_test()` is not the constructor used in this module's tests, mirror whatever the existing `process_request.rs` tests use to build a `ServerState` (grep the test module for how other tests construct state) and report the substitution. If `RandrOutput` has fields beyond those listed, copy the field set the struct actually requires (see `crates/yserver-core/src/randr.rs`).
+> `ServerState::new()` is the constructor the existing tests use (grep the test module — e.g. `let mut state = ServerState::new();`). If `RandrOutput` has fields beyond those listed, copy the field set the struct actually requires (see `crates/yserver-core/src/randr.rs:7`; the plan's set matches it).
 
 - [ ] **Step 2: Run the test (expect compile fail → then pass)**
 
-Run: `cargo test -p yserver-core xinerama_screen_count_equals_monitor_count`
+Run: `cargo test -p yserver-core active_monitors_matches_outputs_and_order`
 Expected: FAIL to compile until the helper exists; PASS once it does.
 
 - [ ] **Step 3: Refactor RR_GET_MONITORS to consume the helper**
 
-In the `x11randr::RR_GET_MONITORS =>` arm (~line 2290), change the row source from `state.randr.outputs.iter()` to `active_monitor_outputs(state).iter()` so both paths share the one list:
+In the `x11randr::RR_GET_MONITORS =>` arm (~line 2290), the current code builds `Vec<MonitorRow>` by iterating `state.randr.outputs` and interning the name atom *inside* the closure (it relies on the compiler seeing disjoint `state.randr.outputs` vs `state.atoms` borrows). Replace that with: first take the **owned** list from `active_monitors(state)`, then intern atoms in a second pass (no borrow conflict, because the owned `Vec` doesn't borrow `state`):
 
 ```rust
-            let rows: Vec<MonitorRow> = active_monitor_outputs(state)
+            let monitors_list = active_monitors(state);
+            let rows: Vec<MonitorRow> = monitors_list
                 .iter()
-                .enumerate()
-                .map(|(i, o)| {
+                .map(|m| MonitorRow {
+                    name_atom: state.atoms.intern(&m.name, false).0,
+                    primary: m.primary,
+                    automatic: true,
+                    x: m.x,
+                    y: m.y,
+                    width: m.width,
+                    height: m.height,
+                    width_mm: m.width_mm,
+                    height_mm: m.height_mm,
+                    outputs: vec![m.output_id],
+                })
+                .collect();
 ```
 
-(The rest of the `RR_GET_MONITORS` arm is unchanged — it still interns the name atom and synthesizes mm sizes per row.)
+The mm-fallback synthesis that used to live in this closure now lives in
+`active_monitors`, so it's deleted here. The rest of the arm (building
+`MonitorInfo<'_>` from `rows`, encoding the reply) is unchanged.
 
-> Note: `active_monitor_outputs` borrows `state` immutably; the `RR_GET_MONITORS` arm later interns atoms via `state.atoms.intern(...)`, a `&mut` borrow. If the borrow checker complains, collect the needed per-output data into the `MonitorRow` vec while the immutable borrow is held (it already builds an owned `Vec<MonitorRow>`), so the immutable borrow ends before the atom interning — verify by building. If interning happens inside the `.map()` over the borrowed slice (it does today), keep the same structure but bind `let outputs = active_monitor_outputs(state);` then iterate — and if that conflicts, fall back to iterating `state.randr.outputs` directly in RR_GET_MONITORS while XINERAMA uses the helper (both still read the same field; the helper is the documented choke point). Report which form you used.
+> Verify `state.atoms.intern(&m.name, false).0` matches the existing call in this arm (it currently does `state.atoms.intern(&o.name, false).0`). `m.name` is borrowed from the owned `monitors_list`, which does NOT borrow `state`, so the `&mut state.atoms` borrow inside the map is fine. Build to confirm.
 
 - [ ] **Step 4: Run RANDR tests to confirm no regression**
 
@@ -449,7 +510,10 @@ fn handle_xinerama_request(
     header: RequestHeader,
     body: &[u8],
 ) -> io::Result<RequestOutcome> {
-    use yserver_protocol::x11::{ClientByteOrder, wire::read_u32, xinerama as xin};
+    // `read_u32` is re-exported at x11 root via `pub use wire::*` in
+    // x11/mod.rs:13 — the `wire` module itself is private, so import the
+    // re-export, NOT `wire::read_u32`.
+    use yserver_protocol::x11::{ClientByteOrder, error, read_u32, xinerama as xin};
     const XINERAMA_MAJOR_OPCODE: u8 = 151;
 
     let byte_order = state
@@ -458,34 +522,30 @@ fn handle_xinerama_request(
         .map_or(ClientByteOrder::LittleEndian, |c| c.byte_order);
     let minor = header.data;
 
-    // Shared monitor list — SAME source as RR_GET_MONITORS (count invariant).
-    let screens: Vec<xin::ScreenInfo> = active_monitor_outputs(state)
+    // Shared monitor list — SAME source (`active_monitors`) as RR_GET_MONITORS,
+    // so the screen count always equals the RANDR monitor count.
+    let screens: Vec<xin::ScreenInfo> = active_monitors(state)
         .iter()
-        .map(|o| xin::ScreenInfo {
-            x_org: o.x,
-            y_org: o.y,
-            width: o.width,
-            height: o.height,
+        .map(|m| xin::ScreenInfo {
+            x_org: m.x,
+            y_org: m.y,
+            width: m.width,
+            height: m.height,
         })
         .collect();
 
-    // Helper: REQUEST_SIZE_MATCH — body must be exactly `n` bytes, else BadLength.
+    // REQUEST_SIZE_MATCH — body must be exactly `n` bytes, else BadLength.
+    // Carries the Xinerama minor opcode in the error for xtrace fidelity.
     macro_rules! require_len {
         ($n:expr) => {
             if body.len() != $n {
-                return emit_x11_error(
+                return emit_x11_error_with_minor(
                     state, client_id, sequence,
-                    yserver_protocol::x11::error::BAD_LENGTH, 0, XINERAMA_MAJOR_OPCODE,
+                    error::BAD_LENGTH, 0, u16::from(minor), XINERAMA_MAJOR_OPCODE,
                 );
             }
         };
     }
-
-    // Validate a windowed request's window arg (first 4 bytes of body) →
-    // BadWindow if it isn't a known window. Mirrors dixLookupWindow.
-    let validate_window = |state: &ServerState, window: u32| -> bool {
-        state.resources.window(ResourceId(window)).is_some()
-    };
 
     let buf: Vec<u8> = match minor {
         xin::QUERY_VERSION => {
@@ -503,10 +563,10 @@ fn handle_xinerama_request(
         xin::GET_STATE => {
             require_len!(4);
             let window = read_u32(byte_order, body);
-            if !validate_window(state, window) {
-                return emit_x11_error(
+            if state.resources.window(ResourceId(window)).is_none() {
+                return emit_x11_error_with_minor(
                     state, client_id, sequence,
-                    yserver_protocol::x11::error::BAD_WINDOW, window, XINERAMA_MAJOR_OPCODE,
+                    error::BAD_WINDOW, window, u16::from(minor), XINERAMA_MAJOR_OPCODE,
                 );
             }
             // GetState = "RANDR present?" — always true here (distinct from IsActive).
@@ -515,10 +575,10 @@ fn handle_xinerama_request(
         xin::GET_SCREEN_COUNT => {
             require_len!(4);
             let window = read_u32(byte_order, body);
-            if !validate_window(state, window) {
-                return emit_x11_error(
+            if state.resources.window(ResourceId(window)).is_none() {
+                return emit_x11_error_with_minor(
                     state, client_id, sequence,
-                    yserver_protocol::x11::error::BAD_WINDOW, window, XINERAMA_MAJOR_OPCODE,
+                    error::BAD_WINDOW, window, u16::from(minor), XINERAMA_MAJOR_OPCODE,
                 );
             }
             #[allow(clippy::cast_possible_truncation)]
@@ -529,35 +589,24 @@ fn handle_xinerama_request(
             require_len!(8);
             let window = read_u32(byte_order, body);
             let screen = read_u32(byte_order, &body[4..]);
-            if !validate_window(state, window) {
-                return emit_x11_error(
+            if state.resources.window(ResourceId(window)).is_none() {
+                return emit_x11_error_with_minor(
                     state, client_id, sequence,
-                    yserver_protocol::x11::error::BAD_WINDOW, window, XINERAMA_MAJOR_OPCODE,
+                    error::BAD_WINDOW, window, u16::from(minor), XINERAMA_MAJOR_OPCODE,
                 );
             }
-            // Root/virtual-screen size = bounding box of all monitors (the root
-            // window spans all heads). No bounds-check on `screen` — matches
-            // rrxinerama.c, which returns the root size and echoes the screen.
-            #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-            let root_w = screens
-                .iter()
-                .map(|s| i32::from(s.x_org) + i32::from(s.width))
-                .max()
-                .unwrap_or(0)
-                .max(0) as u32;
-            #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-            let root_h = screens
-                .iter()
-                .map(|s| i32::from(s.y_org) + i32::from(s.height))
-                .max()
-                .unwrap_or(0)
-                .max(0) as u32;
+            // Root/virtual-screen size = the canonical aggregated extent yserver
+            // already maintains (Xorg returns the root drawable size,
+            // rrxinerama.c:207-215). NO bounds-check on `screen` — rrxinerama
+            // echoes the requested screen and never errors on it.
+            let root_w = u32::from(state.randr.screen_width);
+            let root_h = u32::from(state.randr.screen_height);
             xin::encode_get_screen_size_reply(byte_order, sequence, root_w, root_h, window, screen)
         }
         _ => {
-            return emit_x11_error(
+            return emit_x11_error_with_minor(
                 state, client_id, sequence,
-                yserver_protocol::x11::error::BAD_REQUEST, 0, XINERAMA_MAJOR_OPCODE,
+                error::BAD_REQUEST, 0, u16::from(minor), XINERAMA_MAJOR_OPCODE,
             );
         }
     };
@@ -569,7 +618,7 @@ fn handle_xinerama_request(
 }
 ```
 
-> Verify against the real definitions while implementing: `ResourceId(u32)` tuple construction and `state.resources.window(ResourceId) -> Option<&Window>` (both used elsewhere in this file — e.g. `ResourceId(xid)`, `state.resources.window(id)`); `read_u32(byte_order, &[u8])` (`yserver-protocol/src/x11/wire.rs:12`); the `error::BAD_*` constants (`yserver-protocol/src/x11/mod.rs:5600`); and `write_to_client(client, client_id, &buf)` (the ending used by `handle_query_extension`). If `RequestHeader.data` is not the minor-opcode byte for extension requests, use whatever `handle_randr_request` reads as `let minor = header.data;` (it reads exactly that). Report any signature mismatch.
+> Verify against the real definitions while implementing: `ResourceId(u32)` tuple construction and `state.resources.window(ResourceId) -> Option<&Window>` (used elsewhere in this file — `ResourceId(xid)`, `state.resources.window(id)`); `read_u32` re-exported at `yserver_protocol::x11::read_u32` (`x11/mod.rs:13` `pub use wire::*`); `error::BAD_*` (`x11/mod.rs:5600`); `state.randr.screen_width`/`screen_height` (`randr.rs:47-48`, `u16`); `emit_x11_error_with_minor(state, client_id, sequence, code, bad_value, minor_opcode: u16, major_opcode: u8)` (`process_request.rs:15245`); and `write_to_client(client, client_id, &buf)` (the ending `handle_query_extension` uses). `let minor = header.data;` matches what `handle_randr_request` reads. Report any signature mismatch.
 
 - [ ] **Step 5: Build + run the full crate tests**
 
@@ -625,7 +674,7 @@ Note machine/date/outcome (Cinnamon stable? screen count? rects?) in the PR desc
 
 **Spec coverage:**
 - 6 reply encoders + exact wire layouts → Task 1 (each encoder + byte-level tests incl. 2-screen QueryScreens, `state`/`ScreenCount` in byte 1, length = N*2).
-- Shared `active_monitors` invariant → Task 2 (`active_monitor_outputs`, RR_GET_MONITORS refactor, count-equality test).
+- Shared monitor-list invariant → Task 2 (owned `active_monitors() -> Vec<ActiveMonitor>`, RR_GET_MONITORS refactored to a second-pass atom-intern over it, count/order test).
 - EXTENSIONS registration (opcode 151, no events/errors) + QueryExtension presence → Task 3 Step 1/2.
 - Dispatch + handler with all 6 requests → Task 3 Step 3/4.
 - Semantics: GetState=true (RANDR present), IsActive=count>0, GetScreenSize=root size + echo + no bounds-check, BadWindow on bad window, BadLength on size mismatch (REQUEST_SIZE_MATCH), BadRequest on unknown minor → Task 3 Step 4 (matches spec component 4 + error table).
@@ -633,4 +682,4 @@ Note machine/date/outcome (Cinnamon stable? screen count? rects?) in the PR desc
 
 **Placeholder scan:** none — every code step has complete code; the `>`-noted verification caveats point at real, named definitions to confirm against (not deferred work).
 
-**Type consistency:** `ScreenInfo` (x_org/y_org/width/height) is identical in `xinerama.rs`, Task 2's test, and the handler's mapping. `encode_*` signatures in Task 1 match every call site in Task 3. `XINERAMA_MAJOR_OPCODE = 151` is consistent across nested.rs, the dispatch arm, and the handler's local const. `active_monitor_outputs(&ServerState) -> &[RandrOutput]` is defined in Task 2 and used in Task 2 (RR_GET_MONITORS) + Task 3 (handler).
+**Type consistency:** `ScreenInfo` (x_org/y_org/width/height) is identical in `xinerama.rs`, Task 2's test, and the handler's mapping. `encode_*` signatures in Task 1 match every call site in Task 3. `XINERAMA_MAJOR_OPCODE = 151` is consistent across nested.rs, the dispatch arm, and the handler's local const. `active_monitors(&ServerState) -> Vec<ActiveMonitor>` (owned, avoiding the `&mut state.atoms` borrow conflict) is defined in Task 2 and used in Task 2 (RR_GET_MONITORS second-pass intern) + Task 3 (handler builds `ScreenInfo` from it).

--- a/docs/superpowers/plans/2026-06-12-xinerama.md
+++ b/docs/superpowers/plans/2026-06-12-xinerama.md
@@ -1,0 +1,636 @@
+# XINERAMA Extension Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the XINERAMA X extension so multi-head WMs (muffin/mutter) see one Xinerama screen per RANDR monitor, fixing a NULL-deref crash on dual-head.
+
+**Architecture:** A new pure wire-encoder module `xinerama.rs` (mirrors `randr.rs`), registered in the `EXTENSIONS` table with a dispatch arm. A handler reads the monitor list through a new shared `active_monitor_outputs()` helper that `RR_GET_MONITORS` *also* uses — so the Xinerama screen count and the RANDR monitor count are equal by construction (the load-bearing crash invariant). Read-only; no events, no state, no per-client tracking.
+
+**Tech Stack:** Rust; existing `yserver-protocol` wire helpers (`fixed_reply`/`put`/`write_u16/u32/i16`, `read_u32`); RANDR-backed Xinerama semantics from Xorg `randr/rrxinerama.c`.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-xinerama-design.md`
+
+**Toolchain (AGENTS.md):** `cargo +nightly fmt`; regular `cargo clippy` (NOT pedantic); `cargo test`.
+
+---
+
+## File Structure
+
+- **Create** `crates/yserver-protocol/src/x11/xinerama.rs` — opcode/version constants, `ScreenInfo`, six pure reply encoders, file-local `Put`/`put`/`fixed_reply` helpers (mirroring `randr.rs`), and unit tests.
+- **Modify** `crates/yserver-protocol/src/x11/mod.rs` — add `pub mod xinerama;`.
+- **Modify** `crates/yserver-core/src/nested.rs` — add `XINERAMA_MAJOR_OPCODE` const + a `XINERAMA` `EXTENSIONS` entry.
+- **Modify** `crates/yserver-core/src/core_loop/process_request.rs` — add `active_monitor_outputs()` helper; refactor the `RR_GET_MONITORS` arm to use it; add the `151 => handle_xinerama_request(...)` dispatch arm and the `handle_xinerama_request` function.
+
+---
+
+### Task 1: `xinerama.rs` wire encoders (pure)
+
+**Files:**
+- Create: `crates/yserver-protocol/src/x11/xinerama.rs`
+- Modify: `crates/yserver-protocol/src/x11/mod.rs`
+
+- [ ] **Step 1: Create the module with constants, encoders, and failing tests**
+
+Create `crates/yserver-protocol/src/x11/xinerama.rs`:
+
+```rust
+//! XINERAMA (PanoramiX) extension wire encoders. yserver mirrors the
+//! RANDR-backed Xinerama path (Xorg `randr/rrxinerama.c`): the Xinerama
+//! screens ARE the RANDR monitors. All replies are the 32-byte fixed reply;
+//! only `QueryScreens` appends `N × 8` bytes.
+//! Spec: docs/superpowers/specs/2026-06-12-xinerama-design.md
+//! Wire: /usr/include/X11/extensions/panoramiXproto.h
+
+use super::{
+    ClientByteOrder, SequenceNumber,
+    wire::{write_i16, write_u16, write_u32},
+};
+
+pub const MAJOR_VERSION: u16 = 1;
+pub const MINOR_VERSION: u16 = 1;
+
+// minor opcodes (panoramiXproto.h)
+pub const QUERY_VERSION: u8 = 0;
+pub const GET_STATE: u8 = 1;
+pub const GET_SCREEN_COUNT: u8 = 2;
+pub const GET_SCREEN_SIZE: u8 = 3;
+pub const IS_ACTIVE: u8 = 4;
+pub const QUERY_SCREENS: u8 = 5;
+
+/// One Xinerama screen rect. Wire: x_org i16, y_org i16, width u16, height u16
+/// = 8 bytes (`xXineramaScreenInfo`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScreenInfo {
+    pub x_org: i16,
+    pub y_org: i16,
+    pub width: u16,
+    pub height: u16,
+}
+
+trait Put {
+    fn put(self, bo: ClientByteOrder, out: &mut Vec<u8>);
+}
+impl Put for u16 {
+    fn put(self, bo: ClientByteOrder, out: &mut Vec<u8>) {
+        write_u16(bo, out, self);
+    }
+}
+impl Put for u32 {
+    fn put(self, bo: ClientByteOrder, out: &mut Vec<u8>) {
+        write_u32(bo, out, self);
+    }
+}
+impl Put for i16 {
+    fn put(self, bo: ClientByteOrder, out: &mut Vec<u8>) {
+        write_i16(bo, out, self);
+    }
+}
+fn put<T: Put>(bo: ClientByteOrder, out: &mut Vec<u8>, x: T) {
+    x.put(bo, out);
+}
+
+/// 8-byte reply prefix: `[type=1, data, sequence u16, length u32]`. `length`
+/// counts 4-byte words BEYOND the 32-byte fixed reply. `data` is byte 1 — it
+/// carries `state`/`ScreenCount` for the GetState/GetScreenCount replies, else 0.
+fn fixed_reply(bo: ClientByteOrder, seq: SequenceNumber, data: u8, length: u32) -> Vec<u8> {
+    let mut r = Vec::with_capacity(32);
+    r.push(1u8);
+    r.push(data);
+    put(bo, &mut r, seq.0);
+    put(bo, &mut r, length);
+    r
+}
+
+#[must_use]
+pub fn encode_query_version_reply(bo: ClientByteOrder, seq: SequenceNumber) -> Vec<u8> {
+    let mut r = fixed_reply(bo, seq, 0, 0);
+    put(bo, &mut r, MAJOR_VERSION);
+    put(bo, &mut r, MINOR_VERSION);
+    r.resize(32, 0);
+    r
+}
+
+#[must_use]
+pub fn encode_get_state_reply(
+    bo: ClientByteOrder,
+    seq: SequenceNumber,
+    active: bool,
+    window: u32,
+) -> Vec<u8> {
+    let mut r = fixed_reply(bo, seq, u8::from(active), 0);
+    put(bo, &mut r, window);
+    r.resize(32, 0);
+    r
+}
+
+#[must_use]
+pub fn encode_get_screen_count_reply(
+    bo: ClientByteOrder,
+    seq: SequenceNumber,
+    count: u8,
+    window: u32,
+) -> Vec<u8> {
+    let mut r = fixed_reply(bo, seq, count, 0);
+    put(bo, &mut r, window);
+    r.resize(32, 0);
+    r
+}
+
+#[must_use]
+pub fn encode_get_screen_size_reply(
+    bo: ClientByteOrder,
+    seq: SequenceNumber,
+    width: u32,
+    height: u32,
+    window: u32,
+    screen: u32,
+) -> Vec<u8> {
+    let mut r = fixed_reply(bo, seq, 0, 0);
+    put(bo, &mut r, width);
+    put(bo, &mut r, height);
+    put(bo, &mut r, window);
+    put(bo, &mut r, screen);
+    r.resize(32, 0);
+    r
+}
+
+#[must_use]
+pub fn encode_is_active_reply(bo: ClientByteOrder, seq: SequenceNumber, active: bool) -> Vec<u8> {
+    let mut r = fixed_reply(bo, seq, 0, 0);
+    put(bo, &mut r, u32::from(active));
+    r.resize(32, 0);
+    r
+}
+
+#[must_use]
+pub fn encode_query_screens_reply(
+    bo: ClientByteOrder,
+    seq: SequenceNumber,
+    screens: &[ScreenInfo],
+) -> Vec<u8> {
+    // length = data words beyond the 32-byte header; each ScreenInfo is 8 bytes
+    // = 2 words.
+    #[allow(clippy::cast_possible_truncation)]
+    let length = (screens.len() * 2) as u32;
+    let mut r = fixed_reply(bo, seq, 0, length);
+    #[allow(clippy::cast_possible_truncation)]
+    put(bo, &mut r, screens.len() as u32); // number
+    r.resize(32, 0); // pad the fixed header to 32
+    for s in screens {
+        put(bo, &mut r, s.x_org);
+        put(bo, &mut r, s.y_org);
+        put(bo, &mut r, s.width);
+        put(bo, &mut r, s.height);
+    }
+    r
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LE: ClientByteOrder = ClientByteOrder::LittleEndian;
+    fn seq() -> SequenceNumber {
+        SequenceNumber(0x1234)
+    }
+
+    #[test]
+    fn query_version_reply_bytes() {
+        let r = encode_query_version_reply(LE, seq());
+        assert_eq!(r.len(), 32);
+        assert_eq!(r[0], 1); // reply
+        assert_eq!(&r[2..4], &0x1234u16.to_le_bytes()); // sequence
+        assert_eq!(&r[4..8], &0u32.to_le_bytes()); // length
+        assert_eq!(&r[8..10], &1u16.to_le_bytes()); // major
+        assert_eq!(&r[10..12], &1u16.to_le_bytes()); // minor
+    }
+
+    #[test]
+    fn get_state_reply_has_state_in_byte1() {
+        let r = encode_get_state_reply(LE, seq(), true, 0xdead_beef);
+        assert_eq!(r.len(), 32);
+        assert_eq!(r[1], 1); // state rides in byte 1
+        assert_eq!(&r[8..12], &0xdead_beefu32.to_le_bytes()); // window
+        let r0 = encode_get_state_reply(LE, seq(), false, 0);
+        assert_eq!(r0[1], 0);
+    }
+
+    #[test]
+    fn get_screen_count_reply_has_count_in_byte1() {
+        let r = encode_get_screen_count_reply(LE, seq(), 2, 0x55);
+        assert_eq!(r.len(), 32);
+        assert_eq!(r[1], 2); // ScreenCount in byte 1
+        assert_eq!(&r[8..12], &0x55u32.to_le_bytes());
+    }
+
+    #[test]
+    fn get_screen_size_reply_bytes() {
+        let r = encode_get_screen_size_reply(LE, seq(), 5120, 1440, 0x10, 0);
+        assert_eq!(r.len(), 32);
+        assert_eq!(&r[8..12], &5120u32.to_le_bytes()); // width
+        assert_eq!(&r[12..16], &1440u32.to_le_bytes()); // height
+        assert_eq!(&r[16..20], &0x10u32.to_le_bytes()); // window
+        assert_eq!(&r[20..24], &0u32.to_le_bytes()); // screen
+    }
+
+    #[test]
+    fn is_active_reply_state_word() {
+        let r = encode_is_active_reply(LE, seq(), true);
+        assert_eq!(r.len(), 32);
+        assert_eq!(&r[8..12], &1u32.to_le_bytes());
+        assert_eq!(&encode_is_active_reply(LE, seq(), false)[8..12], &0u32.to_le_bytes());
+    }
+
+    #[test]
+    fn query_screens_two_screens() {
+        let screens = [
+            ScreenInfo { x_org: 0, y_org: 0, width: 2560, height: 1440 },
+            ScreenInfo { x_org: 2560, y_org: 0, width: 2560, height: 1440 },
+        ];
+        let r = encode_query_screens_reply(LE, seq(), &screens);
+        assert_eq!(r.len(), 32 + 2 * 8); // 48
+        assert_eq!(&r[4..8], &4u32.to_le_bytes()); // length = N*2 = 4 words
+        assert_eq!(&r[8..12], &2u32.to_le_bytes()); // number = 2
+        // screen 0 at [32..40]
+        assert_eq!(&r[32..34], &0i16.to_le_bytes());
+        assert_eq!(&r[34..36], &0i16.to_le_bytes());
+        assert_eq!(&r[36..38], &2560u16.to_le_bytes());
+        assert_eq!(&r[38..40], &1440u16.to_le_bytes());
+        // screen 1 at [40..48]
+        assert_eq!(&r[40..42], &2560i16.to_le_bytes());
+        assert_eq!(&r[44..46], &2560u16.to_le_bytes());
+    }
+
+    #[test]
+    fn query_screens_empty() {
+        let r = encode_query_screens_reply(LE, seq(), &[]);
+        assert_eq!(r.len(), 32);
+        assert_eq!(&r[4..8], &0u32.to_le_bytes());
+        assert_eq!(&r[8..12], &0u32.to_le_bytes());
+    }
+}
+```
+
+Register the module in `crates/yserver-protocol/src/x11/mod.rs` — add `pub mod xinerama;` in the `pub mod` block next to `pub mod randr;` (alphabetical / adjacent is fine).
+
+- [ ] **Step 2: Run the tests**
+
+Run: `cargo test -p yserver-protocol xinerama`
+Expected: PASS (7 tests). If a `SequenceNumber`/`ClientByteOrder` import or field (`SequenceNumber(..)`, `.0`) doesn't match the crate, adjust to the real definitions (mirror how `randr.rs` constructs `fixed_reply` / uses `sequence.0`) and report the adjustment.
+
+- [ ] **Step 3: Format, lint, commit**
+
+```bash
+cargo +nightly fmt
+cargo clippy -p yserver-protocol
+git add crates/yserver-protocol/src/x11/xinerama.rs crates/yserver-protocol/src/x11/mod.rs
+git commit -m "feat(xinerama): wire encoders for the 6 PanoramiX/Xinerama replies"
+```
+Expected: clean, commit succeeds.
+
+---
+
+### Task 2: shared `active_monitor_outputs()` helper + RR_GET_MONITORS refactor
+
+**Files:**
+- Modify: `crates/yserver-core/src/core_loop/process_request.rs` (the `RR_GET_MONITORS` arm at ~line 2290, and a new helper)
+
+- [ ] **Step 1: Add the helper and write its failing test**
+
+Add this helper near the other free functions in `process_request.rs` (e.g. just above `handle_randr_request`):
+
+```rust
+/// The canonical active-monitor list — the SINGLE source of truth for both
+/// RANDR `GetMonitors` and the XINERAMA extension, so their counts can never
+/// disagree (the muffin multi-head crash is exactly a count mismatch). Order
+/// is the RANDR report order (primary = index 0). If enabled/disconnected
+/// filtering is ever added, it goes HERE and both consumers stay consistent.
+/// Mirrors Xorg sharing `RRMonitorMakeList` between RRGetMonitors and
+/// RRXineramaQueryScreens.
+fn active_monitor_outputs(state: &ServerState) -> &[crate::randr::RandrOutput] {
+    &state.randr.outputs
+}
+```
+
+Add a test in the `process_request.rs` `#[cfg(test)] mod tests` block (find it near the bottom of the file):
+
+```rust
+    #[test]
+    fn xinerama_screen_count_equals_monitor_count() {
+        use yserver_protocol::x11::xinerama::ScreenInfo;
+        let mut state = ServerState::for_test();
+        state.randr.outputs = vec![
+            crate::randr::RandrOutput {
+                name: "DP-1".into(), output_id: 1, crtc_id: 1, mode_id: 1,
+                x: 0, y: 0, width: 2560, height: 1440, vrefresh: 60,
+                mm_width: 0, mm_height: 0,
+            },
+            crate::randr::RandrOutput {
+                name: "HDMI-A-1".into(), output_id: 2, crtc_id: 2, mode_id: 1,
+                x: 2560, y: 0, width: 2560, height: 1440, vrefresh: 60,
+                mm_width: 0, mm_height: 0,
+            },
+        ];
+        let screens: Vec<ScreenInfo> = active_monitor_outputs(&state)
+            .iter()
+            .map(|o| ScreenInfo { x_org: o.x, y_org: o.y, width: o.width, height: o.height })
+            .collect();
+        assert_eq!(screens.len(), state.randr.outputs.len());
+        assert_eq!(screens.len(), 2);
+        assert_eq!(screens[1].x_org, 2560);
+    }
+```
+
+> If `ServerState::for_test()` is not the constructor used in this module's tests, mirror whatever the existing `process_request.rs` tests use to build a `ServerState` (grep the test module for how other tests construct state) and report the substitution. If `RandrOutput` has fields beyond those listed, copy the field set the struct actually requires (see `crates/yserver-core/src/randr.rs`).
+
+- [ ] **Step 2: Run the test (expect compile fail → then pass)**
+
+Run: `cargo test -p yserver-core xinerama_screen_count_equals_monitor_count`
+Expected: FAIL to compile until the helper exists; PASS once it does.
+
+- [ ] **Step 3: Refactor RR_GET_MONITORS to consume the helper**
+
+In the `x11randr::RR_GET_MONITORS =>` arm (~line 2290), change the row source from `state.randr.outputs.iter()` to `active_monitor_outputs(state).iter()` so both paths share the one list:
+
+```rust
+            let rows: Vec<MonitorRow> = active_monitor_outputs(state)
+                .iter()
+                .enumerate()
+                .map(|(i, o)| {
+```
+
+(The rest of the `RR_GET_MONITORS` arm is unchanged — it still interns the name atom and synthesizes mm sizes per row.)
+
+> Note: `active_monitor_outputs` borrows `state` immutably; the `RR_GET_MONITORS` arm later interns atoms via `state.atoms.intern(...)`, a `&mut` borrow. If the borrow checker complains, collect the needed per-output data into the `MonitorRow` vec while the immutable borrow is held (it already builds an owned `Vec<MonitorRow>`), so the immutable borrow ends before the atom interning — verify by building. If interning happens inside the `.map()` over the borrowed slice (it does today), keep the same structure but bind `let outputs = active_monitor_outputs(state);` then iterate — and if that conflicts, fall back to iterating `state.randr.outputs` directly in RR_GET_MONITORS while XINERAMA uses the helper (both still read the same field; the helper is the documented choke point). Report which form you used.
+
+- [ ] **Step 4: Run RANDR tests to confirm no regression**
+
+Run: `cargo test -p yserver-core randr` and `cargo test -p yserver-core get_monitors`
+Expected: PASS — the GetMonitors reply is byte-identical to before (pure refactor).
+
+- [ ] **Step 5: Format, lint, commit**
+
+```bash
+cargo +nightly fmt
+cargo clippy -p yserver-core
+git add crates/yserver-core/src/core_loop/process_request.rs
+git commit -m "refactor(randr): shared active_monitor_outputs() for RANDR + XINERAMA"
+```
+
+---
+
+### Task 3: register XINERAMA + dispatch + handler
+
+**Files:**
+- Modify: `crates/yserver-core/src/nested.rs` (opcode const + EXTENSIONS entry)
+- Modify: `crates/yserver-core/src/core_loop/process_request.rs` (dispatch arm + handler)
+
+- [ ] **Step 1: Add the opcode constant + EXTENSIONS entry, with a failing test**
+
+In `crates/yserver-core/src/nested.rs`, add the constant near the other `*_MAJOR_OPCODE` consts (e.g. after `MIT_SCREEN_SAVER_MAJOR_OPCODE: u8 = 150`):
+
+```rust
+pub(crate) const XINERAMA_MAJOR_OPCODE: u8 = 151;
+```
+
+Add to the `EXTENSIONS` array:
+
+```rust
+    ExtensionMetadata {
+        name: "XINERAMA",
+        major_opcode: XINERAMA_MAJOR_OPCODE,
+        first_event: 0,
+        event_count: 0,
+        first_error: 0,
+        availability: ExtensionAvailability::Always,
+        unsupported_minor_policy: UnsupportedMinorPolicy::HandledInline,
+    },
+```
+
+Add a test in `nested.rs`'s test module (or `process_request.rs` tests):
+
+```rust
+    #[test]
+    fn xinerama_is_advertised() {
+        let ext = crate::nested::EXTENSIONS
+            .iter()
+            .find(|e| e.name == "XINERAMA")
+            .expect("XINERAMA in EXTENSIONS");
+        assert_eq!(ext.major_opcode, 151);
+        assert_eq!(ext.first_event, 0);
+        assert_eq!(ext.first_error, 0);
+    }
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `cargo test -p yserver-core xinerama_is_advertised`
+Expected: PASS.
+
+- [ ] **Step 3: Add the dispatch arm**
+
+In `process_request.rs`, the top-level `match header.opcode` (~line 200), add next to `128 => handle_randr_request(...)`:
+
+```rust
+        151 => handle_xinerama_request(state, client_id, sequence, header, body),
+```
+
+(151 == `crate::nested::XINERAMA_MAJOR_OPCODE`; the surrounding arms use integer literals, so a literal with this comment matches the local style.)
+
+- [ ] **Step 4: Add the handler**
+
+Add `handle_xinerama_request` near `handle_randr_request` in `process_request.rs`:
+
+```rust
+fn handle_xinerama_request(
+    state: &mut ServerState,
+    client_id: ClientId,
+    sequence: SequenceNumber,
+    header: RequestHeader,
+    body: &[u8],
+) -> io::Result<RequestOutcome> {
+    use yserver_protocol::x11::{ClientByteOrder, wire::read_u32, xinerama as xin};
+    const XINERAMA_MAJOR_OPCODE: u8 = 151;
+
+    let byte_order = state
+        .clients
+        .get(&client_id.0)
+        .map_or(ClientByteOrder::LittleEndian, |c| c.byte_order);
+    let minor = header.data;
+
+    // Shared monitor list — SAME source as RR_GET_MONITORS (count invariant).
+    let screens: Vec<xin::ScreenInfo> = active_monitor_outputs(state)
+        .iter()
+        .map(|o| xin::ScreenInfo {
+            x_org: o.x,
+            y_org: o.y,
+            width: o.width,
+            height: o.height,
+        })
+        .collect();
+
+    // Helper: REQUEST_SIZE_MATCH — body must be exactly `n` bytes, else BadLength.
+    macro_rules! require_len {
+        ($n:expr) => {
+            if body.len() != $n {
+                return emit_x11_error(
+                    state, client_id, sequence,
+                    yserver_protocol::x11::error::BAD_LENGTH, 0, XINERAMA_MAJOR_OPCODE,
+                );
+            }
+        };
+    }
+
+    // Validate a windowed request's window arg (first 4 bytes of body) →
+    // BadWindow if it isn't a known window. Mirrors dixLookupWindow.
+    let validate_window = |state: &ServerState, window: u32| -> bool {
+        state.resources.window(ResourceId(window)).is_some()
+    };
+
+    let buf: Vec<u8> = match minor {
+        xin::QUERY_VERSION => {
+            require_len!(4); // clientMajor, clientMinor, pad(2)
+            xin::encode_query_version_reply(byte_order, sequence)
+        }
+        xin::IS_ACTIVE => {
+            require_len!(0);
+            xin::encode_is_active_reply(byte_order, sequence, !screens.is_empty())
+        }
+        xin::QUERY_SCREENS => {
+            require_len!(0);
+            xin::encode_query_screens_reply(byte_order, sequence, &screens)
+        }
+        xin::GET_STATE => {
+            require_len!(4);
+            let window = read_u32(byte_order, body);
+            if !validate_window(state, window) {
+                return emit_x11_error(
+                    state, client_id, sequence,
+                    yserver_protocol::x11::error::BAD_WINDOW, window, XINERAMA_MAJOR_OPCODE,
+                );
+            }
+            // GetState = "RANDR present?" — always true here (distinct from IsActive).
+            xin::encode_get_state_reply(byte_order, sequence, true, window)
+        }
+        xin::GET_SCREEN_COUNT => {
+            require_len!(4);
+            let window = read_u32(byte_order, body);
+            if !validate_window(state, window) {
+                return emit_x11_error(
+                    state, client_id, sequence,
+                    yserver_protocol::x11::error::BAD_WINDOW, window, XINERAMA_MAJOR_OPCODE,
+                );
+            }
+            #[allow(clippy::cast_possible_truncation)]
+            let count = screens.len() as u8;
+            xin::encode_get_screen_count_reply(byte_order, sequence, count, window)
+        }
+        xin::GET_SCREEN_SIZE => {
+            require_len!(8);
+            let window = read_u32(byte_order, body);
+            let screen = read_u32(byte_order, &body[4..]);
+            if !validate_window(state, window) {
+                return emit_x11_error(
+                    state, client_id, sequence,
+                    yserver_protocol::x11::error::BAD_WINDOW, window, XINERAMA_MAJOR_OPCODE,
+                );
+            }
+            // Root/virtual-screen size = bounding box of all monitors (the root
+            // window spans all heads). No bounds-check on `screen` — matches
+            // rrxinerama.c, which returns the root size and echoes the screen.
+            #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+            let root_w = screens
+                .iter()
+                .map(|s| i32::from(s.x_org) + i32::from(s.width))
+                .max()
+                .unwrap_or(0)
+                .max(0) as u32;
+            #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+            let root_h = screens
+                .iter()
+                .map(|s| i32::from(s.y_org) + i32::from(s.height))
+                .max()
+                .unwrap_or(0)
+                .max(0) as u32;
+            xin::encode_get_screen_size_reply(byte_order, sequence, root_w, root_h, window, screen)
+        }
+        _ => {
+            return emit_x11_error(
+                state, client_id, sequence,
+                yserver_protocol::x11::error::BAD_REQUEST, 0, XINERAMA_MAJOR_OPCODE,
+            );
+        }
+    };
+
+    let Some(client) = state.clients.get_mut(&client_id.0) else {
+        return Ok(RequestOutcome::Handled);
+    };
+    Ok(write_to_client(client, client_id, &buf))
+}
+```
+
+> Verify against the real definitions while implementing: `ResourceId(u32)` tuple construction and `state.resources.window(ResourceId) -> Option<&Window>` (both used elsewhere in this file — e.g. `ResourceId(xid)`, `state.resources.window(id)`); `read_u32(byte_order, &[u8])` (`yserver-protocol/src/x11/wire.rs:12`); the `error::BAD_*` constants (`yserver-protocol/src/x11/mod.rs:5600`); and `write_to_client(client, client_id, &buf)` (the ending used by `handle_query_extension`). If `RequestHeader.data` is not the minor-opcode byte for extension requests, use whatever `handle_randr_request` reads as `let minor = header.data;` (it reads exactly that). Report any signature mismatch.
+
+- [ ] **Step 5: Build + run the full crate tests**
+
+Run: `cargo test -p yserver-core` and `cargo build --release --bin yserver`
+Expected: PASS / builds clean. (Handler request/response behavior is covered by the Task 1 encoder unit tests + the Task 4 HW smoke; this step confirms it compiles and wires in without regressing other tests.)
+
+- [ ] **Step 6: Format, lint, commit**
+
+```bash
+cargo +nightly fmt
+cargo clippy -p yserver-core
+git add crates/yserver-core/src/nested.rs crates/yserver-core/src/core_loop/process_request.rs
+git commit -m "feat(xinerama): register extension + dispatch + handler (RANDR-backed)"
+```
+Expected: clippy clean (watch for `unused` on the `require_len!` macro paths or the `validate_window` closure — both are used). Fix any lint, re-run, commit.
+
+---
+
+### Task 4: hardware smoke (manual gate — the real proof)
+
+The crash and fix are display-path behavior that unit tests can't exercise (mutter's consumption of XINERAMA). Per repo practice, this isn't done until observed on hardware. Run on silence (dual-head: DP-1 + HDMI-A-1).
+
+**Files:** none committed (verification only).
+
+- [ ] **Step 1: Build + install, both monitors on**
+
+```bash
+cargo build --release --bin yserver
+sudo install -m755 target/release/yserver /usr/local/bin/yserver   # or point lightdm at target/release
+```
+Ensure both monitors are physically on before starting.
+
+- [ ] **Step 2: Start lightdm (single X server, dual-head) and log into Cinnamon**
+
+From a text VT: `sudo systemctl restart lightdm`, then log into the Cinnamon session.
+Expected: **Cinnamon starts and stays up** — no `libmuffin` SIGSEGV ~11s in. (Before this fix, dual-head crashed; single-head did not.)
+
+- [ ] **Step 3: Verify XINERAMA is live and correct**
+
+In the Cinnamon session (or any client on `:0`):
+```bash
+xdpyinfo -ext XINERAMA | sed -n '/XINERAMA/,/^[^ ]/p'
+```
+Expected: XINERAMA present, **2** screens (`head #0: 2560x1440 @ 0,0`, `head #1: 2560x1440 @ 2560,0`). And `xrandr --listmonitors` still shows 2 monitors (counts agree).
+
+- [ ] **Step 4: Record the result**
+
+Note machine/date/outcome (Cinnamon stable? screen count? rects?) in the PR description. If it still crashes, capture `~/.xsession-errors` + the journal `segfault` line and re-open investigation (next suspect: whether this mutter build reads the X XINERAMA extension vs its own RANDR-monitor list — but Xorg's RANDR↔Xinerama glue says this is the surface it expects).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- 6 reply encoders + exact wire layouts → Task 1 (each encoder + byte-level tests incl. 2-screen QueryScreens, `state`/`ScreenCount` in byte 1, length = N*2).
+- Shared `active_monitors` invariant → Task 2 (`active_monitor_outputs`, RR_GET_MONITORS refactor, count-equality test).
+- EXTENSIONS registration (opcode 151, no events/errors) + QueryExtension presence → Task 3 Step 1/2.
+- Dispatch + handler with all 6 requests → Task 3 Step 3/4.
+- Semantics: GetState=true (RANDR present), IsActive=count>0, GetScreenSize=root size + echo + no bounds-check, BadWindow on bad window, BadLength on size mismatch (REQUEST_SIZE_MATCH), BadRequest on unknown minor → Task 3 Step 4 (matches spec component 4 + error table).
+- HW proof (Cinnamon survives, xdpyinfo shows 2) → Task 4.
+
+**Placeholder scan:** none — every code step has complete code; the `>`-noted verification caveats point at real, named definitions to confirm against (not deferred work).
+
+**Type consistency:** `ScreenInfo` (x_org/y_org/width/height) is identical in `xinerama.rs`, Task 2's test, and the handler's mapping. `encode_*` signatures in Task 1 match every call site in Task 3. `XINERAMA_MAJOR_OPCODE = 151` is consistent across nested.rs, the dispatch arm, and the handler's local const. `active_monitor_outputs(&ServerState) -> &[RandrOutput]` is defined in Task 2 and used in Task 2 (RR_GET_MONITORS) + Task 3 (handler).

--- a/docs/superpowers/plans/2026-06-12-xinerama.md
+++ b/docs/superpowers/plans/2026-06-12-xinerama.md
@@ -4,7 +4,7 @@
 
 **Goal:** Implement the XINERAMA X extension so multi-head WMs (muffin/mutter) see one Xinerama screen per RANDR monitor, fixing a NULL-deref crash on dual-head.
 
-**Architecture:** A new pure wire-encoder module `xinerama.rs` (mirrors `randr.rs`), registered in the `EXTENSIONS` table with a dispatch arm. A handler reads the monitor list through a new shared `active_monitor_outputs()` helper that `RR_GET_MONITORS` *also* uses — so the Xinerama screen count and the RANDR monitor count are equal by construction (the load-bearing crash invariant). Read-only; no events, no state, no per-client tracking.
+**Architecture:** A new pure wire-encoder module `xinerama.rs` (mirrors `randr.rs`), registered in the `EXTENSIONS` table with a dispatch arm. A handler reads the monitor list through a new shared `active_monitors()` helper that `RR_GET_MONITORS` *also* uses — so the Xinerama screen count and the RANDR monitor count are equal by construction (the load-bearing crash invariant). Read-only; no events, no state, no per-client tracking.
 
 **Tech Stack:** Rust; existing `yserver-protocol` wire helpers (`fixed_reply`/`put`/`write_u16/u32/i16`, `read_u32`); RANDR-backed Xinerama semantics from Xorg `randr/rrxinerama.c`.
 
@@ -19,7 +19,7 @@
 - **Create** `crates/yserver-protocol/src/x11/xinerama.rs` — opcode/version constants, `ScreenInfo`, six pure reply encoders, file-local `Put`/`put`/`fixed_reply` helpers (mirroring `randr.rs`), and unit tests.
 - **Modify** `crates/yserver-protocol/src/x11/mod.rs` — add `pub mod xinerama;`.
 - **Modify** `crates/yserver-core/src/nested.rs` — add `XINERAMA_MAJOR_OPCODE` const + a `XINERAMA` `EXTENSIONS` entry.
-- **Modify** `crates/yserver-core/src/core_loop/process_request.rs` — add `active_monitor_outputs()` helper; refactor the `RR_GET_MONITORS` arm to use it; add the `151 => handle_xinerama_request(...)` dispatch arm and the `handle_xinerama_request` function.
+- **Modify** `crates/yserver-core/src/core_loop/process_request.rs` — add `active_monitors()` helper; refactor the `RR_GET_MONITORS` arm to use it; add the `151 => handle_xinerama_request(...)` dispatch arm and the `handle_xinerama_request` function.
 
 ---
 
@@ -292,7 +292,7 @@ Expected: clean, commit succeeds.
 
 ---
 
-### Task 2: shared `active_monitor_outputs()` helper + RR_GET_MONITORS refactor
+### Task 2: shared `active_monitors()` helper + RR_GET_MONITORS refactor
 
 **Files:**
 - Modify: `crates/yserver-core/src/core_loop/process_request.rs` (the `RR_GET_MONITORS` arm at ~line 2290, and a new helper)
@@ -435,7 +435,7 @@ Expected: PASS — the GetMonitors reply is byte-identical to before (pure refac
 cargo +nightly fmt
 cargo clippy -p yserver-core
 git add crates/yserver-core/src/core_loop/process_request.rs
-git commit -m "refactor(randr): shared active_monitor_outputs() for RANDR + XINERAMA"
+git commit -m "refactor(randr): shared active_monitors() helper for RANDR + XINERAMA"
 ```
 
 ---

--- a/docs/superpowers/plans/2026-06-12-xinerama.md
+++ b/docs/superpowers/plans/2026-06-12-xinerama.md
@@ -29,7 +29,7 @@
 - Create: `crates/yserver-protocol/src/x11/xinerama.rs`
 - Modify: `crates/yserver-protocol/src/x11/mod.rs`
 
-- [ ] **Step 1: Create the module with constants, encoders, and failing tests**
+- [x] **Step 1: Create the module with constants, encoders, and failing tests**
 
 Create `crates/yserver-protocol/src/x11/xinerama.rs`:
 
@@ -275,12 +275,12 @@ mod tests {
 
 Register the module in `crates/yserver-protocol/src/x11/mod.rs` — add `pub mod xinerama;` in the `pub mod` block next to `pub mod randr;` (alphabetical / adjacent is fine).
 
-- [ ] **Step 2: Run the tests**
+- [x] **Step 2: Run the tests**
 
 Run: `cargo test -p yserver-protocol xinerama`
 Expected: PASS (7 tests). If a `SequenceNumber`/`ClientByteOrder` import or field (`SequenceNumber(..)`, `.0`) doesn't match the crate, adjust to the real definitions (mirror how `randr.rs` constructs `fixed_reply` / uses `sequence.0`) and report the adjustment.
 
-- [ ] **Step 3: Format, lint, commit**
+- [x] **Step 3: Format, lint, commit**
 
 ```bash
 cargo +nightly fmt
@@ -297,7 +297,7 @@ Expected: clean, commit succeeds.
 **Files:**
 - Modify: `crates/yserver-core/src/core_loop/process_request.rs` (the `RR_GET_MONITORS` arm at ~line 2290, and a new helper)
 
-- [ ] **Step 1: Add the helper and write its failing test**
+- [x] **Step 1: Add the helper and write its failing test**
 
 Add this helper near the other free functions in `process_request.rs` (e.g. just above `handle_randr_request`). It returns an **owned** `Vec` (not a borrow of `state`) so callers can intern atoms / take other `&mut state` borrows afterward without a borrow-checker conflict:
 
@@ -390,12 +390,12 @@ Add a test in the `process_request.rs` `#[cfg(test)] mod tests` block (existing 
 
 > `ServerState::new()` is the constructor the existing tests use (grep the test module — e.g. `let mut state = ServerState::new();`). If `RandrOutput` has fields beyond those listed, copy the field set the struct actually requires (see `crates/yserver-core/src/randr.rs:7`; the plan's set matches it).
 
-- [ ] **Step 2: Run the test (expect compile fail → then pass)**
+- [x] **Step 2: Run the test (expect compile fail → then pass)**
 
 Run: `cargo test -p yserver-core active_monitors_matches_outputs_and_order`
 Expected: FAIL to compile until the helper exists; PASS once it does.
 
-- [ ] **Step 3: Refactor RR_GET_MONITORS to consume the helper**
+- [x] **Step 3: Refactor RR_GET_MONITORS to consume the helper**
 
 In the `x11randr::RR_GET_MONITORS =>` arm (~line 2290), the current code builds `Vec<MonitorRow>` by iterating `state.randr.outputs` and interning the name atom *inside* the closure (it relies on the compiler seeing disjoint `state.randr.outputs` vs `state.atoms` borrows). Replace that with: first take the **owned** list from `active_monitors(state)`, then intern atoms in a second pass (no borrow conflict, because the owned `Vec` doesn't borrow `state`):
 
@@ -424,12 +424,12 @@ The mm-fallback synthesis that used to live in this closure now lives in
 
 > Verify `state.atoms.intern(&m.name, false).0` matches the existing call in this arm (it currently does `state.atoms.intern(&o.name, false).0`). `m.name` is borrowed from the owned `monitors_list`, which does NOT borrow `state`, so the `&mut state.atoms` borrow inside the map is fine. Build to confirm.
 
-- [ ] **Step 4: Run RANDR tests to confirm no regression**
+- [x] **Step 4: Run RANDR tests to confirm no regression**
 
 Run: `cargo test -p yserver-core randr` and `cargo test -p yserver-core get_monitors`
 Expected: PASS — the GetMonitors reply is byte-identical to before (pure refactor).
 
-- [ ] **Step 5: Format, lint, commit**
+- [x] **Step 5: Format, lint, commit**
 
 ```bash
 cargo +nightly fmt
@@ -446,7 +446,7 @@ git commit -m "refactor(randr): shared active_monitors() helper for RANDR + XINE
 - Modify: `crates/yserver-core/src/nested.rs` (opcode const + EXTENSIONS entry)
 - Modify: `crates/yserver-core/src/core_loop/process_request.rs` (dispatch arm + handler)
 
-- [ ] **Step 1: Add the opcode constant + EXTENSIONS entry, with a failing test**
+- [x] **Step 1: Add the opcode constant + EXTENSIONS entry, with a failing test**
 
 In `crates/yserver-core/src/nested.rs`, add the constant near the other `*_MAJOR_OPCODE` consts (e.g. after `MIT_SCREEN_SAVER_MAJOR_OPCODE: u8 = 150`):
 
@@ -483,12 +483,12 @@ Add a test in `nested.rs`'s test module (or `process_request.rs` tests):
     }
 ```
 
-- [ ] **Step 2: Run the test**
+- [x] **Step 2: Run the test**
 
 Run: `cargo test -p yserver-core xinerama_is_advertised`
 Expected: PASS.
 
-- [ ] **Step 3: Add the dispatch arm**
+- [x] **Step 3: Add the dispatch arm**
 
 In `process_request.rs`, the top-level `match header.opcode` (~line 200), add next to `128 => handle_randr_request(...)`:
 
@@ -498,7 +498,7 @@ In `process_request.rs`, the top-level `match header.opcode` (~line 200), add ne
 
 (151 == `crate::nested::XINERAMA_MAJOR_OPCODE`; the surrounding arms use integer literals, so a literal with this comment matches the local style.)
 
-- [ ] **Step 4: Add the handler**
+- [x] **Step 4: Add the handler**
 
 Add `handle_xinerama_request` near `handle_randr_request` in `process_request.rs`:
 
@@ -620,12 +620,12 @@ fn handle_xinerama_request(
 
 > Verify against the real definitions while implementing: `ResourceId(u32)` tuple construction and `state.resources.window(ResourceId) -> Option<&Window>` (used elsewhere in this file — `ResourceId(xid)`, `state.resources.window(id)`); `read_u32` re-exported at `yserver_protocol::x11::read_u32` (`x11/mod.rs:13` `pub use wire::*`); `error::BAD_*` (`x11/mod.rs:5600`); `state.randr.screen_width`/`screen_height` (`randr.rs:47-48`, `u16`); `emit_x11_error_with_minor(state, client_id, sequence, code, bad_value, minor_opcode: u16, major_opcode: u8)` (`process_request.rs:15245`); and `write_to_client(client, client_id, &buf)` (the ending `handle_query_extension` uses). `let minor = header.data;` matches what `handle_randr_request` reads. Report any signature mismatch.
 
-- [ ] **Step 5: Build + run the full crate tests**
+- [x] **Step 5: Build + run the full crate tests**
 
 Run: `cargo test -p yserver-core` and `cargo build --release --bin yserver`
 Expected: PASS / builds clean. (Handler request/response behavior is covered by the Task 1 encoder unit tests + the Task 4 HW smoke; this step confirms it compiles and wires in without regressing other tests.)
 
-- [ ] **Step 6: Format, lint, commit**
+- [x] **Step 6: Format, lint, commit**
 
 ```bash
 cargo +nightly fmt

--- a/docs/superpowers/specs/2026-06-12-lightdm-launch-design.md
+++ b/docs/superpowers/specs/2026-06-12-lightdm-launch-design.md
@@ -20,8 +20,10 @@ needed for them.
 - **Unblocked for free:** Item 3 (first light). yserver has no
   authentication today — it already accepts all local clients, which is
   exactly the "initially accept unauthenticated local clients" path the
-  issue asks for. No new code required to reach first light once items
-  1–2 land.
+  issue asks for. Crucially, lightdm *always* connects *with* a cookie, and
+  yserver's setup reader already **tolerates** a presented cookie without
+  rejecting it (verified — see Key facts). No new code required to reach
+  first light once items 1–2 land.
 - **Deferred (follow-ups):** Item 4 (MIT-MAGIC-COOKIE-1 from the `-auth`
   Xauthority file) and Item 5 (session-cycling teardown hardening — no
   leaked DRM/input state across server generations).
@@ -46,6 +48,49 @@ needed for them.
   `Enable` (= logind activated the session's VT). Therefore yserver
   neither chooses the seat nor switches the VT in libseat mode — `-seat`
   and `vtN` are informational only.
+- yserver's connection-setup reader (`read_setup_request`,
+  `yserver-protocol/src/x11/mod.rs:585-601`) reads the client-presented
+  `auth_protocol_name` + `auth_protocol_data` and **ignores** them; nothing
+  downstream rejects on auth (`write_setup_failed` fires only on
+  byte-order / version mismatch). So a client connecting *with* a
+  `MIT-MAGIC-COOKIE-1` cookie is accepted as-is — see "first light" below.
+
+## Launch-protocol facts (verified against Xorg `../xserver` + lightdm)
+
+These were checked against the upstream X.Org tree and lightdm source, and
+they reshape the design — read before the components:
+
+- **lightdm's default local path does NOT use `-displayfd`.** lightdm
+  picks the display number itself, appends `:N`, and **waits for the
+  SIGUSR1 ready signal** (`src/x-server-local.c`
+  `x_server_local_start()` / `got_signal_cb()`, signal routing in
+  `src/process.c`). So for lightdm the critical path is **explicit `:N` +
+  SIGUSR1-to-parent**, not auto-pick. `-displayfd` is a gdm-style /
+  opt-in path we still support, but it is not how stock lightdm drives us.
+- **Real default lightdm argv** is roughly:
+  `:0 -seat seat0 -auth /var/run/lightdm/root/:0 -nolisten tcp vt7 -novtswitch`
+  (plus optional `-config`, `-layout`, `-background`, user extras). Note
+  `-novtswitch` and the absence of `-displayfd`.
+- **Xorg's SIGUSR1/displayfd mechanism** (`os/connection.c`
+  `NotifyParentProcess()`, ~line 190): writes the display number then
+  `"\n"`, closes the displayfd, then sends `SIGUSR1` to the **captured
+  parent PID** (`ParentProcess = getppid()` from `InitParentProcess()`,
+  `os/connection.c:175`). It is invoked from `dix/main.c` *after*
+  `CreateConnectionBlock()` and before `Dispatch()`. Dynamic display
+  selection runs only when `displayfd >= 0 && !explicit_display`
+  (`os/connection.c:249`).
+- **Xorg lockfiles.** Xorg locks every *explicit* display with
+  `/tmp/.X<N>-lock` before creating the socket (`os/osinit.c:313`,
+  `os/utils.c:258`). It sets `nolock = TRUE` **only** for the `-displayfd`
+  dynamic-selection case (`os/utils.c:764`). lightdm's own
+  `display_number_in_use()` checks `/tmp/.X<N>-lock`, **not** the socket
+  path — so a server that creates only the socket can be misclassified as
+  "display free" by lightdm and other launchers.
+- **lightdm always passes `-auth` and connects *with* auth**
+  (`seat-local.c` → `x_server_set_local_authority()`; `x-server.c` uses
+  `xcb_connect_to_display_with_auth_info()`). First light works only
+  because yserver *tolerates* a presented cookie (verified fact above) —
+  enforcing it is the deferred item 4.
 
 ## Components
 
@@ -55,7 +100,7 @@ A pure, unit-testable argv parser:
 
 ```rust
 pub struct LaunchOptions {
-    pub display: Option<u16>,       // `:N` or bare `N` → explicit; None → auto-pick
+    pub display: Option<u16>,       // `:N` or bare `N` → explicit; None → resolved in run() (component 2)
     pub displayfd: Option<RawFd>,   // `-displayfd N`
     pub vt: Option<u32>,            // `vtN` — parsed, logged, otherwise ignored
     pub seat: Option<String>,       // `-seat NAME` — parsed, logged, ignored
@@ -77,7 +122,14 @@ Token handling:
 | `-auth FILE` | `auth_file = Some(FILE)` — consumes next arg; stashed for item 4 |
 | `-displayfd N` | `displayfd = Some(N)` — consumes next arg |
 | `-nolisten PROTO` | consumes next arg; no-op (yserver never listens on TCP) |
+| `-novtswitch` | known no-op (lightdm passes it; no arg) |
+| `-background none` | known no-op (consumes `none`/value arg) |
+| `-config FILE` / `-layout NAME` | known no-op; consume next arg |
 | unknown `-flag` / stray token | **warn + skip, not fatal** |
+
+The known no-op set above exists so the *default lightdm argv*
+(`:0 -seat seat0 -auth … -nolisten tcp vt7 -novtswitch`) parses with no
+warnings; anything beyond it still falls through to warn + skip.
 
 Behavior change vs. today: unknown arguments are tolerated (warn + skip)
 instead of being a hard error — required by the issue's "tolerate/no-op
@@ -97,49 +149,101 @@ Moves out of the `Justfile` shell loop. `parse_args` leaves `display` as
 (`display`, `displayfd`) using three explicit cases, so existing behavior
 is preserved:
 
-| `display` | `displayfd` | Effective display |
-|-----------|-------------|-------------------|
-| `Some(n)` | any | `n` (explicit `:N`/bare `N` always wins) |
-| `None` | `Some(_)` | **auto-pick** lowest free in `0..256` (the DM path) |
-| `None` | `None` | `DEFAULT_DISPLAY` (7) — back-compat for bare/legacy invocation |
+| `display` | `displayfd` | Effective display | Lockfile? |
+|-----------|-------------|-------------------|-----------|
+| `Some(n)` | any | `n` (explicit `:N`/bare `N` always wins — **this is the lightdm path**) | yes |
+| `None` | `Some(_)` | **auto-pick** lowest free in `0..256` (gdm-style `-displayfd`, *not* stock lightdm) | no (matches Xorg `nolock`) |
+| `None` | `None` | `DEFAULT_DISPLAY` (7) — back-compat for bare/legacy invocation | yes |
 
 `DEFAULT_DISPLAY` stays at 7 (the existing convention that avoids clashing
-with a real Xorg on `:0`); the bare-invocation behavior is unchanged.
+with a real Xorg on `:0`); the bare-invocation behavior is unchanged. The
+lockfile column is implemented by component 2b below; it matters because
+lightdm hands us an explicit `:N` and checks `/tmp/.X<N>-lock`.
 
 Binding per case:
 
-- **Explicit display** and **back-compat default**: keep the current
-  "remove stale socket, then bind" behavior.
+- **Explicit display** and **back-compat default**: acquire the lockfile
+  (component 2b), then keep the current "remove stale socket, then bind"
+  behavior.
 - **Auto-pick**: scan `/tmp/.X11-unix/Xk` for `k` in `0..256` and bind the
   lowest free one. For an existing socket file, `connect()` first to
   disambiguate:
   - connect refused (`ECONNREFUSED`) ⇒ stale ⇒ remove + bind it;
-  - connect succeeds ⇒ a live server ⇒ try the next `k`.
+  - connect succeeds ⇒ a live server ⇒ try the next `k`;
+  - **any other `connect()` error** (e.g. `EACCES`, `ETIMEDOUT`) ⇒ treat
+    as occupied/unknown ⇒ try the next `k`, do **not** delete the socket;
+  - **`bind()` returns `EADDRINUSE`** (lost a race to a concurrent
+    starter between the scan and the bind) ⇒ try the next `k`.
   - Exhausting `0..256` is a hard error.
+  Auto-pick deliberately does **not** create a lockfile, matching Xorg's
+  `nolock = TRUE` for the `-displayfd` path.
 
 Factored as a function taking the socket-directory path so it can be unit
 tested against a tempdir. Cap of 256 chosen as "plenty" (real X allows
 far more; 256 covers any realistic seat count).
 
+### 2b. Display lockfile (`/tmp/.X<N>-lock`)
+
+**Required for interop** — lightdm (and other launchers) test
+`/tmp/.X<N>-lock`, not the socket, to decide whether a display is free.
+For the explicit-`:N` and back-compat-default cases (the lightdm path), we
+must implement the standard Xorg lock protocol before binding the socket:
+
+1. Create `/tmp/.X<N>-lock` with `O_CREAT | O_EXCL`, mode `0444`, and write
+   the owning PID as Xorg does (`"%10d\n"`, 11 bytes).
+2. If `O_EXCL` fails with `EEXIST`: read the PID from the existing lock.
+   - If `kill(pid, 0)` succeeds (process alive) ⇒ display genuinely in use
+     ⇒ for explicit `:N`, hard error; (auto-pick never reaches here — it
+     takes no lock).
+   - If it fails with `ESRCH` (stale lock from a dead server) ⇒ remove the
+     lock and retry the create once.
+3. On clean shutdown, remove our own lockfile (alongside the existing
+   socket cleanup at `lib.rs:387`).
+
+Factored to take the lock-directory path (`/tmp` by default) so the
+create / stale-detection / collision logic is unit-testable against a
+tempdir. This is the fix for codex's interop **blocker**: a socket-only
+server gets misclassified as "free" by lightdm's `display_number_in_use()`.
+
 ### 3. Readiness signaling (in `run()`)
 
-Fired immediately after the socket is bound and chmod'd
-(around `lib.rs:260`) — the earliest point at which connections are
-accepted (the listen backlog queues lightdm's `connect()` until the core
-loop accepts). Both mechanisms run if configured:
+**Timing — when to signal.** Not merely after bind/chmod. lightdm opens
+an XCB connection *with auth* the instant it receives SIGUSR1, so we must
+not signal before yserver can actually complete the initial X
+connection-setup handshake. Xorg signals from `dix/main.c` *after*
+`CreateConnectionBlock()` and before `Dispatch()`. yserver's equivalent
+"ready to serve setup" point is **just before entering the core loop**
+(after `ServerState` is fully constructed, the listener is bound +
+chmod'd, and the lockfile is held — around `lib.rs:351`, just before
+`run_core`). Signal there. (The listen backlog still queues a `connect()`
+that races in slightly early, but the setup *reply* won't be attempted
+until the core loop is running and able to produce a valid connection
+block.) This is between the user's "at bind time" and "after first
+composite/flip" — it does not wait for a painted frame.
+
+Both mechanisms run if configured:
 
 - **`-displayfd`**: write `"<N>\n"` (ASCII, Xorg format) to the fd, then
   close it, where `N` is the **effective** display resolved by component 2
   (the auto-picked number in the DM path). Factored into
   `write_displayfd(fd, display)` so it can be unit-tested through a pipe.
-- **SIGUSR1-to-parent**: **very early in startup, *before* SIGUSR1 is
-  masked for the signalfd**, query SIGUSR1's inherited disposition. If it
-  is `SIG_IGN` (the DM started us that way — the classic X convention),
-  record a flag and `kill(getppid(), SIGUSR1)` once the socket is ready.
-  Order is load-bearing: the existing signalfd setup masks SIGUSR1, which
-  would overwrite the inherited disposition if read too late. Inbound
-  SIGUSR1=dump-scanout is unaffected — that is the receive side; this is
-  the send side, fired exactly once at readiness.
+- **SIGUSR1-to-parent**: at startup, query SIGUSR1's inherited disposition
+  with `sigaction(SIGUSR1, NULL, &old)`. If `old.sa_handler == SIG_IGN`
+  (the DM started us that way — the classic X convention), record a flag
+  and `kill(getppid(), SIGUSR1)` once ready. `getppid()` is correct:
+  Xorg captures `ParentProcess = getppid()` in `InitParentProcess()` and
+  signals that PID (`os/connection.c:175`).
+
+  *Note on ordering:* blocking SIGUSR1 for the signalfd (via
+  `sigprocmask`) only suppresses **delivery** — it does **not** change the
+  signal's *disposition*. So reading the inherited `SIG_IGN` disposition
+  via `sigaction(…, NULL, &old)` is correct regardless of when we later
+  add SIGUSR1 to the signalfd mask; there is no real ordering hazard
+  (an earlier draft overstated this). We only must avoid installing a real
+  `sigaction` *handler* for SIGUSR1 before reading the disposition — and
+  yserver never does, it uses signalfd. Inbound SIGUSR1=dump-scanout is
+  unaffected — that is the receive side; this is the send side, fired
+  exactly once at readiness.
 
 ### 4. `run()` signature
 
@@ -157,16 +261,26 @@ build options → call `run`.
 | Missing value after `-seat` / `-auth` / `-displayfd` | hard error |
 | `-displayfd` write/close failure | warn, continue (lightdm may time out, but don't crash) |
 | Auto-pick exhausts `0..256` | hard error |
+| Explicit `:N` lockfile held by a live PID | hard error (display genuinely in use) |
+| Explicit `:N` lockfile stale (PID dead) | remove + retry create once |
 
 ## Testing
 
-- **`parse_args` unit tests:** each token; lightdm's real argv string
-  (e.g. `:0 vt1 -seat seat0 -auth /var/run/lightdm/root/:0 -nolisten tcp
-  -displayfd 12`); bare-number back-compat (`7`); unknown-flag tolerance;
-  arg-consuming flags; malformed-explicit errors; missing-value errors.
+- **`parse_args` unit tests:** each token; **lightdm's real default argv**
+  (`:0 -seat seat0 -auth /var/run/lightdm/root/:0 -nolisten tcp vt7
+  -novtswitch`) parses with no warnings and yields `display = Some(0)`,
+  `displayfd = None`, `auth_file = Some(...)`; a gdm-style `-displayfd`
+  variant (`-displayfd 12` with no explicit `:N`) yields
+  `displayfd = Some(12)`, `display = None`; bare-number back-compat (`7`);
+  unknown-flag tolerance; arg-consuming flags; malformed-explicit errors;
+  missing-value errors.
 - **Display auto-pick:** tempdir-based test of the scan / stale-socket /
-  live-socket logic (no real server needed — create dummy socket files and
-  a live listener).
+  live-socket logic plus the `EADDRINUSE` bind-race retry and the
+  "non-`ECONNREFUSED` ⇒ skip, don't delete" branch (create dummy socket
+  files and a live listener).
+- **Lockfile protocol:** tempdir-based test of `O_EXCL` create, the
+  stale-lock (`kill(pid,0)` → `ESRCH`) remove-and-retry path, and the
+  live-lock collision (hard error for explicit `:N`).
 - **`write_displayfd`:** unit-test via a `pipe()` — write to the write
   end, assert `"<N>\n"` on the read end.
 - **SIGUSR1-disposition path:** not unit-testable (process-global signal
@@ -179,9 +293,13 @@ build options → call `run`.
 
 ## Risks / notes
 
-- Session cycling (item 5) is out of scope, but the stale-socket handling
-  in auto-pick partly helps lightdm's kill-and-restart loop (a leftover
-  socket from a dead generation is reclaimed). Leaked DRM/input state
-  across generations remains a known follow-up.
+- Session cycling (item 5) is out of scope, but the stale-socket *and*
+  stale-lockfile handling help lightdm's kill-and-restart loop (a leftover
+  socket or lock from a dead generation is reclaimed via the `ESRCH`
+  path). Leaked DRM/input state across generations remains a known
+  follow-up.
+- The lockfile must be removed on clean shutdown (extend the existing
+  socket cleanup at `lib.rs:387`). A crash leaves a stale lock, but the
+  `kill(pid,0)`→`ESRCH` reclaim on the next start handles that.
 - `-auth` is parsed and stashed but unused in this chunk; item 4 will read
   the Xauthority file from `LaunchOptions::auth_file`.

--- a/docs/superpowers/specs/2026-06-12-lightdm-launch-design.md
+++ b/docs/superpowers/specs/2026-06-12-lightdm-launch-design.md
@@ -1,0 +1,187 @@
+# Launch yserver from a display manager (lightdm) — argv + readiness
+
+**Issue:** #6 (Support being launched by a display manager, lightdm first)
+**Scope:** Items 1 (X-style argv handling) and 2 (readiness handshake).
+**Date:** 2026-06-12
+**Branch:** `feat/lightdm-launch`
+
+## Goal
+
+Make lightdm able to start yserver as its X server. lightdm exec's
+`xserver-command` and appends X-style argv; yserver must parse that argv
+and perform the readiness handshake lightdm waits on before launching the
+greeter. The greeter and session are ordinary X clients — nothing new is
+needed for them.
+
+## Scope boundary
+
+- **In scope:** X-server-style argv parsing; display auto-selection;
+  `-displayfd` and SIGUSR1-to-parent readiness signaling.
+- **Unblocked for free:** Item 3 (first light). yserver has no
+  authentication today — it already accepts all local clients, which is
+  exactly the "initially accept unauthenticated local clients" path the
+  issue asks for. No new code required to reach first light once items
+  1–2 land.
+- **Deferred (follow-ups):** Item 4 (MIT-MAGIC-COOKIE-1 from the `-auth`
+  Xauthority file) and Item 5 (session-cycling teardown hardening — no
+  leaked DRM/input state across server generations).
+
+## Key facts grounding the design
+
+- `crates/yserver/src/bin/yserver.rs` currently parses only a bare
+  positional display number (`parse_display`, default 7) and **hard-errors
+  on any non-numeric argument**.
+- `crates/yserver/src/lib.rs::run(display: u16)` (line 48) binds
+  `/tmp/.X11-unix/X{display}` (lines 228–260). Display *selection* lives
+  in the `Justfile` `startx`/`xts-yserver-hw` shell loops, not in yserver.
+- `run()` has exactly one caller: `yserver.rs:28`. `ynest` uses a separate
+  entry point. The signature change is fully contained.
+- Inbound signals (`lib.rs:306–348`, `511–518`): SIGUSR1 → scanout dump,
+  SIGUSR2 → drawable dump, SIGINT/SIGTERM → shutdown. SIGUSR1/2 are masked
+  for a signalfd.
+- `libseat::Seat::open<C>(callback)` (libseat 0.2.4) takes **no seat
+  name**. The builtin logind backend always opens the seat of the current
+  logind session (which lightdm sets up). `Seat::open()`
+  (`seat/mod.rs:143`) already blocks waiting for libseat's initial
+  `Enable` (= logind activated the session's VT). Therefore yserver
+  neither chooses the seat nor switches the VT in libseat mode — `-seat`
+  and `vtN` are informational only.
+
+## Components
+
+### 1. New `launch` module — `crates/yserver/src/launch.rs`
+
+A pure, unit-testable argv parser:
+
+```rust
+pub struct LaunchOptions {
+    pub display: Option<u16>,       // `:N` or bare `N` → explicit; None → auto-pick
+    pub displayfd: Option<RawFd>,   // `-displayfd N`
+    pub vt: Option<u32>,            // `vtN` — parsed, logged, otherwise ignored
+    pub seat: Option<String>,       // `-seat NAME` — parsed, logged, ignored
+    pub auth_file: Option<PathBuf>, // `-auth FILE` — parsed + stashed for item 4; unused now
+}
+
+pub fn parse_args(args: impl IntoIterator<Item = String>)
+    -> Result<LaunchOptions, String>;
+```
+
+Token handling:
+
+| Token | Action |
+|-------|--------|
+| `:N` | `display = Some(N)` |
+| bare `N` (integer, no colon) | `display = Some(N)` — keeps `Justfile` recipes (`yserver 7`) working |
+| `vtN` | `vt = Some(N)` — logged, otherwise ignored (logind owns the VT) |
+| `-seat NAME` | `seat = Some(NAME)` — consumes next arg; logged, otherwise ignored |
+| `-auth FILE` | `auth_file = Some(FILE)` — consumes next arg; stashed for item 4 |
+| `-displayfd N` | `displayfd = Some(N)` — consumes next arg |
+| `-nolisten PROTO` | consumes next arg; no-op (yserver never listens on TCP) |
+| unknown `-flag` / stray token | **warn + skip, not fatal** |
+
+Behavior change vs. today: unknown arguments are tolerated (warn + skip)
+instead of being a hard error — required by the issue's "tolerate/no-op
+the rest." Malformed **explicit** requests still error: `:foo`, `vtbad`,
+`-displayfd notanumber`, a `-seat`/`-auth`/`-displayfd` with no following
+value.
+
+Arity note: only the known arg-consuming flags above consume a following
+token. Unknown `-flags` are skipped individually; a stray value left
+behind by an unknown flag is itself skipped as an unrecognized token (with
+a warning). We do not attempt to infer arity for unknown flags.
+
+### 2. Display selection (in `run()`, factored for tests)
+
+Moves out of the `Justfile` shell loop. `parse_args` leaves `display` as
+`Option<u16>`; `run()` resolves the *effective* display from the pair
+(`display`, `displayfd`) using three explicit cases, so existing behavior
+is preserved:
+
+| `display` | `displayfd` | Effective display |
+|-----------|-------------|-------------------|
+| `Some(n)` | any | `n` (explicit `:N`/bare `N` always wins) |
+| `None` | `Some(_)` | **auto-pick** lowest free in `0..256` (the DM path) |
+| `None` | `None` | `DEFAULT_DISPLAY` (7) — back-compat for bare/legacy invocation |
+
+`DEFAULT_DISPLAY` stays at 7 (the existing convention that avoids clashing
+with a real Xorg on `:0`); the bare-invocation behavior is unchanged.
+
+Binding per case:
+
+- **Explicit display** and **back-compat default**: keep the current
+  "remove stale socket, then bind" behavior.
+- **Auto-pick**: scan `/tmp/.X11-unix/Xk` for `k` in `0..256` and bind the
+  lowest free one. For an existing socket file, `connect()` first to
+  disambiguate:
+  - connect refused (`ECONNREFUSED`) ⇒ stale ⇒ remove + bind it;
+  - connect succeeds ⇒ a live server ⇒ try the next `k`.
+  - Exhausting `0..256` is a hard error.
+
+Factored as a function taking the socket-directory path so it can be unit
+tested against a tempdir. Cap of 256 chosen as "plenty" (real X allows
+far more; 256 covers any realistic seat count).
+
+### 3. Readiness signaling (in `run()`)
+
+Fired immediately after the socket is bound and chmod'd
+(around `lib.rs:260`) — the earliest point at which connections are
+accepted (the listen backlog queues lightdm's `connect()` until the core
+loop accepts). Both mechanisms run if configured:
+
+- **`-displayfd`**: write `"<N>\n"` (ASCII, Xorg format) to the fd, then
+  close it, where `N` is the **effective** display resolved by component 2
+  (the auto-picked number in the DM path). Factored into
+  `write_displayfd(fd, display)` so it can be unit-tested through a pipe.
+- **SIGUSR1-to-parent**: **very early in startup, *before* SIGUSR1 is
+  masked for the signalfd**, query SIGUSR1's inherited disposition. If it
+  is `SIG_IGN` (the DM started us that way — the classic X convention),
+  record a flag and `kill(getppid(), SIGUSR1)` once the socket is ready.
+  Order is load-bearing: the existing signalfd setup masks SIGUSR1, which
+  would overwrite the inherited disposition if read too late. Inbound
+  SIGUSR1=dump-scanout is unaffected — that is the receive side; this is
+  the send side, fired exactly once at readiness.
+
+### 4. `run()` signature
+
+`run(display: u16)` → `run(opts: LaunchOptions)`. The single caller
+(`yserver.rs:28`) builds `LaunchOptions` from argv via `launch::parse_args`
+and passes it through. `yserver.rs` becomes a thin shim: parse argv →
+build options → call `run`.
+
+## Error handling
+
+| Condition | Behavior |
+|-----------|----------|
+| Unknown argv token | warn + ignore (tolerate-the-rest) |
+| Malformed explicit `:N` / `vtN` / `-displayfd N` value | hard error, usage message, exit non-zero |
+| Missing value after `-seat` / `-auth` / `-displayfd` | hard error |
+| `-displayfd` write/close failure | warn, continue (lightdm may time out, but don't crash) |
+| Auto-pick exhausts `0..256` | hard error |
+
+## Testing
+
+- **`parse_args` unit tests:** each token; lightdm's real argv string
+  (e.g. `:0 vt1 -seat seat0 -auth /var/run/lightdm/root/:0 -nolisten tcp
+  -displayfd 12`); bare-number back-compat (`7`); unknown-flag tolerance;
+  arg-consuming flags; malformed-explicit errors; missing-value errors.
+- **Display auto-pick:** tempdir-based test of the scan / stale-socket /
+  live-socket logic (no real server needed — create dummy socket files and
+  a live listener).
+- **`write_displayfd`:** unit-test via a `pipe()` — write to the write
+  end, assert `"<N>\n"` on the read end.
+- **SIGUSR1-disposition path:** not unit-testable (process-global signal
+  state) → verified by **HW smoke under real lightdm** on bee/silence.
+  Per repo practice, startup/KMS-touching changes require hardware smoke
+  before commit anyway.
+- **Integration / first light:** point a real `lightdm.conf`
+  `[Seat:*] xserver-command` at the built binary on a HW machine; confirm
+  the GTK greeter appears. This is the acceptance gate for the chunk.
+
+## Risks / notes
+
+- Session cycling (item 5) is out of scope, but the stale-socket handling
+  in auto-pick partly helps lightdm's kill-and-restart loop (a leftover
+  socket from a dead generation is reclaimed). Leaked DRM/input state
+  across generations remains a known follow-up.
+- `-auth` is parsed and stashed but unused in this chunk; item 4 will read
+  the Xauthority file from `LaunchOptions::auth_file`.

--- a/docs/superpowers/specs/2026-06-12-lightdm-launch-design.md
+++ b/docs/superpowers/specs/2026-06-12-lightdm-launch-design.md
@@ -151,14 +151,22 @@ is preserved:
 
 | `display` | `displayfd` | Effective display | Lockfile? |
 |-----------|-------------|-------------------|-----------|
-| `Some(n)` | any | `n` (explicit `:N`/bare `N` always wins — **this is the lightdm path**) | yes |
-| `None` | `Some(_)` | **auto-pick** lowest free in `0..256` (gdm-style `-displayfd`, *not* stock lightdm) | no (matches Xorg `nolock`) |
-| `None` | `None` | `DEFAULT_DISPLAY` (7) — back-compat for bare/legacy invocation | yes |
+| `Some(n)` | `None` | `n` (explicit `:N`/bare `N` — **this is the lightdm path**) | **yes** |
+| `Some(n)` | `Some(_)` | `n` (explicit display wins; `-displayfd` still reported) | no |
+| `None` | `Some(_)` | **auto-pick** lowest free in `0..256` (gdm-style `-displayfd`, *not* stock lightdm) | no |
+| `None` | `None` | `DEFAULT_DISPLAY` (7) — back-compat for bare/legacy invocation | **yes** |
+
+The lockfile rule is exactly Xorg's: **lock the display iff `-displayfd`
+is absent.** Xorg sets `nolock = TRUE` whenever it parses `-displayfd`
+(`os/utils.c:764`), *before* `LockServer()` runs (`dix/main.c:138`) —
+i.e. presence of `-displayfd` suppresses the lock even when the display is
+explicit. We match that intentionally rather than diverging. Stock lightdm
+passes `:N` with no `-displayfd`, so it lands in the locked row, which is
+what matters: lightdm checks `/tmp/.X<N>-lock`, not the socket.
 
 `DEFAULT_DISPLAY` stays at 7 (the existing convention that avoids clashing
 with a real Xorg on `:0`); the bare-invocation behavior is unchanged. The
-lockfile column is implemented by component 2b below; it matters because
-lightdm hands us an explicit `:N` and checks `/tmp/.X<N>-lock`.
+lockfile column is implemented by component 2b below.
 
 Binding per case:
 
@@ -179,31 +187,49 @@ Binding per case:
   `nolock = TRUE` for the `-displayfd` path.
 
 Factored as a function taking the socket-directory path so it can be unit
-tested against a tempdir. Cap of 256 chosen as "plenty" (real X allows
-far more; 256 covers any realistic seat count).
+tested against a tempdir. The `0..256` cap is an **intentional bound** —
+narrower than Xorg's dynamic `-displayfd` scan (`os/connection.c:249`),
+which ranges much higher — chosen because 256 covers any realistic seat
+count; documented here so it isn't mistaken for parity with Xorg.
 
 ### 2b. Display lockfile (`/tmp/.X<N>-lock`)
 
 **Required for interop** — lightdm (and other launchers) test
 `/tmp/.X<N>-lock`, not the socket, to decide whether a display is free.
-For the explicit-`:N` and back-compat-default cases (the lightdm path), we
-must implement the standard Xorg lock protocol before binding the socket:
+For the locked cases (`-displayfd` absent — see the table above), we
+implement Xorg's exact lock protocol (`os/utils.c:258-380`) **before**
+binding the socket. Create is done via a temp file + atomic `link()`, not
+a direct `O_EXCL`, so a partially-written or empty final lock is never
+observable by a concurrent launcher:
 
-1. Create `/tmp/.X<N>-lock` with `O_CREAT | O_EXCL`, mode `0444`, and write
-   the owning PID as Xorg does (`"%10d\n"`, 11 bytes).
-2. If `O_EXCL` fails with `EEXIST`: read the PID from the existing lock.
-   - If `kill(pid, 0)` succeeds (process alive) ⇒ display genuinely in use
-     ⇒ for explicit `:N`, hard error; (auto-pick never reaches here — it
-     takes no lock).
-   - If it fails with `ESRCH` (stale lock from a dead server) ⇒ remove the
-     lock and retry the create once.
-3. On clean shutdown, remove our own lockfile (alongside the existing
-   socket cleanup at `lib.rs:387`).
+1. Write PID `"%10d\n"` (11 bytes) into `/tmp/.tX<N>-lock`, `chmod 0444`,
+   then `link()` it to `/tmp/.X<N>-lock` and `unlink` the temp file. A
+   successful `link()` is the atomic "we won" signal.
+2. If `link()` fails with `EEXIST`, inspect the existing lock — opened
+   `O_RDONLY | O_NOFOLLOW` (refuse to follow a symlink):
+   - **Malformed / short / non-numeric** contents ⇒ treat as bogus ⇒
+     remove and retry the link once.
+   - Parse the PID and `kill(pid, 0)`:
+     - success **or `EPERM`** ⇒ process alive (a live server owned by
+       another user still counts) ⇒ display in use ⇒ for explicit `:N`,
+       hard error.
+     - `ESRCH` ⇒ stale lock from a dead server ⇒ remove and retry once.
+3. **Error-path release:** if anything after lock acquisition fails
+   (socket bind/listen/chmod), remove our lockfile before returning the
+   error — never leave a lock we don't back with a live socket.
+4. **Clean shutdown ordering:** remove the **socket first, then the lock
+   last** (extend the cleanup at `lib.rs:387`). The lock is the
+   authoritative occupancy marker, so dropping it before the socket would
+   open a brief false-"free" window for a racing launcher.
+
+Auto-pick (and any `-displayfd` case) takes **no** lock, matching Xorg's
+`nolock = TRUE`.
 
 Factored to take the lock-directory path (`/tmp` by default) so the
-create / stale-detection / collision logic is unit-testable against a
-tempdir. This is the fix for codex's interop **blocker**: a socket-only
-server gets misclassified as "free" by lightdm's `display_number_in_use()`.
+create / temp+link / stale-detection / malformed / collision logic is
+unit-testable against a tempdir. This is the fix for codex's interop
+**blocker**: a socket-only server gets misclassified as "free" by
+lightdm's `display_number_in_use()`.
 
 ### 3. Readiness signaling (in `run()`)
 
@@ -278,9 +304,13 @@ build options → call `run`.
   live-socket logic plus the `EADDRINUSE` bind-race retry and the
   "non-`ECONNREFUSED` ⇒ skip, don't delete" branch (create dummy socket
   files and a live listener).
-- **Lockfile protocol:** tempdir-based test of `O_EXCL` create, the
-  stale-lock (`kill(pid,0)` → `ESRCH`) remove-and-retry path, and the
-  live-lock collision (hard error for explicit `:N`).
+- **Lockfile protocol:** tempdir-based test of the temp-file + atomic
+  `link()` create; the stale-lock (`kill(pid,0)` → `ESRCH`)
+  remove-and-retry path; the live-lock collision (hard error for explicit
+  `:N`); malformed/short lock contents treated as bogus + reclaimed; and
+  the error-path release (lock removed when a simulated bind failure
+  follows acquisition). Cleanup ordering (socket-then-lock) is asserted by
+  checking the lock outlives the socket during teardown.
 - **`write_displayfd`:** unit-test via a `pipe()` — write to the write
   end, assert `"<N>\n"` on the read end.
 - **SIGUSR1-disposition path:** not unit-testable (process-global signal

--- a/docs/superpowers/specs/2026-06-12-lightdm-launch-design.md
+++ b/docs/superpowers/specs/2026-06-12-lightdm-launch-design.md
@@ -299,10 +299,16 @@ Both mechanisms run if configured:
   `write_displayfd(fd, display)` so it can be unit-tested through a pipe.
 - **SIGUSR1-to-parent**: at startup, query SIGUSR1's inherited disposition
   with `sigaction(SIGUSR1, NULL, &old)`. If `old.sa_handler == SIG_IGN`
-  (the DM started us that way — the classic X convention), record a flag
-  and `kill(getppid(), SIGUSR1)` once ready. `getppid()` is correct:
-  Xorg captures `ParentProcess = getppid()` in `InitParentProcess()` and
-  signals that PID (`os/connection.c:175`).
+  (the DM started us that way — the classic X convention), record a flag,
+  and **also capture the parent PID once at startup** (`getppid()`, stored
+  as `Option<i32>` — `None` if already orphaned). Once ready,
+  `kill(parent_pid, SIGUSR1)`. Capturing the PID at startup rather than at
+  readiness is deliberate and matches Xorg: it stores
+  `ParentProcess = getppid()` in `InitParentProcess()` (`os/connection.c`)
+  and signals that captured PID in `NotifyParentProcess()` — reading
+  `getppid()` at readiness instead would, if the DM died during yserver's
+  init and we were reparented, point at a subreaper or PID 1 and either
+  misfire or silently skip the signal.
 
   *Note on ordering:* blocking SIGUSR1 for the signalfd (via
   `sigprocmask`) only suppresses **delivery** — it does **not** change the

--- a/docs/superpowers/specs/2026-06-12-lightdm-launch-design.md
+++ b/docs/superpowers/specs/2026-06-12-lightdm-launch-design.md
@@ -170,9 +170,18 @@ lockfile column is implemented by component 2b below.
 
 Binding per case:
 
+A shared probe rule for both cases below — **file type first**: on Linux,
+`connect(AF_UNIX)` to a *non-socket* inode fails with `ECONNREFUSED`, the
+**same errno as a stale socket**, so errno alone cannot tell "dead
+server's socket" from "some file named `X<n>`". Check
+`symlink_metadata(..).file_type().is_socket()` before any connect-probe;
+a non-socket path is **never deleted** (explicit ⇒ refuse with
+`AddrInUse`; auto-pick ⇒ skip to the next `k`). This also refuses
+symlinks.
+
 - **Explicit display** and **back-compat default**: acquire the lockfile
-  (component 2b, when the table says so), then **probe** any existing
-  socket before removing it: `connect()` succeeds ⇒ a live server owns the
+  (component 2b, when the table says so), then probe any existing path:
+  non-socket ⇒ refuse; `connect()` succeeds ⇒ a live server owns the
   display ⇒ hard error (`AddrInUse`) — never steal it (old yservers take
   no lock, so holding the lock alone doesn't prove the display free);
   `ECONNREFUSED` ⇒ stale ⇒ remove + bind; any other probe error ⇒ refuse
@@ -180,12 +189,13 @@ Binding per case:
   change vs. the old inline code, which removed the socket
   unconditionally.)
 - **Auto-pick**: scan `/tmp/.X11-unix/Xk` for `k` in `0..256` and bind the
-  lowest free one. For an existing socket file, `connect()` first to
-  disambiguate:
+  lowest free one. For an existing path:
+  - not a socket (or unreadable metadata) ⇒ skip to the next `k`, do
+    **not** delete;
   - connect refused (`ECONNREFUSED`) ⇒ stale ⇒ remove + bind it;
   - connect succeeds ⇒ a live server ⇒ try the next `k`;
-  - **any other `connect()` error** (e.g. `EACCES`, `ETIMEDOUT`) ⇒ treat
-    as occupied/unknown ⇒ try the next `k`, do **not** delete the socket;
+  - **any other `connect()` error** (e.g. `EACCES`) ⇒ treat as
+    occupied/unknown ⇒ try the next `k`, do **not** delete the socket;
   - **`bind()` returns `EADDRINUSE`** (lost a race to a concurrent
     starter between the scan and the bind) ⇒ try the next `k`.
   - Exhausting `0..256` is a hard error.
@@ -227,6 +237,15 @@ observable by a concurrent launcher:
        another user still counts) ⇒ display in use ⇒ for explicit `:N`,
        hard error.
      - `ESRCH` ⇒ stale lock from a dead server ⇒ remove and retry once.
+   Stale/bogus removal is **identity-bracketed**: record the lock's
+   `(dev, ino)` before inspecting and unlink only if the path still names
+   that inode — this narrows the race where a concurrent starter reclaims
+   the same stale lock and publishes its own fresh one between our inspect
+   and our unlink. Xorg has the full-width version of this race
+   (`LockServer`: read → `kill(pid,0)` → `unlink`, no identity check);
+   Linux has no unlink-by-fd, so a tiny lstat→unlink window remains —
+   acceptable, since same-display concurrent starts are DM-serialized in
+   practice.
 3. **Error-path release:** if anything after lock acquisition fails
    (socket bind/listen/chmod), remove our lockfile before returning the
    error — never leave a lock we don't back with a live socket.
@@ -314,13 +333,13 @@ build options → call `run`.
   unknown-flag tolerance; arg-consuming flags; malformed-explicit errors;
   missing-value errors.
 - **Display auto-pick:** tempdir-based test of the scan / stale-socket /
-  live-socket logic and the "non-`ECONNREFUSED` ⇒ skip, don't delete"
-  branch (a regular file named `Xk` exercises it via `ENOTSOCK`). The
-  `EADDRINUSE` bind-race `continue` branch cannot be hit deterministically
-  in a unit test (it needs a socket to appear between the existence check
-  and the `bind()`) — verified by inspection.
+  live-socket logic and the "non-socket ⇒ skip, don't delete" branch (a
+  regular file named `Xk` exercises the file-type check). The `EADDRINUSE`
+  bind-race `continue` branch cannot be hit deterministically in a unit
+  test (it needs a socket to appear between the existence check and the
+  `bind()`) — verified by inspection.
 - **Explicit bind:** live socket refused (`AddrInUse`), stale socket
-  reclaimed, chmod 0777 applied.
+  reclaimed, non-socket path refused without deletion, chmod 0777 applied.
 - **Lockfile protocol:** tempdir-based test of the temp-file + atomic
   `link()` create; the stale-lock (`kill(pid,0)` → `ESRCH`)
   remove-and-retry path; the live-lock collision (hard error for explicit

--- a/docs/superpowers/specs/2026-06-12-lightdm-launch-design.md
+++ b/docs/superpowers/specs/2026-06-12-lightdm-launch-design.md
@@ -179,6 +179,18 @@ a non-socket path is **never deleted** (explicit ⇒ refuse with
 `AddrInUse`; auto-pick ⇒ skip to the next `k`). This also refuses
 symlinks.
 
+The connect-probe itself must be **nonblocking**: a blocking
+`connect(AF_UNIX)` to a live listener whose accept backlog is full waits
+for an `accept()` — potentially forever. A wedged X server (precisely the
+case where the DM restarts us), or a hostile local user's never-accepting
+listener in the world-writable socket dir, must not hang the launch.
+Nonblocking errno mapping: success/`EINPROGRESS` ⇒ live; **`EAGAIN` ⇒
+backlog full ⇒ live** (the display *is* occupied); `ECONNREFUSED` ⇒
+stale; anything else ⇒ opaque/refuse-to-touch. Implemented as one shared
+`probe()` classifier returning {Free, Live, Stale, NonSocket, Opaque} so
+the explicit (refuse) and auto-pick (skip) policies stay visibly separate
+while the errno subtleties exist once.
+
 - **Explicit display** and **back-compat default**: acquire the lockfile
   (component 2b, when the table says so), then probe any existing path:
   non-socket ⇒ refuse; `connect()` succeeds ⇒ a live server owns the

--- a/docs/superpowers/specs/2026-06-12-lightdm-launch-design.md
+++ b/docs/superpowers/specs/2026-06-12-lightdm-launch-design.md
@@ -197,8 +197,8 @@ count; documented here so it isn't mistaken for parity with Xorg.
 **Required for interop** — lightdm (and other launchers) test
 `/tmp/.X<N>-lock`, not the socket, to decide whether a display is free.
 For the locked cases (`-displayfd` absent — see the table above), we
-implement Xorg's exact lock protocol (`os/utils.c:258-380`) **before**
-binding the socket. Create is done via a temp file + atomic `link()`, not
+implement Xorg's lock protocol (`os/utils.c:258-380`), with minor
+cleanups, **before** binding the socket. Create is done via a temp file + atomic `link()`, not
 a direct `O_EXCL`, so a partially-written or empty final lock is never
 observable by a concurrent launcher:
 

--- a/docs/superpowers/specs/2026-06-12-lightdm-launch-design.md
+++ b/docs/superpowers/specs/2026-06-12-lightdm-launch-design.md
@@ -171,8 +171,14 @@ lockfile column is implemented by component 2b below.
 Binding per case:
 
 - **Explicit display** and **back-compat default**: acquire the lockfile
-  (component 2b), then keep the current "remove stale socket, then bind"
-  behavior.
+  (component 2b, when the table says so), then **probe** any existing
+  socket before removing it: `connect()` succeeds ⇒ a live server owns the
+  display ⇒ hard error (`AddrInUse`) — never steal it (old yservers take
+  no lock, so holding the lock alone doesn't prove the display free);
+  `ECONNREFUSED` ⇒ stale ⇒ remove + bind; any other probe error ⇒ refuse
+  conservatively rather than delete something unidentified. (Behavior
+  change vs. the old inline code, which removed the socket
+  unconditionally.)
 - **Auto-pick**: scan `/tmp/.X11-unix/Xk` for `k` in `0..256` and bind the
   lowest free one. For an existing socket file, `connect()` first to
   disambiguate:
@@ -202,13 +208,20 @@ cleanups, **before** binding the socket. Create is done via a temp file + atomic
 a direct `O_EXCL`, so a partially-written or empty final lock is never
 observable by a concurrent launcher:
 
-1. Write PID `"%10d\n"` (11 bytes) into `/tmp/.tX<N>-lock`, `chmod 0444`,
-   then `link()` it to `/tmp/.X<N>-lock` and `unlink` the temp file. A
-   successful `link()` is the atomic "we won" signal.
+1. Write PID `"%10d\n"` (11 bytes) into a **PID-suffixed** temp file
+   `/tmp/.tX<N>-lock.<pid>`, `chmod 0444`, then `link()` it to
+   `/tmp/.X<N>-lock` and `unlink` the temp file. A successful `link()` is
+   the atomic "we won" signal. (Deviation from Xorg's fixed `.tX<N>-lock`
+   temp name: with a fixed name two concurrent starters can clobber each
+   other's temp before the `link()`, letting the winner publish a lock
+   holding the *loser's* PID; the PID suffix makes each starter's temp
+   unique. A crash can orphan one 11-byte temp file — harmless.)
 2. If `link()` fails with `EEXIST`, inspect the existing lock — opened
    `O_RDONLY | O_NOFOLLOW` (refuse to follow a symlink):
-   - **Malformed / short / non-numeric** contents ⇒ treat as bogus ⇒
-     remove and retry the link once.
+   - **Malformed contents** (not exactly 11 bytes ending in `\n`, or a
+     non-positive/non-numeric PID field) ⇒ treat as bogus ⇒ remove and
+     retry the link once. A genuine *read error* propagates instead —
+     never delete a lock that couldn't actually be inspected.
    - Parse the PID and `kill(pid, 0)`:
      - success **or `EPERM`** ⇒ process alive (a live server owned by
        another user still counts) ⇒ display in use ⇒ for explicit `:N`,
@@ -301,16 +314,22 @@ build options → call `run`.
   unknown-flag tolerance; arg-consuming flags; malformed-explicit errors;
   missing-value errors.
 - **Display auto-pick:** tempdir-based test of the scan / stale-socket /
-  live-socket logic plus the `EADDRINUSE` bind-race retry and the
-  "non-`ECONNREFUSED` ⇒ skip, don't delete" branch (create dummy socket
-  files and a live listener).
+  live-socket logic and the "non-`ECONNREFUSED` ⇒ skip, don't delete"
+  branch (a regular file named `Xk` exercises it via `ENOTSOCK`). The
+  `EADDRINUSE` bind-race `continue` branch cannot be hit deterministically
+  in a unit test (it needs a socket to appear between the existence check
+  and the `bind()`) — verified by inspection.
+- **Explicit bind:** live socket refused (`AddrInUse`), stale socket
+  reclaimed, chmod 0777 applied.
 - **Lockfile protocol:** tempdir-based test of the temp-file + atomic
   `link()` create; the stale-lock (`kill(pid,0)` → `ESRCH`)
   remove-and-retry path; the live-lock collision (hard error for explicit
-  `:N`); malformed/short lock contents treated as bogus + reclaimed; and
-  the error-path release (lock removed when a simulated bind failure
-  follows acquisition). Cleanup ordering (socket-then-lock) is asserted by
-  checking the lock outlives the socket during teardown.
+  `:N`); malformed (non-11-byte / short-numeric / non-numeric) lock
+  contents treated as bogus + reclaimed; and the error-path release (lock
+  removed when a bind failure follows acquisition — `?` drops the guard).
+  Cleanup ordering (socket-then-lock) follows from code structure (the
+  guard is dropped at end-of-`run()`, after the socket `remove_file`) and
+  is observed in the HW smoke's restart-cycle check.
 - **`write_displayfd`:** unit-test via a `pipe()` — write to the write
   end, assert `"<N>\n"` on the read end.
 - **SIGUSR1-disposition path:** not unit-testable (process-global signal

--- a/docs/superpowers/specs/2026-06-12-xinerama-design.md
+++ b/docs/superpowers/specs/2026-06-12-xinerama-design.md
@@ -2,7 +2,14 @@
 
 **Date:** 2026-06-12
 **Branch:** `feat/lightdm-launch` (XINERAMA is a ship-blocker for usable multi-head DM sessions)
-**Reference:** `/usr/include/X11/extensions/panoramiXproto.h`; Xorg `Xext/panoramiX.c` / `Xext/xvmc`… (PanoramiX/Xinerama dispatch)
+**Reference:** `/usr/include/X11/extensions/panoramiXproto.h` (wire format); Xorg
+`randr/rrxinerama.c` (the **RANDR-backed** Xinerama implementation — registered
+by `RRXineramaExtensionInit`, `randr/randr.c:449`). Mirror *that*, not the
+legacy full-PanoramiX path (`Xext/panoramiX.c`), since yserver is RANDR-backed:
+`ProcRRXineramaIsActive` reports active when monitor count > 0
+(`rrxinerama.c:159`), `QueryScreens` returns RANDR monitor rects
+(`rrxinerama.c:274`), and all requests use `REQUEST_SIZE_MATCH` + validate the
+window via `dixLookupWindow`.
 
 ## Goal
 
@@ -126,32 +133,66 @@ XINERAMA_MAJOR_OPCODE => handle_xinerama_request(state, client_id, sequence, hea
 ### 4. `handle_xinerama_request`
 
 Matches `header.data` (the minor opcode) over the six requests. Builds the
-screen list **from the same `state.randr.outputs` the RANDR monitor path uses**
-(same order, primary first), mapping each to `ScreenInfo { x_org: o.x, y_org:
-o.y, width: o.width, height: o.height }`.
+screen list from the **shared monitor-list helper** (see below), mapping each to
+`ScreenInfo { x_org: o.x, y_org: o.y, width: o.width, height: o.height }`.
 
-- `QueryVersion` → `encode_query_version_reply`.
-- `GetState` → `encode_get_state_reply(active = !screens.is_empty(), window = req.window)`.
-- `GetScreenCount` → `encode_get_screen_count_reply(count = screens.len(), window = req.window)`.
-- `GetScreenSize` → if `req.screen < screens.len()`: reply with that screen's
-  width/height (+ echoed window/screen); else **BadValue** (Xorg behavior).
+All six requests are fixed-size: validate length with `REQUEST_SIZE_MATCH`
+semantics — **any** size mismatch (too short *or* too long) → `BadLength`
+(`rrxinerama.c` uses `REQUEST_SIZE_MATCH` for all six). The three windowed
+requests (`GetState`, `GetScreenCount`, `GetScreenSize`) carry a `window` and
+must **validate it** (`dixLookupWindow` equivalent — yserver's window lookup);
+an invalid window → `BadWindow` (`rrxinerama.c:124,172,202`).
+
+- `QueryVersion` → `encode_query_version_reply` (major=1, minor=1).
+- `GetState` → validate `window`; `encode_get_state_reply(active = !screens.is_empty(), window)`.
+- `GetScreenCount` → validate `window`; `encode_get_screen_count_reply(count = screens.len(), window)`.
+- `GetScreenSize` → validate `window`; reply with the **root/virtual-screen**
+  width/height (the full bounding size, not the per-monitor size), echoing the
+  requested `window` and `screen`. **No bounds-check on `screen`** — Xorg's
+  RANDR-backed path returns the root drawable size regardless of the screen
+  index and does *not* error (`rrxinerama.c:202,210`). (This is a deliberate
+  match to `rrxinerama.c`, replacing an earlier draft that wrongly returned
+  per-screen size + `BadValue` — that was legacy full-PanoramiX behavior, not
+  the RANDR path yserver mirrors.)
 - `IsActive` → `encode_is_active_reply(active = !screens.is_empty())`.
 - `QueryScreens` → `encode_query_screens_reply(&screens)`.
 - Unknown minor opcode → **BadRequest** (X convention for an extension's
   unknown minor).
 
-**IsActive / GetState `active` = true whenever ≥1 output** — so clients use
-`QueryScreens` (the matching-count path) rather than the single-screen fallback
-that crashes. Single-head → 1 screen, active=true, harmless (the one screen is
-the whole display).
+**IsActive / GetState `active` = true whenever ≥1 monitor** (`rrxinerama.c:159`
+reports active when monitor count > 0) — so clients use `QueryScreens` (the
+matching-count path) rather than the single-screen fallback that crashes.
+Single-head → 1 screen, active=true, harmless (the one screen is the whole
+display).
+
+### 5. Shared monitor-list helper (enforces the invariant mechanically)
+
+To make the load-bearing invariant (XINERAMA screen count == RANDR monitor
+count) **impossible to break by future drift**, extract the monitor-list
+construction `RR_GET_MONITORS` currently does inline (`process_request.rs:2290`)
+into one helper, and have **both** `RR_GET_MONITORS` and XINERAMA `QueryScreens`
+/ `GetScreenCount` call it:
+
+```rust
+/// The active monitor list — the single source of truth for both
+/// RANDR GetMonitors and XINERAMA. Order: primary first (index 0).
+fn active_monitors(state: &ServerState) -> Vec<MonitorRect> { /* from state.randr.outputs */ }
+```
+
+Xorg does exactly this: `RRGetMonitors` and `RRXineramaQueryScreens` share
+`RRMonitorMakeList` (`rrmonitor.c:600`, `rrxinerama.c:284`). If any
+enabled/disconnected filtering is later added, it lands in the one helper and
+both sides stay consistent — the crash can't silently return.
 
 ## Error handling
 
 | Condition | Response |
 |-----------|----------|
-| `GetScreenSize` screen index ≥ N | `BadValue` |
+| Request size mismatch (short *or* long) — all 6 are fixed-size | `BadLength` (`REQUEST_SIZE_MATCH`) |
+| Invalid `window` on `GetState`/`GetScreenCount`/`GetScreenSize` | `BadWindow` |
 | Unknown minor opcode | `BadRequest` |
-| Truncated request body | `BadLength` (consistent with other handlers) |
+
+(`GetScreenSize` does **not** bounds-check the screen index — see component 4.)
 
 ## Testing
 
@@ -159,11 +200,15 @@ the whole display).
   `panoramiXproto.h`. Critically a **2-screen `QueryScreens`**: `length == 4`
   (N*2), `number == 2`, and the two 8-byte `ScreenInfo` records for DP-1 @ (0,0)
   2560×1440 and HDMI-A-1 @ (2560,0) 2560×1440.
-- **Invariant test:** for a given `state.randr.outputs`, the XINERAMA screen
-  count equals the `RR_GET_MONITORS` monitor count (guards the load-bearing
-  property against future drift).
-- **`GetScreenSize` bounds:** in-range returns the right size; out-of-range →
-  `BadValue`.
+- **Invariant test:** XINERAMA `QueryScreens` and `RR_GET_MONITORS` both call
+  the shared `active_monitors` helper, so their counts are equal *by
+  construction*; a test asserts both reply with the same N for a multi-output
+  `state.randr.outputs` (guards against any future one-sided filtering).
+- **`GetScreenSize`:** returns the root/virtual-screen size and echoes the
+  requested `window`/`screen` for any in-bounds-or-not screen index (no
+  `BadValue`); an invalid `window` → `BadWindow`.
+- **Length/window validation:** an over-long or truncated request → `BadLength`;
+  `GetState`/`GetScreenCount`/`GetScreenSize` with a bogus window → `BadWindow`.
 - **Dispatch/QueryExtension:** `QueryExtension("XINERAMA")` reports present with
   the major opcode; an unknown minor → `BadRequest`.
 - **HW smoke (the real gate):** dual-head Cinnamon under lightdm on silence —

--- a/docs/superpowers/specs/2026-06-12-xinerama-design.md
+++ b/docs/superpowers/specs/2026-06-12-xinerama-design.md
@@ -55,7 +55,7 @@ may use it):
 | 0 | `PanoramiXQueryVersion` | server version (1.1) |
 | 1 | `PanoramiXGetState` | active flag + echoed window |
 | 2 | `PanoramiXGetScreenCount` | N + echoed window |
-| 3 | `PanoramiXGetScreenSize` | width/height of screen *i* + echoed window/screen |
+| 3 | `PanoramiXGetScreenSize` | root/virtual-screen width/height + echoed window/screen |
 | 4 | `XineramaIsActive` | active flag (CARD32) |
 | 5 | `XineramaQueryScreens` | N screen rects |
 
@@ -144,7 +144,11 @@ must **validate it** (`dixLookupWindow` equivalent — yserver's window lookup);
 an invalid window → `BadWindow` (`rrxinerama.c:124,172,202`).
 
 - `QueryVersion` → `encode_query_version_reply` (major=1, minor=1).
-- `GetState` → validate `window`; `encode_get_state_reply(active = !screens.is_empty(), window)`.
+- `GetState` → validate `window`; `encode_get_state_reply(active = true, window)`.
+  Xorg's `PanoramiXGetState` returns true whenever the RANDR screen-private
+  exists — i.e. **independent of monitor count** (`rrxinerama.c:129-134`) — and
+  yserver always has RANDR, so this is unconditionally `true`. (Distinct from
+  `IsActive` below, which *is* the monitor-count path.)
 - `GetScreenCount` → validate `window`; `encode_get_screen_count_reply(count = screens.len(), window)`.
 - `GetScreenSize` → validate `window`; reply with the **root/virtual-screen**
   width/height (the full bounding size, not the per-monitor size), echoing the
@@ -159,11 +163,11 @@ an invalid window → `BadWindow` (`rrxinerama.c:124,172,202`).
 - Unknown minor opcode → **BadRequest** (X convention for an extension's
   unknown minor).
 
-**IsActive / GetState `active` = true whenever ≥1 monitor** (`rrxinerama.c:159`
-reports active when monitor count > 0) — so clients use `QueryScreens` (the
-matching-count path) rather than the single-screen fallback that crashes.
-Single-head → 1 screen, active=true, harmless (the one screen is the whole
-display).
+**`IsActive` = true whenever ≥1 monitor** (`rrxinerama.c:238` reports active
+when monitor count > 0) — so clients use `QueryScreens` (the matching-count
+path) rather than the single-screen fallback that crashes. Single-head → 1
+screen, IsActive=true, harmless (the one screen is the whole display).
+(`GetState` is the separate "RANDR present?" flag above — always true here.)
 
 ### 5. Shared monitor-list helper (enforces the invariant mechanically)
 

--- a/docs/superpowers/specs/2026-06-12-xinerama-design.md
+++ b/docs/superpowers/specs/2026-06-12-xinerama-design.md
@@ -1,0 +1,190 @@
+# XINERAMA extension — multi-head support (fixes muffin/mutter crash)
+
+**Date:** 2026-06-12
+**Branch:** `feat/lightdm-launch` (XINERAMA is a ship-blocker for usable multi-head DM sessions)
+**Reference:** `/usr/include/X11/extensions/panoramiXproto.h`; Xorg `Xext/panoramiX.c` / `Xext/xvmc`… (PanoramiX/Xinerama dispatch)
+
+## Goal
+
+Implement the **XINERAMA** X extension so multi-head window managers (muffin/
+mutter, and others) see **one Xinerama screen per RANDR monitor**, eliminating
+a NULL-deref crash and giving correct multi-monitor layout.
+
+## Root cause (confirmed on hardware, silence, 2026-06-12)
+
+yserver advertises **RANDR** (reports *N* monitors via `RR_GET_MONITORS`) but
+implements **no XINERAMA**. mutter/muffin, when `XineramaIsActive()` is false,
+builds its **logical monitor** list from RANDR (*N* entries) but collapses its
+**xinerama** list to a single synthesized screen. Mapping logical monitor #1
+(the second head) then does:
+
+```
+meta_display_logical_index_to_xinerama_index(1)
+  → g_list_nth(xinerama_list /* len 1 */, 1) → NULL
+  → mov (%rax),%rbx on NULL → SIGSEGV     (libmuffin.so, ~11s after start)
+```
+
+Proven by: **single-head works, dual-head crashes, same binary.** Real Xorg
+derives Xinerama from its monitors, so its xinerama list always matches its
+monitor count — no overrun. The fix is to give yserver the same property.
+
+## The load-bearing invariant
+
+**Xinerama screen count MUST equal the RANDR monitor count, always.** The two
+must be sourced from the *same* data so they can never disagree. yserver builds
+RANDR monitors from `state.randr.outputs` (1:1, primary = index 0, in
+`RR_GET_MONITORS` at `process_request.rs:2290`). XINERAMA `QueryScreens` MUST
+source from that **same list, same order**. This invariant — not any single
+reply field — is what prevents the crash.
+
+## Scope
+
+Implement **all six** PanoramiX/XINERAMA requests (no stubs — yserver's standing
+rule, and the legacy PanoramiX trio predates the `Xinerama*` calls so older WMs
+may use it):
+
+| # | Request | Reply |
+|---|---------|-------|
+| 0 | `PanoramiXQueryVersion` | server version (1.1) |
+| 1 | `PanoramiXGetState` | active flag + echoed window |
+| 2 | `PanoramiXGetScreenCount` | N + echoed window |
+| 3 | `PanoramiXGetScreenSize` | width/height of screen *i* + echoed window/screen |
+| 4 | `XineramaIsActive` | active flag (CARD32) |
+| 5 | `XineramaQueryScreens` | N screen rects |
+
+No events, no errors of its own (`first_event = event_count = first_error = 0`),
+no per-client state, no state mutation — entirely read-only over
+`state.randr.outputs`. This is among the simplest X extensions.
+
+## Components
+
+### 1. `crates/yserver-protocol/src/x11/xinerama.rs` (new)
+
+Pure wire layer, mirroring `randr.rs`. Constants + encoders, unit-tested against
+the `panoramiXproto.h` byte layouts. All replies are the **32-byte fixed reply
+header**; only `QueryScreens` appends `N × 8` bytes.
+
+```rust
+pub const MAJOR_VERSION: u16 = 1;
+pub const MINOR_VERSION: u16 = 1;
+
+// minor opcodes
+pub const QUERY_VERSION: u8 = 0;
+pub const GET_STATE: u8 = 1;
+pub const GET_SCREEN_COUNT: u8 = 2;
+pub const GET_SCREEN_SIZE: u8 = 3;
+pub const IS_ACTIVE: u8 = 4;
+pub const QUERY_SCREENS: u8 = 5;
+
+/// One Xinerama screen (wire: x_org i16, y_org i16, width u16, height u16).
+pub struct ScreenInfo { pub x_org: i16, pub y_org: i16, pub width: u16, pub height: u16 }
+
+pub fn encode_query_version_reply(bo, seq) -> Vec<u8>;        // major=1, minor=1
+pub fn encode_get_state_reply(bo, seq, state: bool, window: u32) -> Vec<u8>;
+pub fn encode_get_screen_count_reply(bo, seq, count: u8, window: u32) -> Vec<u8>;
+pub fn encode_get_screen_size_reply(bo, seq, width: u32, height: u32, window: u32, screen: u32) -> Vec<u8>;
+pub fn encode_is_active_reply(bo, seq, active: bool) -> Vec<u8>;
+pub fn encode_query_screens_reply(bo, seq, screens: &[ScreenInfo]) -> Vec<u8>;
+```
+
+**Exact reply layouts** (all 32 bytes unless noted; `length` is in 4-byte words
+of data *beyond* the 32-byte header):
+
+- **QueryVersion**: `[1, pad, seq(2), len=0(4), major u16=1, minor u16=1, pad×20]`
+- **GetState**: `[1, state u8, seq(2), len=0(4), window u32, pad×20]` — note `state` rides in **byte 1** (the pad1 slot), per `xPanoramiXGetStateReply`.
+- **GetScreenCount**: `[1, ScreenCount u8, seq(2), len=0(4), window u32, pad×20]` — count in **byte 1**.
+- **GetScreenSize**: `[1, pad, seq(2), len=0(4), width u32, height u32, window u32, screen u32, pad×8]`
+- **IsActive**: `[1, pad, seq(2), len=0(4), state u32, pad×20]`
+- **QueryScreens**: `[1, pad, seq(2), len = N*2 (4), number u32 = N, pad×20]` then `N × {x_org i16, y_org i16, width u16, height u16}`.
+
+### 2. `nested::EXTENSIONS` entry
+
+```rust
+ExtensionMetadata {
+    name: "XINERAMA",
+    major_opcode: XINERAMA_MAJOR_OPCODE,   // = 151 (strictly above all
+                                           // assigned opcodes; current max is
+                                           // MIT-SCREEN-SAVER = 150). Arbitrary
+                                           // but unique — clients learn it via
+                                           // QueryExtension.
+    first_event: 0, event_count: 0, first_error: 0,
+    availability: ExtensionAvailability::Always,
+    unsupported_minor_policy: UnsupportedMinorPolicy::HandledInline,
+}
+```
+
+Makes `QueryExtension("XINERAMA")` report present with the major opcode, so
+libXinerama (`XineramaQueryExtension`) succeeds and clients proceed to the
+`Xinerama*` calls.
+
+### 3. Dispatch arm — `process_request.rs:200` `match header.opcode`
+
+```rust
+XINERAMA_MAJOR_OPCODE => handle_xinerama_request(state, client_id, sequence, header, body),
+```
+
+### 4. `handle_xinerama_request`
+
+Matches `header.data` (the minor opcode) over the six requests. Builds the
+screen list **from the same `state.randr.outputs` the RANDR monitor path uses**
+(same order, primary first), mapping each to `ScreenInfo { x_org: o.x, y_org:
+o.y, width: o.width, height: o.height }`.
+
+- `QueryVersion` → `encode_query_version_reply`.
+- `GetState` → `encode_get_state_reply(active = !screens.is_empty(), window = req.window)`.
+- `GetScreenCount` → `encode_get_screen_count_reply(count = screens.len(), window = req.window)`.
+- `GetScreenSize` → if `req.screen < screens.len()`: reply with that screen's
+  width/height (+ echoed window/screen); else **BadValue** (Xorg behavior).
+- `IsActive` → `encode_is_active_reply(active = !screens.is_empty())`.
+- `QueryScreens` → `encode_query_screens_reply(&screens)`.
+- Unknown minor opcode → **BadRequest** (X convention for an extension's
+  unknown minor).
+
+**IsActive / GetState `active` = true whenever ≥1 output** — so clients use
+`QueryScreens` (the matching-count path) rather than the single-screen fallback
+that crashes. Single-head → 1 screen, active=true, harmless (the one screen is
+the whole display).
+
+## Error handling
+
+| Condition | Response |
+|-----------|----------|
+| `GetScreenSize` screen index ≥ N | `BadValue` |
+| Unknown minor opcode | `BadRequest` |
+| Truncated request body | `BadLength` (consistent with other handlers) |
+
+## Testing
+
+- **Unit (wire encoders):** one per reply, asserting exact bytes vs
+  `panoramiXproto.h`. Critically a **2-screen `QueryScreens`**: `length == 4`
+  (N*2), `number == 2`, and the two 8-byte `ScreenInfo` records for DP-1 @ (0,0)
+  2560×1440 and HDMI-A-1 @ (2560,0) 2560×1440.
+- **Invariant test:** for a given `state.randr.outputs`, the XINERAMA screen
+  count equals the `RR_GET_MONITORS` monitor count (guards the load-bearing
+  property against future drift).
+- **`GetScreenSize` bounds:** in-range returns the right size; out-of-range →
+  `BadValue`.
+- **Dispatch/QueryExtension:** `QueryExtension("XINERAMA")` reports present with
+  the major opcode; an unknown minor → `BadRequest`.
+- **HW smoke (the real gate):** dual-head Cinnamon under lightdm on silence —
+  no longer crashes; `xdpyinfo -ext XINERAMA` reports **2** screens with the
+  correct rects; `xrandr` still shows 2 monitors. Per repo practice, the
+  display-path change isn't done until observed on hardware.
+
+## Risk / open validation
+
+The crash mechanism (count mismatch) is proven, and matching the counts is the
+established Xorg fix. The one thing only HW confirms: that mutter actually
+consumes `IsActive=true` + `QueryScreens=N` to build *N* xinerama entries (vs.
+still synthesizing one). If it still crashes after this, the next step is to
+trace whether this mutter build reads the X **XINERAMA** extension vs. its own
+RANDR-monitor list for the xinerama mapping — but the crash function name
+(`..._to_xinerama_index`) and Xorg's own XINERAMA-from-RANDR glue both point
+squarely here.
+
+## Out of scope
+
+- Runtime display hotplug (separate — GH #9).
+- VT switching under the DM (separate, also landing on this branch).
+- RANDR 1.5 "monitor" objects that span multiple outputs (yserver maps monitors
+  1:1 to outputs today; XINERAMA follows that same mapping).

--- a/tools/yserver-lightdm.sh
+++ b/tools/yserver-lightdm.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# lightdm launches this as its X server (xserver-command). lightdm appends
+# X-style argv (:N -seat seatN -auth FILE -nolisten tcp vtN -novtswitch),
+# which yserver parses natively (see crates/yserver/src/launch.rs). This
+# wrapper only adds logging + backtraces; it execs yserver so the SIGUSR1
+# readiness handshake reaches lightdm (the real parent), not a shell.
+exec env RUST_LOG="${YSERVER_LOG:-info}" RUST_BACKTRACE=1 \
+    /usr/local/bin/yserver "$@" 2>>/var/log/yserver-lightdm.log


### PR DESCRIPTION
Closes #6 (items 1–3). Lets a display manager (lightdm) launch yserver as its X server, and fixes multi-head so a real desktop survives.

## What's in

**Launch (issue #6 items 1–3)** — `crates/yserver/src/launch.rs`:
- X-server-style argv parsing: `:N` / bare `N`, `vtN`, `-seat`, `-auth`, `-nolisten`, `-displayfd`, tolerate-the-rest.
- Display resolution + the X `/tmp/.X<N>-lock` lockfile protocol (temp + atomic `link`, stale reclaim, umask-immune 0444) — lightdm checks the lock, not the socket.
- Socket binding (explicit + auto-pick) with a non-blocking occupancy probe (a wedged/backlogged listener can't hang the launch).
- Readiness handshake: `-displayfd` write + SIGUSR1-to-parent (parent PID captured at startup, à la Xorg `InitParentProcess`).

**XINERAMA** — `crates/yserver-protocol/src/x11/xinerama.rs` + handler:
- Implements all 6 PanoramiX/Xinerama requests, RANDR-backed (mirrors Xorg `rrxinerama.c`).
- Screens come from a shared `active_monitors()` helper that RANDR `GetMonitors` also uses, so the Xinerama screen count always equals the RANDR monitor count — the invariant that fixes a muffin/mutter NULL-deref crash on dual-head.

**Packaging** — `just install` + README "Use with a display manager" section.

## Validated
- HW: dual-head Cinnamon via lightdm on silence (AMD/RADV) — greeter, login, full session, keyring unlocked, **no crash**.
- 736 core + 279 protocol tests pass; `cargo fmt` + `clippy` clean.
- Specs/plans (codex-reviewed to convergence) under `docs/superpowers/`.

## Deferred (tracked)
- VT switching under a DM is **not** supported yet (#10) — yserver runs rootful without a logind session there, so libseat can't drive VT control. Documented as a known limitation.
- Runtime display hotplug (#9).
- MIT-MAGIC-COOKIE-1 auth enforcement (issue #6 item 4) — yserver currently accepts local clients (tolerates the presented cookie).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
