### PR TITLE
Declare MIT license in Cargo.toml (was GPL-3.0-only, contradicting LICENSE)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 version = "1.0.0"
 edition = "2024"
 repository = ""
-license = "GPL-3.0-only"
+license = "MIT"
 
 [workspace.dependencies]
 ash = "0.38"


### PR DESCRIPTION
The workspace `Cargo.toml` declared `GPL-3.0-only` while the repository ships an MIT `LICENSE` file (all crates inherit via `license.workspace = true`, so this is the single declaration). The intended license is **MIT** — this aligns the manifest with the LICENSE file.

Surfaced by @jboero in #13 (Fedora packaging needs an unambiguous `License:` tag). After this merges, the spec file in #13 is correct as written with `License: MIT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)