### PR TITLE
Implement XC-MISC extension — fix silent client death from XID-range exhaustion

### DIFF
--- a/crates/yserver-core/src/core_loop/process_request.rs
+++ b/crates/yserver-core/src/core_loop/process_request.rs
@@ -23369,7 +23369,56 @@ fn handle_xcmisc_request(
             };
             Ok(write_to_client(client, client_id, &buf))
         }
-        // GetXIDList — Task 5.
+        // GetXIDList — req 8 bytes: count(4).
+        2 => {
+            if body.len() != 4 {
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    x11::error::BAD_LENGTH,
+                    0,
+                    u16::from(minor),
+                    header.opcode,
+                );
+            }
+            let want = u32::from_le_bytes([body[0], body[1], body[2], body[3]]);
+            let Some((base, mask)) = state
+                .clients
+                .get(&client_id.0)
+                .map(|c| (c.resource_id_base, c.resource_id_mask))
+            else {
+                return Ok(RequestOutcome::Handled);
+            };
+            // Clamp to the range size — never allocate
+            // client-controlled gigabytes (explicit Xorg deviation,
+            // spec "Edge cases"; Xorg would BadAlloc instead).
+            let limit = u64::from(want).min(u64::from(mask) + 1);
+            let mut ids: Vec<u32> = Vec::new();
+            let lo = base.max(1);
+            let hi = base | mask;
+            let mut id = lo;
+            while ids.len() < limit as usize {
+                if !state.xid_occupied(id) {
+                    ids.push(id);
+                }
+                if id == hi {
+                    break;
+                }
+                id += 1;
+            }
+            log::info!(
+                "client {} XC-MISC GetXIDList want={want} → {} ids",
+                client_id.0,
+                ids.len(),
+            );
+            let mut buf: Vec<u8> = Vec::with_capacity(32 + ids.len() * 4);
+            x11::write_xcmisc_get_xid_list_reply(&mut buf, byte_order, sequence, &ids)?;
+            let Some(client) = state.clients.get_mut(&client_id.0) else {
+                return Ok(RequestOutcome::Handled);
+            };
+            Ok(write_to_client(client, client_id, &buf))
+        }
         other => emit_x11_error_with_minor(
             state,
             client_id,
@@ -41146,6 +41195,55 @@ mod tests {
         assert_eq!(count, 0x000F_FFFF - 4 + 1);
         // Wrong length → BadLength.
         send_xcmisc(&mut state, &mut backend, 2, 1, &[0u8; 4]);
+        let bytes = read_all_available(&mut peer);
+        assert_eq!(bytes[1], x11::error::BAD_LENGTH);
+    }
+
+    #[test]
+    fn xcmisc_get_xid_list_returns_free_ids() {
+        let mut state = ServerState::new();
+        let mut peer = install_client(&mut state, 1);
+        let mut backend = RecordingBackend::new();
+        {
+            let c = state.clients.get_mut(&1).unwrap();
+            c.resource_id_base = 0x0010_0000;
+            c.resource_id_mask = 0x000F_FFFF;
+        }
+        // Occupy ids 0,2 in the range; ask for 4 ids.
+        state
+            .resources
+            .create_cursor(ClientId(1), ResourceId(0x0010_0000));
+        state
+            .resources
+            .create_cursor(ClientId(1), ResourceId(0x0010_0002));
+        send_xcmisc(&mut state, &mut backend, 1, 2, &4u32.to_le_bytes());
+        let bytes = read_all_available(&mut peer);
+        assert_eq!(bytes.len(), 32 + 16, "32 header + 4 ids");
+        let count = u32::from_le_bytes(bytes[8..12].try_into().unwrap());
+        assert_eq!(count, 4);
+        let length = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
+        assert_eq!(length, 4, "reply length in words = id count");
+        let ids: Vec<u32> = bytes[32..]
+            .chunks_exact(4)
+            .map(|c| u32::from_le_bytes(c.try_into().unwrap()))
+            .collect();
+        assert_eq!(
+            ids,
+            vec![0x0010_0001, 0x0010_0003, 0x0010_0004, 0x0010_0005],
+            "skips occupied 0x...0 and 0x...2"
+        );
+        // Huge count is clamped to the RANGE size, not allocated. Shrink
+        // the client's range first so the reply stays ~1 KiB — a 1M-id
+        // reply would block the test's unread socketpair (write_or_buffer
+        // does a synchronous write; OUTBOUND_CAP would trip the
+        // disconnect path).
+        state.clients.get_mut(&1).unwrap().resource_id_mask = 0xFF;
+        send_xcmisc(&mut state, &mut backend, 2, 2, &u32::MAX.to_le_bytes());
+        let bytes = read_all_available(&mut peer);
+        let count = u32::from_le_bytes(bytes[8..12].try_into().unwrap());
+        assert_eq!(count, 0x100 - 2, "256-id range minus 2 occupied");
+        // BadLength on wrong size.
+        send_xcmisc(&mut state, &mut backend, 3, 2, &[]);
         let bytes = read_all_available(&mut peer);
         assert_eq!(bytes[1], x11::error::BAD_LENGTH);
     }

--- a/crates/yserver-core/src/core_loop/process_request.rs
+++ b/crates/yserver-core/src/core_loop/process_request.rs
@@ -23225,6 +23225,77 @@ fn emit_xi2_device_changed_bootstrap(
     Ok(())
 }
 
+/// Largest contiguous free run in `[max(base,1) .. base|mask]`,
+/// given the SORTED+DEDUPED occupied ids in that range. Returns
+/// Xorg's exact exhaustion wire shape `(0, 1)` when nothing is free
+/// (dix/resource.c:733-737 zeroes min/max; the reply encodes
+/// max-min+1 = 1; libxcb treats start 0 as exhausted). Largest-gap
+/// is an implementation choice — the protocol promises only "a
+/// contiguous range of unused IDs" (spec "GetXIDRange algorithm").
+fn largest_free_xid_gap(base: u32, mask: u32, used_sorted: &[u32]) -> (u32, u32) {
+    let lo = base.max(1); // XID 0 is never allocatable
+    let hi = base | mask;
+    let mut best_start = 0u32;
+    let mut best_len = 0u64;
+    let mut cursor = lo;
+    for &u in used_sorted {
+        if u < lo {
+            continue;
+        }
+        if u > hi {
+            break;
+        }
+        if u > cursor {
+            let len = u64::from(u - cursor);
+            if len > best_len {
+                best_len = len;
+                best_start = cursor;
+            }
+        }
+        cursor = cursor.max(u.saturating_add(1));
+    }
+    if cursor <= hi {
+        let len = u64::from(hi - cursor) + 1;
+        if len > best_len {
+            best_len = len;
+            best_start = cursor;
+        }
+    }
+    if best_len == 0 {
+        (0, 1)
+    } else {
+        #[allow(clippy::cast_possible_truncation)]
+        (best_start, best_len as u32) // len ≤ mask+1 ≤ u32 range
+    }
+}
+
+#[cfg(test)]
+mod largest_free_xid_gap_tests {
+    use super::largest_free_xid_gap;
+
+    #[test]
+    fn largest_free_xid_gap_cases() {
+        let base = 0x0010_0000u32;
+        let mask = 0x000F_FFFFu32;
+        let hi = base | mask;
+        // empty range → whole range (lo = base since base != 0)
+        assert_eq!(largest_free_xid_gap(base, mask, &[]), (base, mask + 1));
+        // one used id at the start → gap after it
+        assert_eq!(largest_free_xid_gap(base, mask, &[base]), (base + 1, mask));
+        // split: small gap low, big gap high → picks the big one
+        let used: Vec<u32> = (base..base + 10).chain([base + 12]).collect();
+        assert_eq!(
+            largest_free_xid_gap(base, mask, &used),
+            (base + 13, hi - (base + 13) + 1)
+        );
+        // fully exhausted → Xorg wire shape (0, 1)
+        let all: Vec<u32> = (base..=hi).collect(); // NOTE: 1M entries — fine in a test
+        assert_eq!(largest_free_xid_gap(base, mask, &all), (0, 1));
+        // base 0 (hypothetical) excludes XID 0
+        assert_eq!(largest_free_xid_gap(0, 0xFF, &[]), (1, 0xFF));
+    }
+}
+
 /// XC-MISC (major opcode 152) — XID recycling for long-lived clients.
 /// Spec docs/superpowers/specs/2026-06-12-xcmisc-design.md; Xorg ref
 /// Xext/xcmisc.c. Length validation lives here because the top-level
@@ -23263,7 +23334,42 @@ fn handle_xcmisc_request(
             };
             Ok(write_to_client(client, client_id, &buf))
         }
-        // GetXIDRange / GetXIDList — Tasks 4 and 5.
+        // GetXIDRange — req 4 bytes (header only).
+        1 => {
+            if !body.is_empty() {
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    x11::error::BAD_LENGTH,
+                    0,
+                    u16::from(minor),
+                    header.opcode,
+                );
+            }
+            let Some((base, mask)) = state
+                .clients
+                .get(&client_id.0)
+                .map(|c| (c.resource_id_base, c.resource_id_mask))
+            else {
+                return Ok(RequestOutcome::Handled);
+            };
+            let used = state.used_xids_in(base, mask);
+            let (start_id, count) = largest_free_xid_gap(base, mask, &used);
+            log::info!(
+                "client {} XC-MISC GetXIDRange → start=0x{start_id:x} count={count} \
+                 ({} ids in use)",
+                client_id.0,
+                used.len(),
+            );
+            let mut buf: Vec<u8> = Vec::with_capacity(32);
+            x11::write_xcmisc_get_xid_range_reply(&mut buf, byte_order, sequence, start_id, count)?;
+            let Some(client) = state.clients.get_mut(&client_id.0) else {
+                return Ok(RequestOutcome::Handled);
+            };
+            Ok(write_to_client(client, client_id, &buf))
+        }
+        // GetXIDList — Task 5.
         other => emit_x11_error_with_minor(
             state,
             client_id,
@@ -41010,5 +41116,37 @@ mod tests {
         let reply = extension_query_reply("XC-MISC", &mut backend);
         assert_eq!(reply, Some((152, 0, 0)));
         assert!(advertised_extension_names(&mut backend).contains(&"XC-MISC"));
+    }
+
+    #[test]
+    fn xcmisc_get_xid_range_skips_used_ids() {
+        let mut state = ServerState::new();
+        let mut peer = install_client(&mut state, 1);
+        let mut backend = RecordingBackend::new();
+        // Give the test client a realistic base/mask (install_client
+        // defaults to base=0, mask=u32::MAX).
+        {
+            let c = state.clients.get_mut(&1).unwrap();
+            c.resource_id_base = 0x0010_0000;
+            c.resource_id_mask = 0x000F_FFFF;
+        }
+        // Occupy the low end of the range.
+        for i in 0..4u32 {
+            state
+                .resources
+                .create_cursor(ClientId(1), ResourceId(0x0010_0000 + i));
+        }
+        send_xcmisc(&mut state, &mut backend, 1, 1, &[]);
+        let bytes = read_all_available(&mut peer);
+        assert_eq!(bytes.len(), 32);
+        assert_eq!(bytes[0], 1);
+        let start = u32::from_le_bytes(bytes[8..12].try_into().unwrap());
+        let count = u32::from_le_bytes(bytes[12..16].try_into().unwrap());
+        assert_eq!(start, 0x0010_0004, "range starts after the used prefix");
+        assert_eq!(count, 0x000F_FFFF - 4 + 1);
+        // Wrong length → BadLength.
+        send_xcmisc(&mut state, &mut backend, 2, 1, &[0u8; 4]);
+        let bytes = read_all_available(&mut peer);
+        assert_eq!(bytes[1], x11::error::BAD_LENGTH);
     }
 }

--- a/crates/yserver-core/src/core_loop/process_request.rs
+++ b/crates/yserver-core/src/core_loop/process_request.rs
@@ -404,6 +404,8 @@ pub fn process_request(
         149 => handle_x_resource_request(state, client_id, sequence, header, body),
         // ── MIT-SCREEN-SAVER extension dispatcher ──
         150 => handle_screen_saver_request(state, backend, client_id, sequence, header, body),
+        // ── XC-MISC extension dispatcher ──
+        152 => handle_xcmisc_request(state, client_id, sequence, header, body),
         opcode => {
             debug!(
                 "client {} #{} unsupported opcode {} ({} bytes)",
@@ -23223,6 +23225,57 @@ fn emit_xi2_device_changed_bootstrap(
     Ok(())
 }
 
+/// XC-MISC (major opcode 152) — XID recycling for long-lived clients.
+/// Spec docs/superpowers/specs/2026-06-12-xcmisc-design.md; Xorg ref
+/// Xext/xcmisc.c. Length validation lives here because the top-level
+/// exact-length table is core-opcode-only.
+fn handle_xcmisc_request(
+    state: &mut ServerState,
+    client_id: ClientId,
+    sequence: SequenceNumber,
+    header: RequestHeader,
+    body: &[u8],
+) -> io::Result<RequestOutcome> {
+    use yserver_protocol::x11::ClientByteOrder;
+    let byte_order = state
+        .clients
+        .get(&client_id.0)
+        .map_or(ClientByteOrder::LittleEndian, |c| c.byte_order);
+    let minor = header.data;
+    match minor {
+        // GetVersion — req 8 bytes (client version, ignored).
+        0 => {
+            if body.len() != 4 {
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    x11::error::BAD_LENGTH,
+                    0,
+                    u16::from(minor),
+                    header.opcode,
+                );
+            }
+            let mut buf: Vec<u8> = Vec::with_capacity(32);
+            x11::write_xcmisc_get_version_reply(&mut buf, byte_order, sequence)?;
+            let Some(client) = state.clients.get_mut(&client_id.0) else {
+                return Ok(RequestOutcome::Handled);
+            };
+            Ok(write_to_client(client, client_id, &buf))
+        }
+        // GetXIDRange / GetXIDList — Tasks 4 and 5.
+        other => emit_x11_error_with_minor(
+            state,
+            client_id,
+            sequence,
+            x11::error::BAD_REQUEST,
+            0,
+            u16::from(other),
+            header.opcode,
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
@@ -40885,5 +40938,77 @@ mod tests {
             s.contains("GLX_SGIX_fbconfig"),
             "glx_extension_string must contain GLX_SGIX_fbconfig when supported"
         );
+    }
+
+    // NOTE: the 3rd argument is the SEQUENCE number, not a client id —
+    // every request in these tests comes from ClientId(1).
+    fn send_xcmisc(
+        state: &mut ServerState,
+        backend: &mut RecordingBackend,
+        seq: u16,
+        minor: u8,
+        body: &[u8],
+    ) {
+        process_request(
+            state,
+            backend,
+            ClientId(1),
+            SequenceNumber(seq),
+            RequestHeader {
+                opcode: 152,
+                data: minor,
+                length_units: u32::try_from(1 + body.len().div_ceil(4)).unwrap(),
+            },
+            body,
+            None,
+        )
+        .expect("process_request");
+    }
+
+    #[test]
+    fn xcmisc_get_version_replies_1_1() {
+        let mut state = ServerState::new();
+        let mut peer = install_client(&mut state, 1);
+        let mut backend = RecordingBackend::new();
+        // GetVersion body: client major(2), minor(2) — values ignored.
+        let body = [0u8, 0, 0, 0];
+        send_xcmisc(&mut state, &mut backend, 1, 0, &body);
+        let bytes = read_all_available(&mut peer);
+        assert_eq!(bytes.len(), 32, "fixed 32-byte reply, got {bytes:02x?}");
+        assert_eq!(bytes[0], 1, "X_Reply");
+        assert_eq!(&bytes[2..4], &1u16.to_le_bytes(), "sequence");
+        assert_eq!(&bytes[8..10], &1u16.to_le_bytes(), "major=1");
+        assert_eq!(&bytes[10..12], &1u16.to_le_bytes(), "minor=1");
+    }
+
+    #[test]
+    fn xcmisc_bad_length_and_unknown_minor() {
+        let mut state = ServerState::new();
+        let mut peer = install_client(&mut state, 1);
+        let mut backend = RecordingBackend::new();
+        // GetVersion with wrong body size → BadLength.
+        send_xcmisc(&mut state, &mut backend, 1, 0, &[0u8; 8]);
+        let bytes = read_all_available(&mut peer);
+        assert!(bytes.len() >= 32);
+        assert_eq!(bytes[1], x11::error::BAD_LENGTH);
+        assert_eq!(bytes[10], 152, "major opcode");
+        assert_eq!(&bytes[8..10], &0u16.to_le_bytes(), "minor 0 echoed");
+        // Unknown minor 3 → BadRequest (Xorg dispatcher default).
+        send_xcmisc(&mut state, &mut backend, 2, 3, &[]);
+        let bytes = read_all_available(&mut peer);
+        assert!(bytes.len() >= 32);
+        assert_eq!(bytes[1], x11::error::BAD_REQUEST);
+        assert_eq!(&bytes[8..10], &3u16.to_le_bytes(), "minor 3 echoed");
+    }
+
+    #[test]
+    fn xcmisc_advertised_in_query_and_list_extensions() {
+        // QueryExtension "XC-MISC" → present with major 152; covered via
+        // extension_query_reply + advertised_extension_names directly
+        // (cheaper than wire round-trips; they are what the handlers use).
+        let mut backend = RecordingBackend::new();
+        let reply = extension_query_reply("XC-MISC", &mut backend);
+        assert_eq!(reply, Some((152, 0, 0)));
+        assert!(advertised_extension_names(&mut backend).contains(&"XC-MISC"));
     }
 }

--- a/crates/yserver-core/src/core_loop/process_request.rs
+++ b/crates/yserver-core/src/core_loop/process_request.rs
@@ -23265,7 +23265,7 @@ fn largest_free_xid_gap(base: u32, mask: u32, used_sorted: &[u32]) -> (u32, u32)
         (0, 1)
     } else {
         #[allow(clippy::cast_possible_truncation)]
-        (best_start, best_len as u32) // len ≤ mask+1 ≤ u32 range
+        (best_start, best_len as u32) // len ≤ hi - lo + 1 ≤ hi ≤ u32::MAX
     }
 }
 

--- a/crates/yserver-core/src/nested.rs
+++ b/crates/yserver-core/src/nested.rs
@@ -88,6 +88,7 @@ pub(crate) const DPMS_MAJOR_OPCODE: u8 = 134;
 
 pub(crate) const MIT_SCREEN_SAVER_MAJOR_OPCODE: u8 = 150;
 pub(crate) const XINERAMA_MAJOR_OPCODE: u8 = 151;
+pub(crate) const XCMISC_MAJOR_OPCODE: u8 = 152;
 // MUST be <= 127: X event codes are 7-bit (2..=127); bit 0x80 is the
 // SendEvent/synthetic flag, so a base first_event with the high bit set is
 // illegal and strict clients (Google Chrome's X11 layer) abort on it. 92 is
@@ -316,6 +317,15 @@ pub(crate) const EXTENSIONS: &[ExtensionMetadata] = &[
     ExtensionMetadata {
         name: "X-Resource",
         major_opcode: X_RESOURCE_MAJOR_OPCODE,
+        first_event: 0,
+        event_count: 0,
+        first_error: 0,
+        availability: ExtensionAvailability::Always,
+        unsupported_minor_policy: UnsupportedMinorPolicy::HandledInline,
+    },
+    ExtensionMetadata {
+        name: "XC-MISC",
+        major_opcode: XCMISC_MAJOR_OPCODE,
         first_event: 0,
         event_count: 0,
         first_error: 0,

--- a/crates/yserver-core/src/resources.rs
+++ b/crates/yserver-core/src/resources.rs
@@ -336,6 +336,10 @@ impl ResourceTable {
     /// (window, pixmap, gc, font, cursor, colormap, picture, or
     /// glyphset). Used by `CreateXxx` opcodes to detect a
     /// `BadIDChoice` violation when a client tries to reuse an ID.
+    ///
+    /// NOTE: covers ResourceTable namespaces only; XC-MISC's
+    /// `ServerState::xid_occupied` additionally covers the extension
+    /// maps — extend BOTH when adding an XID namespace.
     pub fn xid_in_use(&self, id: ResourceId) -> bool {
         let id = id.0;
         self.windows.contains_key(&id)
@@ -346,6 +350,45 @@ impl ResourceTable {
             || self.colormaps.contains_key(&id)
             || self.pictures.contains_key(&id)
             || self.glyphsets.contains_key(&id)
+    }
+
+    /// Append all table-owned XIDs within `base..=base|mask` to `out`
+    /// (the 8 ResourceTable namespaces; extension-map namespaces are
+    /// appended by `ServerState::used_xids_in`). XC-MISC GetXIDRange
+    /// support.
+    pub fn collect_xids_in(&self, base: u32, mask: u32, out: &mut Vec<u32>) {
+        let in_range = |id: &&u32| (**id & !mask) == base;
+        out.extend(self.windows.keys().filter(in_range));
+        out.extend(self.pixmaps.keys().filter(in_range));
+        out.extend(self.gcs.keys().filter(in_range));
+        out.extend(self.fonts.keys().filter(in_range));
+        out.extend(self.cursors.keys().filter(in_range));
+        out.extend(self.colormaps.keys().filter(in_range));
+        out.extend(self.pictures.keys().filter(in_range));
+        out.extend(self.glyphsets.keys().filter(in_range));
+    }
+
+    /// Seed a minimal GC into the resource table. For use in tests only.
+    #[cfg(test)]
+    pub fn seed_gc_for_test(&mut self, owner: ClientId, id: ResourceId) {
+        self.gcs
+            .insert(id.0, Gc::with_defaults(id, ROOT_WINDOW, owner));
+    }
+
+    /// Seed a minimal Font into the resource table. For use in tests only.
+    #[cfg(test)]
+    pub fn seed_font_for_test(&mut self, owner: ClientId, id: ResourceId) {
+        use crate::backend::FontHandle;
+        self.fonts.insert(
+            id.0,
+            Font {
+                id,
+                name: String::new(),
+                host_xid: FontHandle::from_raw_for_test(1),
+                metrics: FontMetrics::default(),
+                owner,
+            },
+        );
     }
 
     pub fn visuals_iter(&self) -> impl Iterator<Item = &Visual> {

--- a/crates/yserver-core/src/server.rs
+++ b/crates/yserver-core/src/server.rs
@@ -1403,6 +1403,50 @@ impl ServerState {
         }
         self.screensaver.next_cycle
     }
+
+    /// True iff `id` designates ANY live resource in ANY client-XID
+    /// namespace: the 8 ResourceTable maps (via
+    /// `resources.xid_in_use`) plus the 9 extension maps that
+    /// `xid_in_use` does NOT cover. XC-MISC must never report an
+    /// occupied id as free — extend this (and the
+    /// `xid_occupied_covers_every_namespace` test) when adding an
+    /// XID-keyed map. Maps keyed by client ids / host xids /
+    /// internal handles do NOT belong here.
+    #[must_use]
+    pub fn xid_occupied(&self, id: u32) -> bool {
+        self.resources.xid_in_use(ResourceId(id))
+            || self.xfixes_regions.contains_key(&id)
+            || self.sync_counters.contains_key(&id)
+            || self.sync_alarms.contains_key(&id)
+            || self.sync_fences.contains_key(&id)
+            || self.damage_objects.contains_key(&id)
+            || self.mit_shm_segments.contains_key(&id)
+            || self.glx_contexts.contains_key(&id)
+            || self.glx_drawables.contains_key(&id)
+            || self.present_event_selections.contains_key(&id)
+    }
+
+    /// Sorted, deduped list of occupied XIDs in `base..=base|mask`
+    /// across all 17 namespaces. O(total live resources) — called
+    /// only on the rare XC-MISC GetXIDRange path.
+    #[must_use]
+    pub fn used_xids_in(&self, base: u32, mask: u32) -> Vec<u32> {
+        let mut out = Vec::new();
+        self.resources.collect_xids_in(base, mask, &mut out);
+        let in_range = |id: &&u32| (**id & !mask) == base;
+        out.extend(self.xfixes_regions.keys().filter(in_range));
+        out.extend(self.sync_counters.keys().filter(in_range));
+        out.extend(self.sync_alarms.keys().filter(in_range));
+        out.extend(self.sync_fences.keys().filter(in_range));
+        out.extend(self.damage_objects.keys().filter(in_range));
+        out.extend(self.mit_shm_segments.keys().filter(in_range));
+        out.extend(self.glx_contexts.keys().filter(in_range));
+        out.extend(self.glx_drawables.keys().filter(in_range));
+        out.extend(self.present_event_selections.keys().filter(in_range));
+        out.sort_unstable();
+        out.dedup();
+        out
+    }
 }
 
 impl Default for ServerState {
@@ -4764,5 +4808,236 @@ mod tests {
             },
         );
         assert!(state.idletime_alarm_deadline().is_none());
+    }
+
+    /// XC-MISC guard test: every client-XID namespace must register in
+    /// xid_occupied. Seeds ONE resource per namespace at a distinct id.
+    /// A future XID-keyed map added without xid_occupied coverage should
+    /// be caught by review against this pattern (spec
+    /// 2026-06-12-xcmisc-design.md "maintenance hazard").
+    #[test]
+    fn xid_occupied_covers_every_namespace() {
+        use crate::{
+            backend::{GlyphSetHandle, PictureHandle},
+            resources::{GlyphSetState, PictureKind, PictureState, ROOT_VISUAL},
+        };
+        use yserver_protocol::x11::{CreatePixmapRequest, CreateWindowRequest};
+
+        let mut state = ServerState::new();
+        let owner = ClientId(1);
+        let base = 0x0010_0000u32;
+        let mut expect = Vec::new();
+
+        // ── 8 ResourceTable namespaces ──
+
+        // 1. window
+        let id_window = base + 1;
+        state.resources.create_window(
+            owner,
+            CreateWindowRequest {
+                depth: 24,
+                window: ResourceId(id_window),
+                parent: ROOT_WINDOW,
+                x: 0,
+                y: 0,
+                width: 10,
+                height: 10,
+                border_width: 0,
+                class: 1,
+                visual: ROOT_VISUAL,
+                ..Default::default()
+            },
+        );
+        expect.push(id_window);
+
+        // 2. pixmap
+        let id_pixmap = base + 2;
+        state.resources.create_pixmap(
+            owner,
+            CreatePixmapRequest {
+                depth: 24,
+                pixmap: ResourceId(id_pixmap),
+                drawable: ROOT_WINDOW,
+                width: 1,
+                height: 1,
+            },
+        );
+        expect.push(id_pixmap);
+
+        // 3. gc
+        let id_gc = base + 3;
+        state.resources.seed_gc_for_test(owner, ResourceId(id_gc));
+        expect.push(id_gc);
+
+        // 4. font
+        let id_font = base + 4;
+        state
+            .resources
+            .seed_font_for_test(owner, ResourceId(id_font));
+        expect.push(id_font);
+
+        // 5. cursor
+        let id_cursor = base + 5;
+        state.resources.create_cursor(owner, ResourceId(id_cursor));
+        expect.push(id_cursor);
+
+        // 6. colormap
+        let id_colormap = base + 6;
+        state
+            .resources
+            .create_colormap(owner, ResourceId(id_colormap), ROOT_VISUAL);
+        expect.push(id_colormap);
+
+        // 7. picture (pub map — insert literal directly)
+        let id_picture = base + 7;
+        state.resources.pictures.insert(
+            id_picture,
+            PictureState {
+                client: owner,
+                host_picture_xid: PictureHandle::from_raw_for_test(1),
+                host_owned_pixmap: None,
+                kind: PictureKind::Sourceless,
+                drawable: None,
+            },
+        );
+        expect.push(id_picture);
+
+        // 8. glyphset (pub map — insert literal directly)
+        let id_glyphset = base + 8;
+        state.resources.glyphsets.insert(
+            id_glyphset,
+            GlyphSetState {
+                client: owner,
+                host_glyphset_xid: GlyphSetHandle::from_raw_for_test(1),
+            },
+        );
+        expect.push(id_glyphset);
+
+        // ── 9 ServerState extension namespaces ──
+
+        // 9. xfixes_regions
+        let id_xfixes = base + 9;
+        state.xfixes_regions.insert(
+            id_xfixes,
+            XFixesRegion {
+                owner,
+                rects: vec![],
+            },
+        );
+        expect.push(id_xfixes);
+
+        // 10. sync_counters
+        let id_sync_counter = base + 10;
+        state
+            .sync_counters
+            .insert(id_sync_counter, SyncCounter { owner, value: 0 });
+        expect.push(id_sync_counter);
+
+        // 11. sync_alarms
+        let id_sync_alarm = base + 11;
+        state.sync_alarms.insert(
+            id_sync_alarm,
+            SyncAlarm {
+                owner,
+                ..SyncAlarm::default()
+            },
+        );
+        expect.push(id_sync_alarm);
+
+        // 12. sync_fences
+        let id_sync_fence = base + 12;
+        state.sync_fences.insert(
+            id_sync_fence,
+            SyncFence {
+                owner,
+                triggered: false,
+            },
+        );
+        expect.push(id_sync_fence);
+
+        // 13. damage_objects
+        let id_damage = base + 13;
+        state.damage_objects.insert(
+            id_damage,
+            DamageObject {
+                owner,
+                drawable: ROOT_WINDOW,
+                level: 0,
+                rects: vec![],
+                pending_notify_fired: false,
+                last_reported_geometry: None,
+            },
+        );
+        expect.push(id_damage);
+
+        // 14. mit_shm_segments — requires a real fd; use memfd_create
+        let id_shm = base + 14;
+        let fd = unsafe { libc::memfd_create(c"xcmisc-test-shm".as_ptr(), libc::MFD_CLOEXEC) };
+        assert!(fd >= 0, "memfd_create failed");
+        let rc = unsafe { libc::ftruncate(fd, 4096) };
+        assert_eq!(rc, 0, "ftruncate failed");
+        let shm_seg = MitShmSegment::from_fd(owner, fd, false).expect("MitShmSegment::from_fd");
+        state.mit_shm_segments.insert(id_shm, shm_seg);
+        expect.push(id_shm);
+
+        // 15. glx_contexts
+        let id_glx_ctx = base + 15;
+        state.glx_contexts.insert(
+            id_glx_ctx,
+            GlxContext {
+                owner,
+                fbconfig: 0,
+                render_type: 0,
+            },
+        );
+        expect.push(id_glx_ctx);
+
+        // 16. glx_drawables
+        let id_glx_draw = base + 16;
+        state.glx_drawables.insert(
+            id_glx_draw,
+            GlxDrawable {
+                owner,
+                x_drawable: 0,
+                fbconfig: 0,
+                width: 0,
+                height: 0,
+                attributes: vec![],
+                glx_export_host_xid: None,
+            },
+        );
+        expect.push(id_glx_draw);
+
+        // 17. present_event_selections
+        let id_present = base + 17;
+        state.present_event_selections.insert(
+            id_present,
+            PresentEventSelection {
+                owner,
+                window: ROOT_WINDOW,
+                event_mask: 0,
+            },
+        );
+        expect.push(id_present);
+
+        // ── assertions ──
+
+        for id in &expect {
+            assert!(state.xid_occupied(*id), "id 0x{id:x} must be occupied");
+        }
+        assert_eq!(
+            expect.len(),
+            17,
+            "one seed per namespace — update when adding namespaces"
+        );
+        assert!(!state.xid_occupied(base + 100), "unseeded id must be free");
+
+        // used_xids_in returns exactly the seeded set, sorted
+        let used = state.used_xids_in(base, 0x000F_FFFF);
+        let mut sorted = expect.clone();
+        sorted.sort_unstable();
+        assert_eq!(used, sorted);
+        // out-of-range base sees none of them
+        assert!(state.used_xids_in(0x0020_0000, 0x000F_FFFF).is_empty());
     }
 }

--- a/crates/yserver-protocol/src/x11/mod.rs
+++ b/crates/yserver-protocol/src/x11/mod.rs
@@ -5599,6 +5599,8 @@ pub fn write_render_query_version_reply(
 
 /// XC-MISC GetVersion reply — fixed 32 bytes, version 1.1 (Xorg
 /// echoes its own version regardless of the client's ask).
+/// `major`/`minor` are u16 on the wire (unlike RENDER QueryVersion's
+/// u32).
 pub fn write_xcmisc_get_version_reply(
     writer: &mut impl Write,
     byte_order: ClientByteOrder,
@@ -5609,7 +5611,7 @@ pub fn write_xcmisc_get_version_reply(
     write_u32(byte_order, &mut out, 0); // reply length
     write_u16(byte_order, &mut out, 1); // major
     write_u16(byte_order, &mut out, 1); // minor
-    out.extend_from_slice(&[0u8; 20]);
+    out.extend_from_slice(&[0u8; 20]); // pad to 32 bytes
     writer.write_all(&out)
 }
 

--- a/crates/yserver-protocol/src/x11/mod.rs
+++ b/crates/yserver-protocol/src/x11/mod.rs
@@ -5597,6 +5597,22 @@ pub fn write_render_query_version_reply(
     writer.write_all(&out)
 }
 
+/// XC-MISC GetVersion reply — fixed 32 bytes, version 1.1 (Xorg
+/// echoes its own version regardless of the client's ask).
+pub fn write_xcmisc_get_version_reply(
+    writer: &mut impl Write,
+    byte_order: ClientByteOrder,
+    sequence: SequenceNumber,
+) -> io::Result<()> {
+    let mut out = vec![1u8, 0];
+    write_u16(byte_order, &mut out, sequence.0);
+    write_u32(byte_order, &mut out, 0); // reply length
+    write_u16(byte_order, &mut out, 1); // major
+    write_u16(byte_order, &mut out, 1); // minor
+    out.extend_from_slice(&[0u8; 20]);
+    writer.write_all(&out)
+}
+
 pub mod error {
     pub const BAD_REQUEST: u8 = 1;
     pub const BAD_VALUE: u8 = 2;

--- a/crates/yserver-protocol/src/x11/mod.rs
+++ b/crates/yserver-protocol/src/x11/mod.rs
@@ -5632,6 +5632,25 @@ pub fn write_xcmisc_get_xid_range_reply(
     writer.write_all(&out)
 }
 
+/// XC-MISC GetXIDList reply — 32-byte header + ids (1 word each).
+pub fn write_xcmisc_get_xid_list_reply(
+    writer: &mut impl Write,
+    byte_order: ClientByteOrder,
+    sequence: SequenceNumber,
+    ids: &[u32],
+) -> io::Result<()> {
+    let mut out = vec![1u8, 0];
+    write_u16(byte_order, &mut out, sequence.0);
+    let n = u32::try_from(ids.len()).map_err(|_| io::Error::other("id list too long"))?;
+    write_u32(byte_order, &mut out, n); // reply length in words = id count
+    write_u32(byte_order, &mut out, n); // count
+    out.extend_from_slice(&[0u8; 20]); // pad to 32 bytes
+    for id in ids {
+        write_u32(byte_order, &mut out, *id);
+    }
+    writer.write_all(&out)
+}
+
 pub mod error {
     pub const BAD_REQUEST: u8 = 1;
     pub const BAD_VALUE: u8 = 2;

--- a/crates/yserver-protocol/src/x11/mod.rs
+++ b/crates/yserver-protocol/src/x11/mod.rs
@@ -5625,7 +5625,7 @@ pub fn write_xcmisc_get_xid_range_reply(
 ) -> io::Result<()> {
     let mut out = vec![1u8, 0];
     write_u16(byte_order, &mut out, sequence.0);
-    write_u32(byte_order, &mut out, 0);
+    write_u32(byte_order, &mut out, 0); // reply length
     write_u32(byte_order, &mut out, start_id);
     write_u32(byte_order, &mut out, count);
     out.extend_from_slice(&[0u8; 16]); // pad to 32 bytes

--- a/crates/yserver-protocol/src/x11/mod.rs
+++ b/crates/yserver-protocol/src/x11/mod.rs
@@ -5615,6 +5615,23 @@ pub fn write_xcmisc_get_version_reply(
     writer.write_all(&out)
 }
 
+/// XC-MISC GetXIDRange reply — fixed 32 bytes.
+pub fn write_xcmisc_get_xid_range_reply(
+    writer: &mut impl Write,
+    byte_order: ClientByteOrder,
+    sequence: SequenceNumber,
+    start_id: u32,
+    count: u32,
+) -> io::Result<()> {
+    let mut out = vec![1u8, 0];
+    write_u16(byte_order, &mut out, sequence.0);
+    write_u32(byte_order, &mut out, 0);
+    write_u32(byte_order, &mut out, start_id);
+    write_u32(byte_order, &mut out, count);
+    out.extend_from_slice(&[0u8; 16]); // pad to 32 bytes
+    writer.write_all(&out)
+}
+
 pub mod error {
     pub const BAD_REQUEST: u8 = 1;
     pub const BAD_VALUE: u8 = 2;

--- a/docs/status.md
+++ b/docs/status.md
@@ -4569,3 +4569,26 @@ Main fixes that moved the case:
 
 The remaining `UNSUPPORTED` TP is the existing non-actionable XTS
 bucket rather than a live KMS regression in `XFillRectangle`.
+
+## XC-MISC 1.1 (branch `feat/xcmisc`, 2026-06-12)
+
+**Status: IMPLEMENTED and probe-verified.** XC-MISC (major opcode 152,
+minor version 1.1) is fully wired: `GetVersion` (opcode 0), `GetXIDRange`
+(opcode 1), and `GetXIDList` (opcode 2). This fixes the silent WM/client
+death caused by XID-range exhaustion — libxcb calls `xcb_generate_id`
+which, with no XC-MISC extension present, wraps at 2^20 (1 048 576) ids
+and returns `0xffffffff` for every subsequent allocation. Clients hit
+`BadIDChoice` on those ids; GDK-based clients (muffin, marco, most GTK
+apps) treat the first `BadIDChoice` as fatal and exit, silently killing
+the window manager and eventually the entire session after roughly two
+hours of desktop use. With XC-MISC, the server hands the client a fresh
+XID range on demand via `GetXIDRange` and individual ids via
+`GetXIDList`; libxcb's exhaustion path calls these automatically and
+recycling proceeds transparently.
+
+Verified by `tools/xid-exhaust-probe`: **RED pre-fix** — exhausted at
+exactly 1 048 576 ids with no recycling; **GREEN post-fix** — 1 310 718
+ids allocated across the range wrap under ynest, server log confirms
+`GetXIDRange` firing at the wrap boundary. Wire encoder unit tests are
+in `yserver-protocol`; core wiring is in `yserver-core`. `cargo test
+--locked` workspace-green; plain clippy + nightly fmt clean.

--- a/docs/superpowers/plans/2026-06-12-xcmisc.md
+++ b/docs/superpowers/plans/2026-06-12-xcmisc.md
@@ -278,6 +278,8 @@ cargo +nightly fmt && git add -A && git commit -m "feat(core): comprehensive XID
 - [ ] **Step 1: Write the failing tests**
 
 ```rust
+// NOTE: the 3rd argument is the SEQUENCE number, not a client id —
+// every request in these tests comes from ClientId(1).
 fn send_xcmisc(
     state: &mut ServerState,
     backend: &mut RecordingBackend,
@@ -540,7 +542,7 @@ fn xcmisc_get_xid_range_skips_used_ids() {
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `cargo test -p yserver-core largest_free_xid_gap xcmisc_get_xid_range` (separate filters)
+Run: `cargo test -p yserver-core largest_free_xid_gap` then `cargo test -p yserver-core xcmisc_get_xid_range` (cargo accepts ONE filter per invocation)
 Expected: COMPILE ERROR (helper missing); wire test gets BadRequest (Task 3's fallthrough) instead of a range reply.
 
 - [ ] **Step 3: Implement**
@@ -656,7 +658,7 @@ for any future exhaustion triage.)
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `cargo test -p yserver-core xcmisc && cargo test -p yserver-core largest_free`
+Run: `cargo test -p yserver-core xcmisc` then `cargo test -p yserver-core largest_free`
 Expected: all PASS; full suite no regressions.
 
 - [ ] **Step 5: Commit**
@@ -703,23 +705,22 @@ fn xcmisc_get_xid_list_returns_free_ids() {
         .collect();
     assert_eq!(ids, vec![0x0010_0001, 0x0010_0003, 0x0010_0004, 0x0010_0005],
                "skips occupied 0x...0 and 0x...2");
-    // Huge count is clamped to the range size, not allocated.
+    // Huge count is clamped to the RANGE size, not allocated. Shrink
+    // the client's range first so the reply stays ~1 KiB — a 1M-id
+    // reply would block the test's unread socketpair (write_or_buffer
+    // does a synchronous write; OUTBOUND_CAP would trip the
+    // disconnect path).
+    state.clients.get_mut(&1).unwrap().resource_id_mask = 0xFF;
     send_xcmisc(&mut state, &mut backend, 2, 2, &u32::MAX.to_le_bytes());
     let bytes = read_all_available(&mut peer);
     let count = u32::from_le_bytes(bytes[8..12].try_into().unwrap());
-    assert_eq!(count, 0x000F_FFFF + 1 - 2, "range size minus 2 occupied");
+    assert_eq!(count, 0x100 - 2, "256-id range minus 2 occupied");
     // BadLength on wrong size.
     send_xcmisc(&mut state, &mut backend, 3, 2, &[]);
     let bytes = read_all_available(&mut peer);
     assert_eq!(bytes[1], x11::error::BAD_LENGTH);
 }
 ```
-
-NOTE the clamped case returns ~1M ids (≈4 MiB reply) — the test reads
-it through `read_all_available`; if the test peer's buffer churns, raise
-the helper's read cap or assert only `count` and the first/last id. If
-runtime is an issue, drop the huge-count wire assert to checking `count`
-only.
 
 - [ ] **Step 2: Run test to verify it fails**
 

--- a/docs/superpowers/plans/2026-06-12-xcmisc.md
+++ b/docs/superpowers/plans/2026-06-12-xcmisc.md
@@ -1,0 +1,847 @@
+# XC-MISC Extension Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement XC-MISC 1.1 (GetVersion/GetXIDRange/GetXIDList, major opcode 152) so XID-exhausted clients recycle freed IDs instead of dying on `BadIDChoice` (the 2026-06-12 Cinnamon WM death).
+
+**Architecture:** Per `docs/superpowers/specs/2026-06-12-xcmisc-design.md`. Pure core: an `EXTENSIONS` registry entry, a minor-dispatch handler, three reply encoders, and a comprehensive `xid_occupied` checker spanning all 17 client-XID namespaces (8 ResourceTable maps + 9 ServerState extension maps).
+
+**Tech Stack:** Rust (`crates/yserver-core`, `crates/yserver-protocol`), one C probe (`tools/`).
+
+**Conventions:** Work in the worktree `/home/jos/Projects/yserver-master` on branch `feat/xcmisc` (NOT `/home/jos/Projects/yserver` — that checkout belongs to another agent). `cargo +nightly fmt` before commits; plain `cargo clippy` (NOT pedantic); never amend; don't push until told.
+
+---
+
+### Task 1: System-level failing test — `tools/xid-exhaust-probe.c` (RED)
+
+**Files:**
+- Create: `tools/xid-exhaust-probe.c`
+
+This reproduces the bee incident in miniature and MUST FAIL against the
+current build. It goes green in Task 6 with zero probe changes.
+
+- [ ] **Step 1: Write the probe**
+
+```c
+/* xid-exhaust-probe — system test for XC-MISC XID recycling.
+ *
+ * Allocates 1.25x the client's whole XID range via a create/free
+ * pixmap loop. Without XC-MISC, xcb_generate_id() returns
+ * 0xFFFFFFFF once the range is exhausted (the 2026-06-12 Cinnamon
+ * WM death); with it, libxcb transparently recycles freed IDs and
+ * the loop survives a full wrap.
+ *
+ * Build: cc -o target/xid-exhaust-probe tools/xid-exhaust-probe.c -lxcb
+ * Run:   DISPLAY=:97 ./target/xid-exhaust-probe
+ * Exit:  0 = PASS (recycling works), 1 = FAIL (exhausted), 2 = no display
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <xcb/xcb.h>
+
+int main(void) {
+    xcb_connection_t *c = xcb_connect(NULL, NULL);
+    if (!c || xcb_connection_has_error(c)) {
+        fprintf(stderr, "cannot connect to display\n");
+        return 2;
+    }
+    const xcb_setup_t *setup = xcb_get_setup(c);
+    xcb_screen_t *screen = xcb_setup_roots_iterator(setup).data;
+    uint32_t mask = setup->resource_id_mask;
+    unsigned long target = (unsigned long)mask + (mask >> 2); /* 1.25x range */
+    printf("resource_id_mask=0x%x; allocating %lu ids...\n", mask, target);
+
+    for (unsigned long i = 0; i < target; i++) {
+        uint32_t id = xcb_generate_id(c);
+        if (id == 0xFFFFFFFF) {
+            printf("FAIL: xcb_generate_id exhausted after %lu ids "
+                   "(no XC-MISC recycling)\n", i);
+            return 1;
+        }
+        xcb_create_pixmap(c, screen->root_depth, id, screen->root, 1, 1);
+        xcb_free_pixmap(c, id);
+        if ((i & 0xFFFF) == 0) {
+            xcb_flush(c);
+            /* drain any queued errors so the event queue stays flat */
+            xcb_generic_event_t *ev;
+            while ((ev = xcb_poll_for_event(c)) != NULL) {
+                if (((ev->response_type & 0x7f)) == 0)
+                    fprintf(stderr, "unexpected X error mid-loop\n");
+                free(ev);
+            }
+        }
+    }
+
+    /* survived a full wrap — prove a recycled id really works */
+    uint32_t id = xcb_generate_id(c);
+    xcb_void_cookie_t ck =
+        xcb_create_pixmap_checked(c, screen->root_depth, id, screen->root, 4, 4);
+    xcb_generic_error_t *err = xcb_request_check(c, ck);
+    if (err) {
+        printf("FAIL: post-wrap CreatePixmap error code=%d\n", err->error_code);
+        free(err);
+        return 1;
+    }
+    printf("PASS: %lu ids allocated across the range wrap; recycling works\n",
+           target);
+    xcb_disconnect(c);
+    return 0;
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `cd /home/jos/Projects/yserver-master && cc -o target/xid-exhaust-probe tools/xid-exhaust-probe.c -lxcb`
+Expected: clean compile.
+
+- [ ] **Step 3: Demonstrate RED against the current server**
+
+Build the server (`cargo build`), start ynest (`DISPLAY=:0 RUST_LOG=warn target/debug/ynest 97 --geometry 640x480`, give it 2s), then run `DISPLAY=:97 ./target/xid-exhaust-probe`.
+Expected: **FAIL after ~1048576 ids** (exit 1) — this is the bee incident reproduced. Capture the output line. Kill ynest afterwards (`pgrep -f ynest`).
+Note: the loop sends ~1.3M requests; allow a couple of minutes.
+
+- [ ] **Step 4: Commit (probe only — it documents the bug)**
+
+```bash
+git add tools/xid-exhaust-probe.c && git commit -m "tools: xid-exhaust-probe — reproduces XID-exhaustion death (RED without XC-MISC)"
+```
+
+---
+
+### Task 2: `ServerState::xid_occupied` + `used_xids_in` (comprehensive occupancy)
+
+**Files:**
+- Modify: `crates/yserver-core/src/resources.rs` (new `collect_xids_in` + doc cross-ref on `xid_in_use` at `:339`)
+- Modify: `crates/yserver-core/src/server.rs` (new methods on `ServerState`)
+- Test: `mod tests` in `server.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+In `server.rs` tests module. The struct definitions for the 9 extension
+maps are in `server.rs` itself (XFixesRegion ~:1415, SyncCounter ~:1428,
+SyncFence ~:1438, SyncAlarm ~:1444, DamageObject ~:1459,
+PresentEventSelection ~:1478, MitShmSegment ~:1488, GlxContext ~:1042,
+GlxDrawable ~:1053) — read each and construct minimal literals (owner +
+required fields; default/zero everything else). ResourceTable seeding
+uses its simple constructors (`create_cursor(owner, id)` etc.; for maps
+without a simple constructor — `pictures`, `glyphsets` are `pub` — insert
+minimal literals directly).
+
+```rust
+/// XC-MISC guard test: every client-XID namespace must register in
+/// xid_occupied. Seeds ONE resource per namespace at a distinct id.
+/// A future XID-keyed map added without xid_occupied coverage should
+/// be caught by review against this pattern (spec
+/// 2026-06-12-xcmisc-design.md "maintenance hazard").
+#[test]
+fn xid_occupied_covers_every_namespace() {
+    let mut state = ServerState::new();
+    let owner = ClientId(1);
+    let base = 0x0010_0000u32;
+    let mut expect = Vec::new();
+
+    // ── 8 ResourceTable namespaces ──
+    // (use the table's constructors; ids base+1..base+8)
+    // window, pixmap, gc, font, cursor, colormap, picture, glyphset
+    // ... seed each; push each id into `expect`
+    // ── 9 ServerState namespaces ──
+    // xfixes_regions, sync_counters, sync_alarms, sync_fences,
+    // damage_objects, mit_shm_segments, glx_contexts, glx_drawables,
+    // present_event_selections at ids base+9..base+17
+    // ... insert minimal literals; push ids into `expect`
+
+    for id in &expect {
+        assert!(state.xid_occupied(*id), "id 0x{id:x} must be occupied");
+    }
+    assert_eq!(expect.len(), 17, "one seed per namespace — update when adding namespaces");
+    assert!(!state.xid_occupied(base + 100), "unseeded id must be free");
+
+    // used_xids_in returns exactly the seeded set, sorted
+    let used = state.used_xids_in(base, 0x000F_FFFF);
+    let mut sorted = expect.clone();
+    sorted.sort_unstable();
+    assert_eq!(used, sorted);
+    // out-of-range base sees none of them
+    assert!(state.used_xids_in(0x0020_0000, 0x000F_FFFF).is_empty());
+}
+```
+
+The seeding bodies are elided above ONLY because the struct shapes must
+be read from the live code — implementer: write all 17 explicitly, no
+loops/macros, one comment per namespace. If a struct needs a field you
+can't construct meaningfully (e.g. an fd), check how its disconnect-path
+test or construction site does it and mimic; if truly impossible, STOP
+and report NEEDS_CONTEXT rather than skipping the namespace.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p yserver-core xid_occupied_covers -- --nocapture`
+Expected: COMPILE ERROR — `xid_occupied`/`used_xids_in` don't exist.
+
+- [ ] **Step 3: Implement**
+
+In `resources.rs`, next to `xid_in_use` (`:339`) — and add to
+`xid_in_use`'s doc comment: "NOTE: covers ResourceTable namespaces
+only; XC-MISC's `ServerState::xid_occupied` additionally covers the
+extension maps — extend BOTH when adding an XID namespace.":
+
+```rust
+    /// Append all table-owned XIDs within `base..=base|mask` to `out`
+    /// (the 8 ResourceTable namespaces; extension-map namespaces are
+    /// appended by `ServerState::used_xids_in`). XC-MISC GetXIDRange
+    /// support.
+    pub fn collect_xids_in(&self, base: u32, mask: u32, out: &mut Vec<u32>) {
+        let in_range = |id: &&u32| (**id & !mask) == base;
+        out.extend(self.windows.keys().filter(in_range));
+        out.extend(self.pixmaps.keys().filter(in_range));
+        out.extend(self.gcs.keys().filter(in_range));
+        out.extend(self.fonts.keys().filter(in_range));
+        out.extend(self.cursors.keys().filter(in_range));
+        out.extend(self.colormaps.keys().filter(in_range));
+        out.extend(self.pictures.keys().filter(in_range));
+        out.extend(self.glyphsets.keys().filter(in_range));
+    }
+```
+
+In `server.rs`, `impl ServerState`:
+
+```rust
+    /// True iff `id` designates ANY live resource in ANY client-XID
+    /// namespace: the 8 ResourceTable maps (via
+    /// `resources.xid_in_use`) plus the 9 extension maps that
+    /// `xid_in_use` does NOT cover. XC-MISC must never report an
+    /// occupied id as free — extend this (and the
+    /// `xid_occupied_covers_every_namespace` test) when adding an
+    /// XID-keyed map. Maps keyed by client ids / host xids /
+    /// internal handles do NOT belong here.
+    #[must_use]
+    pub fn xid_occupied(&self, id: u32) -> bool {
+        self.resources.xid_in_use(crate::resources::ResourceId(id))
+            || self.xfixes_regions.contains_key(&id)
+            || self.sync_counters.contains_key(&id)
+            || self.sync_alarms.contains_key(&id)
+            || self.sync_fences.contains_key(&id)
+            || self.damage_objects.contains_key(&id)
+            || self.mit_shm_segments.contains_key(&id)
+            || self.glx_contexts.contains_key(&id)
+            || self.glx_drawables.contains_key(&id)
+            || self.present_event_selections.contains_key(&id)
+    }
+
+    /// Sorted, deduped list of occupied XIDs in `base..=base|mask`
+    /// across all 17 namespaces. O(total live resources) — called
+    /// only on the rare XC-MISC GetXIDRange path.
+    #[must_use]
+    pub fn used_xids_in(&self, base: u32, mask: u32) -> Vec<u32> {
+        let mut out = Vec::new();
+        self.resources.collect_xids_in(base, mask, &mut out);
+        let in_range = |id: &&u32| (**id & !mask) == base;
+        out.extend(self.xfixes_regions.keys().filter(in_range));
+        out.extend(self.sync_counters.keys().filter(in_range));
+        out.extend(self.sync_alarms.keys().filter(in_range));
+        out.extend(self.sync_fences.keys().filter(in_range));
+        out.extend(self.damage_objects.keys().filter(in_range));
+        out.extend(self.mit_shm_segments.keys().filter(in_range));
+        out.extend(self.glx_contexts.keys().filter(in_range));
+        out.extend(self.glx_drawables.keys().filter(in_range));
+        out.extend(self.present_event_selections.keys().filter(in_range));
+        out.sort_unstable();
+        out.dedup();
+        out
+    }
+```
+
+If any of the 8 private ResourceTable maps' names differ, match the
+real field names (read `resources.rs:180-191`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p yserver-core xid_occupied_covers`
+Expected: PASS. Also `cargo build --locked` clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo +nightly fmt && git add -A && git commit -m "feat(core): comprehensive XID occupancy across all 17 namespaces"
+```
+
+---
+
+### Task 3: Extension registration + handler skeleton + GetVersion
+
+**Files:**
+- Modify: `crates/yserver-core/src/nested.rs` (EXTENSIONS entry, ~:144)
+- Modify: `crates/yserver-core/src/core_loop/process_request.rs` (dispatch arm ~:355-417 region; new `handle_xcmisc_request`)
+- Modify: `crates/yserver-protocol/src/x11/mod.rs` (encoder)
+- Test: `mod tests` in `process_request.rs` (harness: `install_client` + `RecordingBackend` + `read_all_available`; see the `create_anim_cursor_*` tests for the exact idiom)
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+fn send_xcmisc(
+    state: &mut ServerState,
+    backend: &mut RecordingBackend,
+    seq: u16,
+    minor: u8,
+    body: &[u8],
+) {
+    process_request(
+        state,
+        backend,
+        ClientId(1),
+        SequenceNumber(seq),
+        RequestHeader {
+            opcode: 152,
+            data: minor,
+            length_units: u32::try_from(1 + body.len().div_ceil(4)).unwrap(),
+        },
+        body,
+        None,
+    )
+    .expect("process_request");
+}
+
+#[test]
+fn xcmisc_get_version_replies_1_1() {
+    let mut state = ServerState::new();
+    let mut peer = install_client(&mut state, 1);
+    let mut backend = RecordingBackend::new();
+    // GetVersion body: client major(2), minor(2) — values ignored.
+    let body = [0u8, 0, 0, 0];
+    send_xcmisc(&mut state, &mut backend, 1, 0, &body);
+    let bytes = read_all_available(&mut peer);
+    assert_eq!(bytes.len(), 32, "fixed 32-byte reply, got {bytes:02x?}");
+    assert_eq!(bytes[0], 1, "X_Reply");
+    assert_eq!(&bytes[2..4], &1u16.to_le_bytes(), "sequence");
+    assert_eq!(&bytes[8..10], &1u16.to_le_bytes(), "major=1");
+    assert_eq!(&bytes[10..12], &1u16.to_le_bytes(), "minor=1");
+}
+
+#[test]
+fn xcmisc_bad_length_and_unknown_minor() {
+    let mut state = ServerState::new();
+    let mut peer = install_client(&mut state, 1);
+    let mut backend = RecordingBackend::new();
+    // GetVersion with wrong body size → BadLength.
+    send_xcmisc(&mut state, &mut backend, 1, 0, &[0u8; 8]);
+    let bytes = read_all_available(&mut peer);
+    assert!(bytes.len() >= 32);
+    assert_eq!(bytes[1], x11::error::BAD_LENGTH);
+    assert_eq!(bytes[10], 152, "major opcode");
+    assert_eq!(&bytes[8..10], &0u16.to_le_bytes(), "minor 0 echoed");
+    // Unknown minor 3 → BadRequest (Xorg dispatcher default).
+    send_xcmisc(&mut state, &mut backend, 2, 3, &[]);
+    let bytes = read_all_available(&mut peer);
+    assert!(bytes.len() >= 32);
+    assert_eq!(bytes[1], x11::error::BAD_REQUEST);
+    assert_eq!(&bytes[8..10], &3u16.to_le_bytes(), "minor 3 echoed");
+}
+
+#[test]
+fn xcmisc_advertised_in_query_and_list_extensions() {
+    // QueryExtension "XC-MISC" → present with major 152; covered via
+    // extension_query_reply + advertised_extension_names directly
+    // (cheaper than wire round-trips; they are what the handlers use).
+    let mut backend = RecordingBackend::new();
+    let reply = extension_query_reply(&mut backend, b"XC-MISC");
+    assert_eq!(reply, Some((152, 0, 0)));
+    assert!(advertised_extension_names(&mut backend).contains(&"XC-MISC"));
+}
+```
+
+NOTE: check `extension_query_reply`'s real signature/arg types
+(`process_request.rs:14943-14964`) and adapt the third test's call shape
+to it (it may take the name as `&str` or `&[u8]`, and the backend by
+`&dyn Backend`). The assertion targets stay the same.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p yserver-core xcmisc -- --nocapture`
+Expected: opcode 152 is currently unhandled — the GetVersion test FAILS
+on empty reply (or an unknown-request error, depending on the default
+arm; either is a valid red), the third test fails on `None`.
+
+- [ ] **Step 3: Implement**
+
+`nested.rs`: add to `EXTENSIONS` (match the existing entry style; define
+`pub(crate) const XCMISC_MAJOR_OPCODE: u8 = 152;` next to the other
+opcode consts in the same file — grep `RANDR_MAJOR_OPCODE` for where):
+
+```rust
+    ExtensionMetadata {
+        name: "XC-MISC",
+        major_opcode: XCMISC_MAJOR_OPCODE,
+        first_event: 0,
+        event_count: 0,
+        first_error: 0,
+        availability: ExtensionAvailability::Always,
+        unsupported_minor_policy: UnsupportedMinorPolicy::HandledInline,
+    },
+```
+
+`yserver-protocol/src/x11/mod.rs`, next to `write_render_query_version_reply` (`:5584`):
+
+```rust
+/// XC-MISC GetVersion reply — fixed 32 bytes, version 1.1 (Xorg
+/// echoes its own version regardless of the client's ask).
+pub fn write_xcmisc_get_version_reply(
+    writer: &mut impl Write,
+    byte_order: ClientByteOrder,
+    sequence: SequenceNumber,
+) -> io::Result<()> {
+    let mut out = vec![1u8, 0];
+    write_u16(byte_order, &mut out, sequence.0);
+    write_u32(byte_order, &mut out, 0); // reply length
+    write_u16(byte_order, &mut out, 1); // major
+    write_u16(byte_order, &mut out, 1); // minor
+    out.extend_from_slice(&[0u8; 20]);
+    writer.write_all(&out)
+}
+```
+
+`process_request.rs`: dispatch arm (next to the other extension arms,
+~:356-417): `152 => handle_xcmisc_request(state, backend, client_id, sequence, header, body),`
+— match the neighboring arms' exact parameter list (drop `origin`/keep it
+per whatever the arm signature needs; the handler itself doesn't use the
+backend or origin, but keep the signature uniform with siblings and
+underscore-prefix unused params).
+
+```rust
+/// XC-MISC (major opcode 152) — XID recycling for long-lived clients.
+/// Spec docs/superpowers/specs/2026-06-12-xcmisc-design.md; Xorg ref
+/// Xext/xcmisc.c. Length validation lives here because the top-level
+/// exact-length table is core-opcode-only.
+fn handle_xcmisc_request(
+    state: &mut ServerState,
+    _backend: &mut dyn Backend,
+    client_id: ClientId,
+    sequence: SequenceNumber,
+    header: RequestHeader,
+    body: &[u8],
+) -> io::Result<RequestOutcome> {
+    use yserver_protocol::x11::ClientByteOrder;
+    let byte_order = state
+        .clients
+        .get(&client_id.0)
+        .map_or(ClientByteOrder::LittleEndian, |c| c.byte_order);
+    let minor = header.data;
+    match minor {
+        // GetVersion — req 8 bytes (client version, ignored).
+        0 => {
+            if body.len() != 4 {
+                return emit_x11_error_with_minor(
+                    state, client_id, sequence,
+                    x11::error::BAD_LENGTH, 0,
+                    u16::from(minor), header.opcode,
+                );
+            }
+            let mut buf: Vec<u8> = Vec::with_capacity(32);
+            x11::write_xcmisc_get_version_reply(&mut buf, byte_order, sequence)?;
+            let Some(client) = state.clients.get_mut(&client_id.0) else {
+                return Ok(RequestOutcome::Handled);
+            };
+            Ok(write_to_client(client, client_id, &buf))
+        }
+        // GetXIDRange / GetXIDList — Tasks 4 and 5.
+        other => emit_x11_error_with_minor(
+            state, client_id, sequence,
+            x11::error::BAD_REQUEST, 0,
+            u16::from(other), header.opcode,
+        ),
+    }
+}
+```
+
+(Until Tasks 4/5 land, minors 1/2 fall into the BadRequest arm — that's
+fine mid-branch; the Task 4/5 tests arrive with their implementations.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p yserver-core xcmisc`
+Expected: all 3 PASS. Full `cargo test -p yserver-core` no regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo +nightly fmt && git add -A && git commit -m "feat(xcmisc): extension registration + GetVersion + dispatcher errors"
+```
+
+---
+
+### Task 4: GetXIDRange
+
+**Files:**
+- Modify: `crates/yserver-core/src/core_loop/process_request.rs` (minor-1 arm + `largest_free_xid_gap` helper)
+- Modify: `crates/yserver-protocol/src/x11/mod.rs` (encoder)
+- Test: both files' tests modules
+
+- [ ] **Step 1: Write the failing tests**
+
+Pure-function tests next to the helper (these pin the algorithm and the
+exhaustion edge without wire plumbing):
+
+```rust
+#[test]
+fn largest_free_xid_gap_cases() {
+    let base = 0x0010_0000u32;
+    let mask = 0x000F_FFFFu32;
+    let hi = base | mask;
+    // empty range → whole range (lo = base since base != 0)
+    assert_eq!(largest_free_xid_gap(base, mask, &[]), (base, mask + 1));
+    // one used id at the start → gap after it
+    assert_eq!(
+        largest_free_xid_gap(base, mask, &[base]),
+        (base + 1, mask)
+    );
+    // split: small gap low, big gap high → picks the big one
+    let used: Vec<u32> = (base..base + 10).chain([base + 12]).collect();
+    assert_eq!(largest_free_xid_gap(base, mask, &used), (base + 13, hi - (base + 13) + 1));
+    // fully exhausted → Xorg wire shape (0, 1)
+    let all: Vec<u32> = (base..=hi).collect(); // NOTE: 1M entries — fine in a test
+    assert_eq!(largest_free_xid_gap(base, mask, &all), (0, 1));
+    // base 0 (hypothetical) excludes XID 0
+    assert_eq!(largest_free_xid_gap(0, 0xFF, &[]), (1, 0xFF));
+}
+```
+
+Wire test in the process_request tests module:
+
+```rust
+#[test]
+fn xcmisc_get_xid_range_skips_used_ids() {
+    let mut state = ServerState::new();
+    let mut peer = install_client(&mut state, 1);
+    let mut backend = RecordingBackend::new();
+    // Give the test client a realistic base/mask (install_client
+    // defaults to base=0, mask=u32::MAX).
+    {
+        let c = state.clients.get_mut(&1).unwrap();
+        c.resource_id_base = 0x0010_0000;
+        c.resource_id_mask = 0x000F_FFFF;
+    }
+    // Occupy the low end of the range.
+    for i in 0..4u32 {
+        state.resources.create_cursor(ClientId(1), ResourceId(0x0010_0000 + i));
+    }
+    send_xcmisc(&mut state, &mut backend, 1, 1, &[]);
+    let bytes = read_all_available(&mut peer);
+    assert_eq!(bytes.len(), 32);
+    assert_eq!(bytes[0], 1);
+    let start = u32::from_le_bytes(bytes[8..12].try_into().unwrap());
+    let count = u32::from_le_bytes(bytes[12..16].try_into().unwrap());
+    assert_eq!(start, 0x0010_0004, "range starts after the used prefix");
+    assert_eq!(count, 0x000F_FFFF - 4 + 1);
+    // Wrong length → BadLength.
+    send_xcmisc(&mut state, &mut backend, 2, 1, &[0u8; 4]);
+    let bytes = read_all_available(&mut peer);
+    assert_eq!(bytes[1], x11::error::BAD_LENGTH);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p yserver-core largest_free_xid_gap xcmisc_get_xid_range` (separate filters)
+Expected: COMPILE ERROR (helper missing); wire test gets BadRequest (Task 3's fallthrough) instead of a range reply.
+
+- [ ] **Step 3: Implement**
+
+Helper near `handle_xcmisc_request`:
+
+```rust
+/// Largest contiguous free run in `[max(base,1) .. base|mask]`,
+/// given the SORTED+DEDUPED occupied ids in that range. Returns
+/// Xorg's exact exhaustion wire shape `(0, 1)` when nothing is free
+/// (dix/resource.c:733-737 zeroes min/max; the reply encodes
+/// max-min+1 = 1; libxcb treats start 0 as exhausted). Largest-gap
+/// is an implementation choice — the protocol promises only "a
+/// contiguous range of unused IDs" (spec "GetXIDRange algorithm").
+fn largest_free_xid_gap(base: u32, mask: u32, used_sorted: &[u32]) -> (u32, u32) {
+    let lo = base.max(1); // XID 0 is never allocatable
+    let hi = base | mask;
+    let mut best_start = 0u32;
+    let mut best_len = 0u64;
+    let mut cursor = lo;
+    for &u in used_sorted {
+        if u < lo {
+            continue;
+        }
+        if u > hi {
+            break;
+        }
+        if u > cursor {
+            let len = u64::from(u - cursor);
+            if len > best_len {
+                best_len = len;
+                best_start = cursor;
+            }
+        }
+        cursor = cursor.max(u.saturating_add(1));
+    }
+    if cursor <= hi {
+        let len = u64::from(hi - cursor) + 1;
+        if len > best_len {
+            best_len = len;
+            best_start = cursor;
+        }
+    }
+    if best_len == 0 {
+        (0, 1)
+    } else {
+        #[allow(clippy::cast_possible_truncation)]
+        (best_start, best_len as u32) // len ≤ mask+1 ≤ u32 range
+    }
+}
+```
+
+Encoder:
+
+```rust
+/// XC-MISC GetXIDRange reply — fixed 32 bytes.
+pub fn write_xcmisc_get_xid_range_reply(
+    writer: &mut impl Write,
+    byte_order: ClientByteOrder,
+    sequence: SequenceNumber,
+    start_id: u32,
+    count: u32,
+) -> io::Result<()> {
+    let mut out = vec![1u8, 0];
+    write_u16(byte_order, &mut out, sequence.0);
+    write_u32(byte_order, &mut out, 0);
+    write_u32(byte_order, &mut out, start_id);
+    write_u32(byte_order, &mut out, count);
+    out.extend_from_slice(&[0u8; 16]);
+    writer.write_all(&out)
+}
+```
+
+Minor-1 arm (insert before the `other =>` arm):
+
+```rust
+        // GetXIDRange — req 4 bytes (header only).
+        1 => {
+            if !body.is_empty() {
+                return emit_x11_error_with_minor(
+                    state, client_id, sequence,
+                    x11::error::BAD_LENGTH, 0,
+                    u16::from(minor), header.opcode,
+                );
+            }
+            let Some((base, mask)) = state
+                .clients
+                .get(&client_id.0)
+                .map(|c| (c.resource_id_base, c.resource_id_mask))
+            else {
+                return Ok(RequestOutcome::Handled);
+            };
+            let used = state.used_xids_in(base, mask);
+            let (start_id, count) = largest_free_xid_gap(base, mask, &used);
+            log::info!(
+                "client {} XC-MISC GetXIDRange → start=0x{start_id:x} count={count} \
+                 ({} ids in use)",
+                client_id.0,
+                used.len(),
+            );
+            let mut buf: Vec<u8> = Vec::with_capacity(32);
+            x11::write_xcmisc_get_xid_range_reply(&mut buf, byte_order, sequence, start_id, count)?;
+            let Some(client) = state.clients.get_mut(&client_id.0) else {
+                return Ok(RequestOutcome::Handled);
+            };
+            Ok(write_to_client(client, client_id, &buf))
+        }
+```
+
+(The `log::info!` is deliberate, not debug: GetXIDRange fires once per
+~1M allocations — rare enough to keep, and it's the smoking-gun line
+for any future exhaustion triage.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p yserver-core xcmisc && cargo test -p yserver-core largest_free`
+Expected: all PASS; full suite no regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo +nightly fmt && git add -A && git commit -m "feat(xcmisc): GetXIDRange — largest free gap with Xorg exhaustion shape"
+```
+
+---
+
+### Task 5: GetXIDList
+
+**Files:**
+- Modify: `crates/yserver-core/src/core_loop/process_request.rs` (minor-2 arm)
+- Modify: `crates/yserver-protocol/src/x11/mod.rs` (variable-length encoder)
+- Test: process_request tests module
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn xcmisc_get_xid_list_returns_free_ids() {
+    let mut state = ServerState::new();
+    let mut peer = install_client(&mut state, 1);
+    let mut backend = RecordingBackend::new();
+    {
+        let c = state.clients.get_mut(&1).unwrap();
+        c.resource_id_base = 0x0010_0000;
+        c.resource_id_mask = 0x000F_FFFF;
+    }
+    // Occupy ids 0,2 in the range; ask for 4 ids.
+    state.resources.create_cursor(ClientId(1), ResourceId(0x0010_0000));
+    state.resources.create_cursor(ClientId(1), ResourceId(0x0010_0002));
+    send_xcmisc(&mut state, &mut backend, 1, 2, &4u32.to_le_bytes());
+    let bytes = read_all_available(&mut peer);
+    assert_eq!(bytes.len(), 32 + 16, "32 header + 4 ids");
+    let count = u32::from_le_bytes(bytes[8..12].try_into().unwrap());
+    assert_eq!(count, 4);
+    let length = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
+    assert_eq!(length, 4, "reply length in words = id count");
+    let ids: Vec<u32> = bytes[32..]
+        .chunks_exact(4)
+        .map(|c| u32::from_le_bytes(c.try_into().unwrap()))
+        .collect();
+    assert_eq!(ids, vec![0x0010_0001, 0x0010_0003, 0x0010_0004, 0x0010_0005],
+               "skips occupied 0x...0 and 0x...2");
+    // Huge count is clamped to the range size, not allocated.
+    send_xcmisc(&mut state, &mut backend, 2, 2, &u32::MAX.to_le_bytes());
+    let bytes = read_all_available(&mut peer);
+    let count = u32::from_le_bytes(bytes[8..12].try_into().unwrap());
+    assert_eq!(count, 0x000F_FFFF + 1 - 2, "range size minus 2 occupied");
+    // BadLength on wrong size.
+    send_xcmisc(&mut state, &mut backend, 3, 2, &[]);
+    let bytes = read_all_available(&mut peer);
+    assert_eq!(bytes[1], x11::error::BAD_LENGTH);
+}
+```
+
+NOTE the clamped case returns ~1M ids (≈4 MiB reply) — the test reads
+it through `read_all_available`; if the test peer's buffer churns, raise
+the helper's read cap or assert only `count` and the first/last id. If
+runtime is an issue, drop the huge-count wire assert to checking `count`
+only.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p yserver-core xcmisc_get_xid_list -- --nocapture`
+Expected: BadRequest fallthrough instead of a list reply.
+
+- [ ] **Step 3: Implement**
+
+Encoder:
+
+```rust
+/// XC-MISC GetXIDList reply — 32-byte header + ids (1 word each).
+pub fn write_xcmisc_get_xid_list_reply(
+    writer: &mut impl Write,
+    byte_order: ClientByteOrder,
+    sequence: SequenceNumber,
+    ids: &[u32],
+) -> io::Result<()> {
+    let mut out = vec![1u8, 0];
+    write_u16(byte_order, &mut out, sequence.0);
+    let n = u32::try_from(ids.len()).map_err(|_| io::Error::other("id list too long"))?;
+    write_u32(byte_order, &mut out, n); // reply length in words
+    write_u32(byte_order, &mut out, n); // count
+    out.extend_from_slice(&[0u8; 20]);
+    for id in ids {
+        write_u32(byte_order, &mut out, *id);
+    }
+    writer.write_all(&out)
+}
+```
+
+Minor-2 arm:
+
+```rust
+        // GetXIDList — req 8 bytes: count(4).
+        2 => {
+            if body.len() != 4 {
+                return emit_x11_error_with_minor(
+                    state, client_id, sequence,
+                    x11::error::BAD_LENGTH, 0,
+                    u16::from(minor), header.opcode,
+                );
+            }
+            let want = u32::from_le_bytes([body[0], body[1], body[2], body[3]]);
+            let Some((base, mask)) = state
+                .clients
+                .get(&client_id.0)
+                .map(|c| (c.resource_id_base, c.resource_id_mask))
+            else {
+                return Ok(RequestOutcome::Handled);
+            };
+            // Clamp to the range size — never allocate
+            // client-controlled gigabytes (explicit Xorg deviation,
+            // spec "Edge cases"; Xorg would BadAlloc instead).
+            let limit = u64::from(want).min(u64::from(mask) + 1);
+            let mut ids: Vec<u32> = Vec::new();
+            let lo = base.max(1);
+            let hi = base | mask;
+            let mut id = lo;
+            while ids.len() < limit as usize {
+                if !state.xid_occupied(id) {
+                    ids.push(id);
+                }
+                if id == hi {
+                    break;
+                }
+                id += 1;
+            }
+            log::info!(
+                "client {} XC-MISC GetXIDList want={want} → {} ids",
+                client_id.0,
+                ids.len(),
+            );
+            let mut buf: Vec<u8> = Vec::with_capacity(32 + ids.len() * 4);
+            x11::write_xcmisc_get_xid_list_reply(&mut buf, byte_order, sequence, &ids)?;
+            let Some(client) = state.clients.get_mut(&client_id.0) else {
+                return Ok(RequestOutcome::Handled);
+            };
+            Ok(write_to_client(client, client_id, &buf))
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p yserver-core xcmisc` — all green; full suite no regressions; `cargo clippy` clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo +nightly fmt && git add -A && git commit -m "feat(xcmisc): GetXIDList with range-bounded scan"
+```
+
+---
+
+### Task 6: Probe goes GREEN (system-level verification)
+
+- [ ] **Step 1: Rebuild + rerun the Task 1 probe, unchanged**
+
+`cargo build`, start ynest as in Task 1, run `DISPLAY=:97 ./target/xid-exhaust-probe`.
+Expected: **PASS** — `PASS: ... ids allocated across the range wrap; recycling works`, exit 0. The server log (RUST_LOG=info) should show the `XC-MISC GetXIDRange` info line firing as libxcb recycles. Capture both lines. Kill ynest + verify no leftover processes.
+
+If it still FAILS: do NOT patch the probe; report DONE_WITH_CONCERNS with the failure output and the server log tail — the bug is in Tasks 3-5.
+
+- [ ] **Step 2: Commit (only if any incidental fix was needed — otherwise nothing to commit; the probe was committed in Task 1)**
+
+---
+
+### Task 7: Full validation + status doc
+
+- [ ] **Step 1:** `cargo test --locked` (workspace) — all green; paste summaries.
+- [ ] **Step 2:** `cargo clippy` (plain) — zero warnings; `cargo +nightly fmt --check` — no diff.
+- [ ] **Step 3:** Read `docs/status.md`, add an entry in its style: XC-MISC implemented (GetVersion/GetXIDRange/GetXIDList, opcode 152); fixes the silent WM death from XID exhaustion (~2h sessions); probe-verified under ynest.
+- [ ] **Step 4:**
+
+```bash
+git add docs/status.md && git commit -m "docs: status — XC-MISC lands, XID-exhaustion death fixed"
+```
+
+---
+
+## Plan self-review notes
+
+- **Spec coverage:** registration/QueryExtension/ListExtensions (T3), GetVersion (T3), GetXIDRange + exhaustion shape + largest-gap (T4), GetXIDList + clamp deviation (T5), BadLength all minors (T3-T5), BadRequest unknown minor (T3), 17-namespace occupancy + maintenance-guard test (T2), exhaustion probe RED→GREEN (T1/T6), no backend changes anywhere (spec "Backend interaction").
+- **Type consistency:** `xid_occupied(u32)`, `used_xids_in(base, mask) -> Vec<u32>`, `collect_xids_in(&self, base, mask, &mut Vec<u32>)`, `largest_free_xid_gap(base, mask, &[u32]) -> (u32, u32)` used identically across T2/T4/T5.
+- **Known judgment calls:** request fields parsed `from_le_bytes` matching the file-wide convention (big-endian clients are a pre-existing, codebase-wide limitation — not in scope); `log::info!` on the two recycling paths is deliberate diagnostics-that-stay (exhaustion triage).

--- a/docs/superpowers/specs/2026-06-12-xcmisc-design.md
+++ b/docs/superpowers/specs/2026-06-12-xcmisc-design.md
@@ -69,8 +69,8 @@ client's `byte_order` — same as every other reply encoder.
   bug-compatibility beats prettiness (libxcb's exhaustion check is
   `start == 0`).
 - GetXIDList with huge `count`: **explicit Xorg deviation.** Xorg
-  pre-rejects `count > u32::MAX/8` with BadAlloc, then allocates
-  `count × 8` bytes (multi-GB for hostile counts) and returns
+  pre-rejects `count > u32::MAX/4` with BadAlloc, then allocates
+  `count × 4` bytes (multi-GB for hostile counts) and returns
   BadAlloc on allocation failure (`xcmisc.c:101-106`). We instead
   clamp the scan to the client's range size — the reply can never
   exceed `min(count, mask+1)` entries (≤ ~4 MiB of reply), so no

--- a/docs/superpowers/specs/2026-06-12-xcmisc-design.md
+++ b/docs/superpowers/specs/2026-06-12-xcmisc-design.md
@@ -1,0 +1,216 @@
+# XC-MISC extension — design
+
+**Date:** 2026-06-12
+**Status:** draft
+**Branch:** `feat/xcmisc` (worktree `yserver-master`)
+
+## Problem
+
+yserver does not implement XC-MISC. When a long-lived client exhausts
+its ~1M-XID range (20-bit per-client mask, `resource_id_mask =
+0x000F_FFFF`; `server.rs` `PER_CLIENT_MASK`), libxcb's
+`xcb_generate_id()` calls XC-MISC `GetXIDRange` to recycle freed IDs.
+With the extension absent it returns the failure sentinel
+`0xffffffff`; the client's next create request draws `BadIDChoice`,
+and GDK-class clients treat X errors as fatal and exit cleanly.
+
+Observed 2026-06-12 on bee (lightdm/Cinnamon): the WM died silently
+at 1h43m, request serial 4.5M —
+`client 34 CreatePixmap BadIDChoice pid=0xffffffff (out-of-range)` in
+`target/x-0.log.old:30874`. Any compositing shell is a ~2h time bomb.
+Also the prime suspect for the recurring "window vanishes from
+yserver resources" bug (Firefox-heavy = high XID churn).
+
+## Goal
+
+Implement XC-MISC 1.1 (GetVersion, GetXIDRange, GetXIDList) matching
+Xorg (`Xext/xcmisc.c`, `dix/resource.c:707-775`,
+`/usr/include/X11/extensions/xcmiscproto.h`), so ID recycling works
+for every client on every backend.
+
+## Non-goals
+
+- Migrating existing `xid_in_use()` callers (fresh-ID validation in
+  CreateAnimCursor etc.) to the new comprehensive occupancy checker.
+  That's a latent-bug fix of its own (a client could today create a
+  pixmap over its own sync-counter ID) — follow-up, not this change.
+- Per-request access control / XACE analogues.
+
+## Protocol (from xcmiscproto.h — canonical)
+
+Extension name: `"XC-MISC"`. No events, no errors. Version 1.1.
+
+- **GetVersion (minor 0)**: req 8 bytes (`major(2), minor(2)` after
+  the 4-byte header — values ignored, Xorg echoes its own); reply:
+  32-byte fixed, `major(2)=1, minor(2)=1` at bytes 8..12, rest pad.
+- **GetXIDRange (minor 1)**: req 4 bytes (header only); reply 32-byte
+  fixed: `start_id(4)` at 8..12, `count(4)` at 12..16, rest pad.
+  Semantics: a contiguous range of `count` XIDs starting at
+  `start_id`, all inside the requesting client's `base..base|mask`
+  space and none currently designating a live resource. Exhausted →
+  `start_id = 0, count = 0` (Xorg `dix/resource.c:733-734` — wait,
+  `id > maxid → id = maxid = 0` then `count = max-min+1 = 1`; see
+  "Edge cases" below).
+- **GetXIDList (minor 2)**: req 8 bytes (`count(4)` after header);
+  reply: variable — `length = count_found` (each XID is one 4-byte
+  word), `count_found(4)` at bytes 8..12, pad to 32, then
+  `count_found` XIDs.
+
+Byte order: all fields through the existing `write_u16`/`write_u32`
+helpers (`yserver-protocol/src/x11/wire.rs:32-51`) honoring the
+client's `byte_order` — same as every other reply encoder.
+
+### Edge cases (Xorg-faithful)
+
+- Xorg's GetXIDRange returns `min=0, max=0` when the range is fully
+  exhausted, which encodes on the wire as `start_id=0, count=1`
+  (`max_id - min_id + 1`). XID 0 is never valid for creation, so
+  clients treat it as exhaustion. We replicate the same wire shape
+  (`start_id=0, count=1`) rather than inventing `count=0` —
+  bug-compatibility beats prettiness (libxcb's exhaustion check is
+  `start == 0`).
+- GetXIDList with huge `count`: Xorg returns BadAlloc only on
+  overflowing alloc; we instead clamp the scan to the client's range
+  size (`mask + 1` IDs max) — the reply can never exceed
+  `min(count, mask+1)` entries. No BadAlloc path needed (no
+  unbounded allocation exists). Deviation note: a client asking for
+  >2M IDs gets a shorter list than Xorg's theoretical (but equally
+  range-bounded) answer — observably identical in practice.
+- Length validation: GetVersion req must be 2 units, GetXIDRange 1
+  unit, GetXIDList 2 units — mismatch → BadLength via
+  `emit_x11_error_with_minor` (match the RENDER arm pattern).
+
+## Design
+
+### Extension registration
+
+- `nested.rs` `EXTENSIONS` table: add
+  `("XC-MISC", major 152, first_event 0, event_count 0, first_error 0,
+  ExtensionAvailability::Always)`. 152 is the next free major (128,
+  130, 133-138, 140-151 taken; gaps 129/131/132/139 left alone to
+  match the table's existing convention of not back-filling host-X11
+  opcodes). QueryExtension and ListExtensions pick it up for free via
+  `extension_query_reply` / `advertised_extension_names`.
+- `process_request.rs` dispatch: `152 => handle_xcmisc_request(...)`.
+
+### Comprehensive XID occupancy
+
+New method on `ServerState` (it needs both the resource table and the
+extension maps):
+
+```rust
+/// True iff `id` designates ANY live resource in ANY XID namespace.
+/// XC-MISC must never report an occupied ID as free — the 8
+/// ResourceTable maps (via `resources.xid_in_use`) plus the 9
+/// extension maps that `xid_in_use` does NOT cover.
+pub fn xid_occupied(&self, id: u32) -> bool {
+    self.resources.xid_in_use(ResourceId(id))
+        || self.xfixes_regions.contains_key(&id)
+        || self.sync_counters.contains_key(&id)
+        || self.sync_alarms.contains_key(&id)
+        || self.sync_fences.contains_key(&id)
+        || self.damage_objects.contains_key(&id)
+        || self.mit_shm_segments.contains_key(&id)
+        || self.glx_contexts.contains_key(&id)
+        || self.glx_drawables.contains_key(&id)
+        || self.present_event_selections.contains_key(&id)
+}
+```
+
+Maintenance hazard: a future extension adding a 10th XID-keyed map
+must extend this. Mitigation: doc comments on `xid_occupied` AND on
+`xid_in_use` cross-referencing each other, plus a test that seeds one
+resource of EVERY namespace and asserts occupancy (a new map without
+coverage shows up in review against that test's pattern).
+
+Zombie clients (RetainPermanent/Temporary) need no special handling:
+their bases are never released by `IdAllocator`, so a live client's
+range cannot contain another owner's resources. GetXIDRange/List
+operate purely within the requester's own `base..base|mask` window —
+ownership filtering is unnecessary; occupancy is sufficient.
+
+### GetXIDRange algorithm
+
+Xorg shrinks a `[id..maxid]` window around live resources via
+`AvailableID` probes. Equivalent and simpler given our map-based
+table: collect the client's used IDs once, sort, and scan gaps:
+
+```rust
+fn free_xid_range(state: &ServerState, base: u32, mask: u32) -> (u32, u32) {
+    let lo = base.max(1); // XID 0 is never allocatable
+    let hi = base | mask;
+    let mut used: Vec<u32> = state.used_xids_in(base, mask); // sorted
+    // scan [lo..hi] gaps between used ids; return the LARGEST gap
+    // as (start, count); none free → (0, 1) per the edge-case note.
+}
+```
+
+`used_xids_in(base, mask)` iterates the 17 maps' keys filtering by
+`(key & !mask) == base` — O(total resources), matching Xorg's cost.
+Returning the largest gap (vs Xorg's "whatever the shrink loop
+leaves") is strictly better for the client and protocol-conformant:
+the spec promises only "a range of unused IDs".
+
+### GetXIDList algorithm
+
+Xorg's brute scan, bounded: walk `id` from `max(base,1)` to
+`base|mask`, collect ids where `!xid_occupied(id)`, stop at
+`min(count, mask+1)` found. Worst case 2M `xid_occupied` probes
+(17 HashMap lookups each) on a degenerate request — acceptable for a
+"very rare" path (Xorg's own comment), and the loop short-circuits
+once `count` is found, which for libxcb is always small.
+
+### Handler shape
+
+`handle_xcmisc_request` in `process_request.rs`, modeled on
+`handle_render_request`: `match header.data { 0 => .., 1 => .., 2 => ..,
+other => log::debug + Handled }`. Reply encoders
+`write_xcmisc_get_version_reply` / `..get_xid_range_reply` /
+`..get_xid_list_reply` in `yserver-protocol/src/x11/mod.rs` next to
+the other fixed-size encoders, using `write_u16`/`write_u32`.
+
+### Backend interaction
+
+None. Pure core. ynest and KMS get it identically — the resource
+table is the single source of truth on both.
+
+## Testing
+
+1. **Unit (process_request tests mod, existing harness):**
+   - GetVersion: reply bytes = 1.1, correct sequence/major opcode.
+   - GetXIDRange on a fresh client: returns `(base.max(1),
+     full-range count)`.
+   - GetXIDRange with seeded occupancy: seed resources splitting the
+     range, assert returned range is the largest gap and contains no
+     occupied id.
+   - **Cross-namespace occupancy:** seed ONE resource from EACH of
+     the 17 namespaces at known ids; assert `xid_occupied` true for
+     every one of them and GetXIDList skips exactly those ids. (The
+     guard test for the maintenance hazard.)
+   - GetXIDList: exact count returned, ids ascending, none occupied,
+     all in-range; huge-count clamp; exhausted range → empty list.
+   - GetXIDRange fully-exhausted edge → wire shape `start_id=0,
+     count=1`.
+   - BadLength for malformed request sizes (all three minors).
+   - QueryExtension "XC-MISC" → present, opcode 152; ListExtensions
+     contains it.
+2. **Exhaustion smoke (`tools/xid-exhaust-probe.c`):** xcb client
+   that loops create/free pixmap >2^21 times (burning the ID space),
+   then asserts `xcb_generate_id()` still returns a valid id and a
+   final CreatePixmap+GetGeometry round-trip succeeds. Run against
+   ynest (backend-independent bug; fastest loop). Pre-fix: probe
+   FAILS with generate_id()==0xffffffff (reproduces bee incident);
+   post-fix: PASSES. Optional control run against Xephyr/Xorg.
+3. **HW/dogfood:** none required beyond normal soak — the bee
+   evidence run (a >2h Cinnamon session) is the real-world validation
+   and will happen organically.
+
+## Risks
+
+- Missing a current XID namespace in `xid_occupied` → hands out
+  colliding ids (the original bug, reintroduced subtly). Mitigated by
+  the cross-namespace seeded test; reviewers should independently
+  grep `HashMap<u32,` in server.rs/resources.rs against the list.
+- Future XID namespaces silently uncovered (see maintenance hazard).
+- `used_xids_in` collection cost per GetXIDRange call — O(total live
+  resources); calls are rare (only at exhaustion), no caching needed.

--- a/docs/superpowers/specs/2026-06-12-xcmisc-design.md
+++ b/docs/superpowers/specs/2026-06-12-xcmisc-design.md
@@ -48,9 +48,8 @@ Extension name: `"XC-MISC"`. No events, no errors. Version 1.1.
   Semantics: a contiguous range of `count` XIDs starting at
   `start_id`, all inside the requesting client's `base..base|mask`
   space and none currently designating a live resource. Exhausted →
-  `start_id = 0, count = 0` (Xorg `dix/resource.c:733-734` — wait,
-  `id > maxid → id = maxid = 0` then `count = max-min+1 = 1`; see
-  "Edge cases" below).
+  wire shape `start_id = 0, count = 1` (see "Edge cases" — this is
+  Xorg's exact encoding, not a typo).
 - **GetXIDList (minor 2)**: req 8 bytes (`count(4)` after header);
   reply: variable — `length = count_found` (each XID is one 4-byte
   word), `count_found(4)` at bytes 8..12, pad to 32, then
@@ -69,16 +68,29 @@ client's `byte_order` — same as every other reply encoder.
   (`start_id=0, count=1`) rather than inventing `count=0` —
   bug-compatibility beats prettiness (libxcb's exhaustion check is
   `start == 0`).
-- GetXIDList with huge `count`: Xorg returns BadAlloc only on
-  overflowing alloc; we instead clamp the scan to the client's range
-  size (`mask + 1` IDs max) — the reply can never exceed
-  `min(count, mask+1)` entries. No BadAlloc path needed (no
-  unbounded allocation exists). Deviation note: a client asking for
-  >2M IDs gets a shorter list than Xorg's theoretical (but equally
-  range-bounded) answer — observably identical in practice.
-- Length validation: GetVersion req must be 2 units, GetXIDRange 1
-  unit, GetXIDList 2 units — mismatch → BadLength via
-  `emit_x11_error_with_minor` (match the RENDER arm pattern).
+- GetXIDList with huge `count`: **explicit Xorg deviation.** Xorg
+  pre-rejects `count > u32::MAX/8` with BadAlloc, then allocates
+  `count × 8` bytes (multi-GB for hostile counts) and returns
+  BadAlloc on allocation failure (`xcmisc.c:101-106`). We instead
+  clamp the scan to the client's range size — the reply can never
+  exceed `min(count, mask+1)` entries (≤ ~4 MiB of reply), so no
+  unbounded allocation exists and no BadAlloc path is reachable by
+  construction (Rust `Vec` growth of ≤4 MiB aborts only on true
+  OOM, same as every other reply buffer in the server). Observable
+  difference vs Xorg: a request for more IDs than the range holds
+  gets `min(count, free-in-range)` instead of Xorg's identical-
+  in-practice range-bounded answer, and absurd counts get a short
+  list instead of BadAlloc. Rationale: never let a client make the
+  server allocate gigabytes.
+- Unknown minor opcode → **BadRequest** via
+  `emit_x11_error_with_minor` (Xorg's dispatcher default,
+  `xcmisc.c:129-141`) — NOT silently ignored.
+- Length validation: the top-level exact-length table
+  (`request_lengths`) is core-opcode-only, so XC-MISC validates
+  inside `handle_xcmisc_request`: GetVersion req must be 2 units
+  (8 bytes), GetXIDRange 1 unit (4 bytes), GetXIDList 2 units
+  (8 bytes) — mismatch → BadLength via `emit_x11_error_with_minor`
+  (match the RENDER arm pattern).
 
 ## Design
 
@@ -121,7 +133,13 @@ Maintenance hazard: a future extension adding a 10th XID-keyed map
 must extend this. Mitigation: doc comments on `xid_occupied` AND on
 `xid_in_use` cross-referencing each other, plus a test that seeds one
 resource of EVERY namespace and asserts occupancy (a new map without
-coverage shows up in review against that test's pattern).
+coverage shows up in review against that test's pattern). When
+auditing, note that not every `HashMap<u32, ..>` is an XID namespace:
+maps keyed by client ids, host xids, or internal handles
+(`zombie_clients`, `host_glyphset_refcounts`, host-side caches) are
+NOT client-XID-keyed and don't belong in `xid_occupied` — the test
+seeds only maps whose keys arrive from client `CARD32` resource-id
+fields on the wire.
 
 Zombie clients (RetainPermanent/Temporary) need no special handling:
 their bases are never released by `IdAllocator`, so a live client's
@@ -131,9 +149,14 @@ ownership filtering is unnecessary; occupancy is sufficient.
 
 ### GetXIDRange algorithm
 
-Xorg shrinks a `[id..maxid]` window around live resources via
-`AvailableID` probes. Equivalent and simpler given our map-based
-table: collect the client's used IDs once, sort, and scan gaps:
+Xorg walks the client's own resource buckets and shrinks a
+`[id..maxid]` window via `AvailableID` probes
+(`dix/resource.c:707-737`). We deliberately use a DIFFERENT,
+protocol-conformant implementation (the spec promises only "a
+contiguous range of unused IDs", not a particular one): collect the
+client's used IDs once, sort, and scan gaps. Not the same algorithm
+or cost profile as Xorg — an implementation choice, traded for
+simplicity against our map-based table:
 
 ```rust
 fn free_xid_range(state: &ServerState, base: u32, mask: u32) -> (u32, u32) {
@@ -164,7 +187,8 @@ once `count` is found, which for libxcb is always small.
 
 `handle_xcmisc_request` in `process_request.rs`, modeled on
 `handle_render_request`: `match header.data { 0 => .., 1 => .., 2 => ..,
-other => log::debug + Handled }`. Reply encoders
+other => BadRequest via emit_x11_error_with_minor }` (Xorg dispatcher
+default — see Edge cases). Reply encoders
 `write_xcmisc_get_version_reply` / `..get_xid_range_reply` /
 `..get_xid_list_reply` in `yserver-protocol/src/x11/mod.rs` next to
 the other fixed-size encoders, using `write_u16`/`write_u32`.
@@ -192,6 +216,7 @@ table is the single source of truth on both.
    - GetXIDRange fully-exhausted edge → wire shape `start_id=0,
      count=1`.
    - BadLength for malformed request sizes (all three minors).
+   - Unknown minor (e.g. 3) → BadRequest with minor echoed.
    - QueryExtension "XC-MISC" → present, opcode 152; ListExtensions
      contains it.
 2. **Exhaustion smoke (`tools/xid-exhaust-probe.c`):** xcb client

--- a/tools/xid-exhaust-probe.c
+++ b/tools/xid-exhaust-probe.c
@@ -1,0 +1,64 @@
+/* xid-exhaust-probe — system test for XC-MISC XID recycling.
+ *
+ * Allocates 1.25x the client's whole XID range via a create/free
+ * pixmap loop. Without XC-MISC, xcb_generate_id() returns
+ * 0xFFFFFFFF once the range is exhausted (the 2026-06-12 Cinnamon
+ * WM death); with it, libxcb transparently recycles freed IDs and
+ * the loop survives a full wrap.
+ *
+ * Build: cc -o target/xid-exhaust-probe tools/xid-exhaust-probe.c -lxcb
+ * Run:   DISPLAY=:97 ./target/xid-exhaust-probe
+ * Exit:  0 = PASS (recycling works), 1 = FAIL (exhausted), 2 = no display
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <xcb/xcb.h>
+
+int main(void) {
+    xcb_connection_t *c = xcb_connect(NULL, NULL);
+    if (!c || xcb_connection_has_error(c)) {
+        fprintf(stderr, "cannot connect to display\n");
+        return 2;
+    }
+    const xcb_setup_t *setup = xcb_get_setup(c);
+    xcb_screen_t *screen = xcb_setup_roots_iterator(setup).data;
+    uint32_t mask = setup->resource_id_mask;
+    unsigned long target = (unsigned long)mask + (mask >> 2); /* 1.25x range */
+    printf("resource_id_mask=0x%x; allocating %lu ids...\n", mask, target);
+
+    for (unsigned long i = 0; i < target; i++) {
+        uint32_t id = xcb_generate_id(c);
+        if (id == 0xFFFFFFFF) {
+            printf("FAIL: xcb_generate_id exhausted after %lu ids "
+                   "(no XC-MISC recycling)\n", i);
+            return 1;
+        }
+        xcb_create_pixmap(c, screen->root_depth, id, screen->root, 1, 1);
+        xcb_free_pixmap(c, id);
+        if ((i & 0xFFFF) == 0) {
+            xcb_flush(c);
+            /* drain any queued errors so the event queue stays flat */
+            xcb_generic_event_t *ev;
+            while ((ev = xcb_poll_for_event(c)) != NULL) {
+                if (((ev->response_type & 0x7f)) == 0)
+                    fprintf(stderr, "unexpected X error mid-loop\n");
+                free(ev);
+            }
+        }
+    }
+
+    /* survived a full wrap — prove a recycled id really works */
+    uint32_t id = xcb_generate_id(c);
+    xcb_void_cookie_t ck =
+        xcb_create_pixmap_checked(c, screen->root_depth, id, screen->root, 4, 4);
+    xcb_generic_error_t *err = xcb_request_check(c, ck);
+    if (err) {
+        printf("FAIL: post-wrap CreatePixmap error code=%d\n", err->error_code);
+        free(err);
+        return 1;
+    }
+    printf("PASS: %lu ids allocated across the range wrap; recycling works\n",
+           target);
+    xcb_disconnect(c);
+    return 0;
+}


### PR DESCRIPTION
## Problem

Long-lived clients die silently after ~2 hours: any client that exhausts its per-connection XID range (20-bit mask, ~1M IDs) has no way to recycle freed IDs, because yserver did not implement the **XC-MISC** extension. libxcb's `xcb_generate_id()` then returns the failure sentinel `0xffffffff`, the next create request draws `BadIDChoice`, and GDK-class clients treat X errors as fatal and `exit(1)` — no coredump, nothing in the journal.

Observed in the wild (2026-06-12, Cinnamon via lightdm): the WM vanished mid-session at 1h43m, request serial 4.5M:

```
client 34 CreatePixmap BadIDChoice pid=0xffffffff (out-of-range)
```

This is also the prime suspect for the long-standing "window vanishes from yserver resources" reports correlated with Firefox-heavy workloads (high XID churn → exhaustion → creates silently fail client-side).

## Fix

Implement XC-MISC 1.1 (major opcode 152) per Xorg (`Xext/xcmisc.c`, `dix/resource.c`):

- **GetVersion** — fixed 1.1 reply
- **GetXIDRange** — returns the largest contiguous free run in the client's range; Xorg-exact exhaustion wire shape (`start_id=0, count=1`)
- **GetXIDList** — range-bounded scan; counts clamped to the range size (deliberate deviation from Xorg's BadAlloc-or-allocate-GiB behavior — documented in the spec)
- New `ServerState::xid_occupied` consults **all 17 client-XID namespaces** (8 ResourceTable maps + 9 extension maps: XFixes regions, SYNC counters/alarms/fences, DAMAGE, MIT-SHM, GLX contexts/drawables, Present selections), with a guard test seeding every namespace so future XID-keyed maps can't silently escape coverage
- Error fidelity: BadLength per minor, BadRequest for unknown minors, minor opcode echoed in error replies

Design spec and implementation plan (each independently reviewed) are included under `docs/superpowers/`.

## Verification

`tools/xid-exhaust-probe.c` (committed) burns 1.25× the client's XID range via create/free-pixmap cycles:

| Environment | Pre-fix | Post-fix |
|---|---|---|
| unit/wire tests (12 new) | — | green |
| ynest (debug) | **FAIL at exactly 2^20 ids** | PASS, 1,310,718 ids |
| vng / KMS v2, Venus GPU path (release) | — | PASS in 2m40s |
| bare metal (real hardware) | (the original incident) | PASS |

Server log confirms the recycling handshake: `XC-MISC GetXIDRange → start=0x100000 count=1048576` firing exactly once at the range wrap.

Full workspace `cargo test --locked` green; plain clippy clean; `cargo +nightly fmt --check` clean.

## Note for testers

The probe is safe to run against a live session (it only create/frees its own 1×1 pixmaps), but it floods requests at maximum rate and currently starves the single-threaded core loop — expect the session to be unresponsive for the ~2-3 minute run. That starvation is a separate, now-tracked issue (missing Xorg-style client scheduling fairness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
