### PR TITLE
Fix/idle compositor redraw loop + get back input devices after hotplug

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -402,6 +402,133 @@ yserver-e16-xterm-hw-trace log="debug":
         kill -TERM $xtrace_pid $yserver_pid 2>/dev/null;\
         wait $yserver_pid 2>/dev/null;'
 
+# Capture the e16 IDLE protocol loop (no wezterm, no interaction) — for the
+# 2026-06-14 "idle never idles" investigation. Starts yserver + x11trace + e16
+# ALONE, lets it settle, then traces `secs` seconds of steady idle into
+# e16-idle.xtrace and tears down cleanly (self-terminating — no zap needed).
+# e16's pager redraws a live desktop miniature by sampling the root (~96
+# CopyArea/rebuild). On yserver this NEVER settles (~970 CopyArea/s for minutes);
+# on Xorg the pager draws once and STOPS. Compare against xorg-e16-idle-trace.
+# Keep `secs` small — the file grows fast at ~1000 req/s.
+#     just yserver-e16-idle-trace          # 5s steady-idle capture
+#     just yserver-e16-idle-trace secs=3
+yserver-e16-idle-trace secs="6" log="warn":
+    cargo build --bin yserver
+    rm -f e16-idle.xtrace
+    bash -c '\
+        unset WAYLAND_DISPLAY WAYLAND_SOCKET;\
+        export GDK_BACKEND=x11 XDG_SESSION_TYPE=x11;\
+        RUST_LOG="{{log}}" RUST_BACKTRACE=1 YSERVER_OPS_SAFE=1 target/debug/yserver > yserver-hw-e16.log 2>&1 &\
+        yserver_pid=$!;\
+        for i in $(seq 100); do [ -S /tmp/.X11-unix/X7 ] && break; sleep 0.1; done;\
+        x11trace -d :7 -D :8 -n -o e16-idle.xtrace >x11trace-idle.err 2>&1 &\
+        xtrace_pid=$!;\
+        for i in $(seq 50); do [ -S /tmp/.X11-unix/X8 ] && break; sleep 0.1; done;\
+        echo "starting e16 through trace; capturing ~{{secs}}s (incl startup). DO NOT touch input.";\
+        DISPLAY=:8 e16 > e16-hw.log 2>&1 &\
+        e16_pid=$!;\
+        sleep {{secs}};\
+        kill -TERM $e16_pid $xtrace_pid $yserver_pid 2>/dev/null;\
+        wait $yserver_pid 2>/dev/null;\
+        echo "done: $(wc -l < e16-idle.xtrace 2>/dev/null) trace lines in e16-idle.xtrace";'
+
+# REFERENCE: same e16 + pager on real Xorg, traced — the de-facto-spec compare
+# for the "idle never idles" bug. Run from a free text VT (Xorg.wrap lets a
+# console user start it). WATCH the screen: e16's pager draws its desktop
+# miniature column-by-column, then on Xorg it should STOP within a few seconds.
+# Longer default window than the yserver recipe so we confirm it settles to 0
+# CopyArea (if the pager finishes, the trace stays small).
+#     just xorg-e16-idle-trace           # 20s capture
+#     just xorg-e16-idle-trace secs=30
+xorg-e16-idle-trace secs="20":
+    rm -f e16-xorg.xtrace
+    bash -c '\
+        unset WAYLAND_DISPLAY WAYLAND_SOCKET;\
+        export GDK_BACKEND=x11 XDG_SESSION_TYPE=x11;\
+        Xorg :9 -keeptty > xorg9.log 2>&1 &\
+        xorg_pid=$!;\
+        for i in $(seq 150); do [ -S /tmp/.X11-unix/X9 ] && break; sleep 0.1; done;\
+        if [ ! -S /tmp/.X11-unix/X9 ]; then echo "FAIL: Xorg :9 did not start"; tail -20 xorg9.log; kill $xorg_pid 2>/dev/null; exit 1; fi;\
+        x11trace -d :9 -D :10 -n -o e16-xorg.xtrace >x11trace-xorg.err 2>&1 &\
+        xtrace_pid=$!;\
+        for i in $(seq 50); do [ -S /tmp/.X11-unix/X10 ] && break; sleep 0.1; done;\
+        echo "e16 on Xorg :9 via trace; capturing {{secs}}s. WATCH: does the pager stop drawing?";\
+        DISPLAY=:10 e16 > e16-xorg.log 2>&1 &\
+        e16_pid=$!;\
+        sleep {{secs}};\
+        kill -TERM $e16_pid $xtrace_pid $xorg_pid 2>/dev/null;\
+        wait $xorg_pid 2>/dev/null;\
+        echo "done: $(wc -l < e16-xorg.xtrace 2>/dev/null) trace lines; CopyArea=$(grep -c CopyArea e16-xorg.xtrace 2>/dev/null)";'
+
+# Idle-rate check under fvwm3 (a quiet, non-polling WM — unlike e16's pager).
+# Brings up yserver + fvwm3 with YSERVER_LOOP_TELEMETRY=1, telemetry -> the same
+# target/yserver-telemetry.log we watch. Leave it idle (don't touch input) and
+# the per-second "vk call rate" / "loop telemetry" lines should show
+# compose=0 / req/s=0 once settled — the decisive "yserver reaches 0/s" gate
+# (the cursor-damage idle fix). Zap or Ctrl-C to stop.
+yserver-fvwm3-idle log="info":
+    cargo build --bin yserver
+    bash -c '\
+        unset WAYLAND_DISPLAY WAYLAND_SOCKET;\
+        export GDK_BACKEND=x11 XDG_SESSION_TYPE=x11;\
+        RUST_LOG="{{log}}" YSERVER_LOOP_TELEMETRY=1 RUST_BACKTRACE=1 target/debug/yserver > target/yserver-telemetry.log 2>&1 &\
+        yserver_pid=$!;\
+        for i in $(seq 100); do [ -S /tmp/.X11-unix/X7 ] && break; sleep 0.1; done;\
+        DISPLAY=:7 fvwm3 > target/fvwm3-idle.log 2>&1 &\
+        echo "fvwm3 up on :7; telemetry -> target/yserver-telemetry.log. Leave idle; watch compose rate. Zap/Ctrl-C to stop.";\
+        wait $yserver_pid 2>/dev/null;'
+
+# Input-device hotplug probe for the "mouse doesn't return after monitor
+# off->on" issue (2026-06-14, vs GNOME-Wayland which recovers it). Runs yserver
+# + fvwm3 AND a UTC-timestamped `udevadm monitor` of the input subsystem, so we
+# can correlate WHEN the kernel re-creates the mouse node vs WHEN yserver picks
+# it up. Procedure: run from a VT, then physically power the monitor OFF, wait
+# ~5s, power ON, move the mouse; then zap/Ctrl-C. Compare:
+#   target/yserver-hotplug.log  — yserver `xi-device`/`libinput` add/remove
+#   target/udev-input.log       — kernel/udev input device add/remove
+# kernel-add at screen-on but yserver-add only later => yserver hotplug bug.
+yserver-input-hotplug-probe log="info":
+    cargo build --bin yserver
+    rm -f target/udev-input.log target/yserver-hotplug.log
+    bash -c '\
+        unset WAYLAND_DISPLAY WAYLAND_SOCKET;\
+        export GDK_BACKEND=x11 XDG_SESSION_TYPE=x11;\
+        ( stdbuf -oL udevadm monitor --udev --kernel --subsystem-match=input 2>&1 | while IFS= read -r l; do printf "%s %s\n" "$(date -u +%H:%M:%S.%3N)" "$l"; done > target/udev-input.log ) &\
+        udev_pid=$!;\
+        RUST_LOG="{{log}}" RUST_BACKTRACE=1 target/debug/yserver > target/yserver-hotplug.log 2>&1 &\
+        yserver_pid=$!;\
+        for i in $(seq 100); do [ -S /tmp/.X11-unix/X7 ] && break; sleep 0.1; done;\
+        DISPLAY=:7 fvwm3 > target/fvwm3-hotplug.log 2>&1 &\
+        echo "up. NOW: power monitor OFF, wait ~5s, power ON, move mouse. Then zap/Ctrl-C.";\
+        echo "logs: target/yserver-hotplug.log + target/udev-input.log";\
+        wait $yserver_pid 2>/dev/null;\
+        kill $udev_pid 2>/dev/null;'
+
+# Same probe under a full Cinnamon session (the DE the original freeze + storm
+# repros used). Release build + YSERVER_LOOP_TELEMETRY (compose rate) + xi-device
+# logging + udev input monitor. Lets us check, in one run: (a) does Cinnamon idle
+# to compose=0, (b) does the mouse re-acquire on monitor off->on, (c) does the
+# storm recur. Let Cinnamon FULLY settle (~20s) before judging idle; then power
+# the monitor OFF ~5s / ON / move mouse; then log out or zap.
+#   watch: target/yserver-cinnamon-probe.log (RATE + xi-device) + target/udev-input.log
+yserver-cinnamon-hotplug-probe log="info":
+    cargo build --release --bin yserver
+    rm -f target/udev-input.log target/yserver-cinnamon-probe.log
+    bash -c '\
+        xdg_rd=$(mktemp -d -t yserver-run.XXXXXX); chmod 700 "$xdg_rd";\
+        ( stdbuf -oL udevadm monitor --udev --kernel --subsystem-match=input 2>&1 | while IFS= read -r l; do printf "%s %s\n" "$(date -u +%H:%M:%S.%3N)" "$l"; done > target/udev-input.log ) &\
+        udev_pid=$!;\
+        YSERVER_LOOP_TELEMETRY=1 RUST_LOG="{{log}}" RUST_BACKTRACE=1 target/release/yserver > target/yserver-cinnamon-probe.log 2>&1 &\
+        yserver_pid=$!;\
+        for i in $(seq 100); do [ -S /tmp/.X11-unix/X7 ] && break; sleep 0.1; done;\
+        echo "yserver up; starting Cinnamon. Let it settle ~20s, check idle, then power-cycle the monitor + move mouse. Log out / zap to stop.";\
+        env -u WAYLAND_DISPLAY -u WAYLAND_SOCKET DISPLAY=:7 GDK_BACKEND=x11 \
+            XDG_SESSION_TYPE=x11 XDG_RUNTIME_DIR="$xdg_rd" \
+            dbus-run-session cinnamon-session > cinnamon.log 2>&1;\
+        kill -TERM $yserver_pid $udev_pid 2>/dev/null;\
+        wait $yserver_pid 2>/dev/null;\
+        rm -rf "$xdg_rd" 2>/dev/null;'
+
 yserver-wmaker-xterm-hw log="debug":
     cargo build --bin yserver
     bash -c '\

--- a/Justfile
+++ b/Justfile
@@ -441,6 +441,36 @@ yserver-wmaker-xterm-hw-trace log="debug":
         kill -TERM $xtrace_pid $yserver_pid 2>/dev/null;\
         wait $yserver_pid 2>/dev/null;'
 
+# DPMS / device-loss leak repro (the overnight "screen on but dead" bug,
+# 2026-06-14). Launches yserver-hw with YSERVER_LOOP_TELEMETRY=1 (per-second
+# PixmapPool stats — the leak detector) + targeted DPMS/scanout/device-loss
+# logging, and stays alive so you can drive the workload and watch.
+#
+# Then, from an ssh shell, reproduce + observe:
+#   # leak: does the PixmapPool count climb while the display is off?
+#   tail -f target/yserver-telemetry.log | grep -iE 'pool|pixmap|DEVICE_LOST|dpms|disable_output'
+#   # hotplug: does the connector drop the link on standby?
+#   watch -n1 'cat /sys/class/drm/card1-HDMI-A-2/status /sys/class/drm/card1-HDMI-A-2/dpms'
+#   dmesg -w | grep -iE 'hdmi|connector|hpd|amdgpu|reset'
+# Drive it: start a continuous full-screen renderer (the real trigger was
+# cinnamon-screensaver doing MIT-SHM PutImage), then `DISPLAY=:7 xset dpms
+# force off` and leave it. Watch for pool growth + the device-loss cascade.
+# Ctrl-C to stop.
+yserver-dpms-telemetry log="info,yserver::kms::v2::backend=debug,yserver::kms::v2::platform=debug,yserver::kms::v2::scene=debug,yserver::kms::vk::scanout=debug,yserver::drm=debug":
+    cargo build --bin yserver
+    bash -c '\
+        unset WAYLAND_DISPLAY WAYLAND_SOCKET;\
+        export GDK_BACKEND=x11 XDG_SESSION_TYPE=x11;\
+        RUST_LOG="{{log}}" YSERVER_LOOP_TELEMETRY=1 RUST_BACKTRACE=1 \
+            target/debug/yserver > target/yserver-telemetry.log 2>&1 &\
+        yserver_pid=$!;\
+        sleep 2;\
+        DISPLAY=:7 e16 > target/e16-dpms.log 2>&1 &\
+        echo "yserver up on :7 (pid $yserver_pid); telemetry+log -> target/yserver-telemetry.log";\
+        echo "drive: DISPLAY=:7 <full-screen renderer>, then DISPLAY=:7 xset dpms force off";\
+        echo "watch: pool growth in the log; /sys/class/drm/.../status for hotplug. Ctrl-C to stop.";\
+        wait $yserver_pid 2>/dev/null;'
+
 # Run picom against yserver as a RENDER smoke test. picom v13's
 # `xrender` backend exercises a wider RENDER surface than xfwm4 /
 # marco do — useful for shaking out RENDER coverage gaps once the

--- a/crates/yserver-core/src/backend/trait_def.rs
+++ b/crates/yserver-core/src/backend/trait_def.rs
@@ -338,6 +338,15 @@ pub trait Backend: Send {
     /// never registered.
     fn on_libinput_ready(&mut self, _state: &mut ServerState) {}
 
+    /// Called once per core-loop iteration (with `state`) so a backend can
+    /// service time-based input work that isn't tied to an fd readiness edge —
+    /// specifically, retry a libseat device open that was DEFERRED by a lagging
+    /// udev ACL on a freshly re-enumerated device (the "mouse stuck after
+    /// monitor off→on" bug). The backend gates its own work on a retry deadline
+    /// (and reports that deadline via [`Backend::next_wakeup`] so the loop wakes
+    /// for it). Default: no-op. project_mouse_hotplug_lost_wakeup.
+    fn poll_deferred_input(&mut self, _state: &mut ServerState) {}
+
     /// Drain libinput's INITIAL device enumeration and seed the XI2
     /// device registry (`state.xi_devices`) BEFORE the core serves any
     /// client — the Xorg model of probing input at startup.

--- a/crates/yserver-core/src/core_loop/run.rs
+++ b/crates/yserver-core/src/core_loop/run.rs
@@ -752,6 +752,14 @@ pub fn run_core(
             crate::core_loop::process_disconnect::process_disconnect(state, backend, disc_id);
         }
 
+        // Service time-based input work that isn't tied to an fd edge —
+        // specifically, retry a libseat device open that a lagging udev ACL
+        // deferred after a monitor-hub hot-add (the "mouse stuck after monitor
+        // off→on until a keypress" bug). No-op unless a retry window is armed;
+        // the backend reports its retry cadence via `next_wakeup`.
+        // project_mouse_hotplug_lost_wakeup.
+        backend.poll_deferred_input(state);
+
         // Wake the composite path back up if the backend went dormant
         // after the previous pageflip-complete (because nothing was
         // dirty) and fresh damage has since arrived. No-op for

--- a/crates/yserver/src/input_thread.rs
+++ b/crates/yserver/src/input_thread.rs
@@ -469,8 +469,31 @@ pub(crate) fn run(
     }
 
     let mut buf = [EpollEvent::empty(); 4];
+    // Mouse-hotplug retry window (project_mouse_hotplug_lost_wakeup). After a
+    // device add/remove, a re-enumerated sibling device's open can be DEFERRED
+    // by a lagging udev uaccess ACL; the level-triggered libinput fd does NOT
+    // re-wake once that udev event is consumed, so without a timeout the thread
+    // would block until unrelated input arrives (the "mouse stuck after monitor
+    // off→on until a keypress" bug, also seen in direct/lightdm mode). While
+    // armed, give epoll_wait a ~250ms timeout so we re-dispatch and complete
+    // the deferred open; the window only extends on further device churn, so it
+    // converges and the thread returns to a blocking wait once devices settle.
+    let mut hotplug_retry_until: Option<std::time::Instant> = None;
     loop {
-        match input_epoll.wait(&mut buf, EpollTimeout::NONE) {
+        let timeout = match hotplug_retry_until {
+            Some(until) => {
+                let now = std::time::Instant::now();
+                if now >= until {
+                    hotplug_retry_until = None;
+                    EpollTimeout::NONE
+                } else {
+                    let ms = u16::try_from((until - now).as_millis().min(250)).unwrap_or(250);
+                    EpollTimeout::from(ms.max(1))
+                }
+            }
+            None => EpollTimeout::NONE,
+        };
+        match input_epoll.wait(&mut buf, timeout) {
             Ok(n) => {
                 if buf[..n].iter().any(|e| e.data() == EPOLL_DATA_CONTROL)
                     && let Some(command) = control.drain()
@@ -556,8 +579,22 @@ pub(crate) fn run(
             }
         };
 
+        // Arm the hotplug retry window on a device add/remove so a deferred
+        // sibling-device open gets retried via the epoll timeout above (the
+        // level-triggered fd won't re-wake on its own once the udev event is
+        // consumed). project_mouse_hotplug_lost_wakeup.
+        let device_change = events.iter().any(|e| {
+            matches!(
+                e,
+                InputEvent::DeviceAdded(_) | InputEvent::DeviceRemoved { .. }
+            )
+        });
         let time_ms = current_time_ms();
         process_batch(&mut state, &sender, &mut pending_motion, events, time_ms)?;
+        if device_change {
+            hotplug_retry_until =
+                Some(std::time::Instant::now() + std::time::Duration::from_millis(2500));
+        }
         // Flush any pending motion before the next epoll_wait so the
         // core sees end-of-burst movement promptly. A subsequent batch
         // whose first event is another motion just starts coalescing

--- a/crates/yserver/src/kms/v2/backend.rs
+++ b/crates/yserver/src/kms/v2/backend.rs
@@ -373,6 +373,15 @@ pub struct KmsBackendV2 {
     /// Hotkey detector — used on the core thread in libseat mode
     /// (`on_libinput_ready`).
     hotkey: crate::input::hotkey::HotkeyDetector,
+    /// Mouse-hotplug retry window (project_mouse_hotplug_lost_wakeup). When a
+    /// libinput device add/remove — or an empty wake during device churn — is
+    /// seen on the on-core (libseat) path, the libseat open of a freshly
+    /// re-enumerated device can be deferred by a lagging udev uaccess ACL, so
+    /// libinput surfaces no `DeviceAdded` and the idle loop would otherwise
+    /// sleep without retrying. While `Some` and not yet elapsed, the core loop
+    /// re-dispatches libinput (`poll_deferred_input`) to retry the deferred
+    /// open, then clears the window — preserving the idle-sleep once settled.
+    libinput_hotplug_retry_until: Option<std::time::Instant>,
 
     /// GLX-TFP (Tasks 2.3 + 2.4): per-`DrawableId` export tracking for
     /// pixmaps shared with a GL consumer via `GLX_EXT_texture_from_pixmap`.
@@ -788,6 +797,7 @@ impl KmsBackendV2 {
             input_sender: None,
             input_thread_control: None,
             hotkey: crate::input::hotkey::HotkeyDetector::new(),
+            libinput_hotplug_retry_until: None,
             exported_dmabufs: HashMap::new(),
             dmabuf_export_supported,
         };
@@ -925,6 +935,7 @@ impl KmsBackendV2 {
             input_sender: None,
             input_thread_control: None,
             hotkey: crate::input::hotkey::HotkeyDetector::new(),
+            libinput_hotplug_retry_until: None,
             exported_dmabufs: HashMap::new(),
             dmabuf_export_supported,
         };
@@ -1735,6 +1746,7 @@ impl KmsBackendV2 {
             input_sender: None,
             input_thread_control: None,
             hotkey: crate::input::hotkey::HotkeyDetector::new(),
+            libinput_hotplug_retry_until: None,
             exported_dmabufs: HashMap::new(),
             dmabuf_export_supported: false,
         }
@@ -8903,9 +8915,22 @@ impl Backend for KmsBackendV2 {
         } else {
             None
         };
+        // Mouse-hotplug retry cadence: while the window is armed, wake at most
+        // ~250 ms out (capped at the window end) so an idle loop still
+        // re-dispatches libinput to retry a deferred device open. Not gated on
+        // `allow_kms_timers` — input recovery must run regardless of scanout
+        // state. project_mouse_hotplug_lost_wakeup.
+        let hotplug_retry_deadline = self.libinput_hotplug_retry_until.map(|until| {
+            if now >= until {
+                now
+            } else {
+                (now + std::time::Duration::from_millis(250)).min(until)
+            }
+        });
         scene_deadline
             .into_iter()
             .chain(present_deadline)
+            .chain(hotplug_retry_deadline)
             .chain(
                 allow_kms_timers
                     .then(|| self.cursor_anim_deadline())
@@ -9346,6 +9371,10 @@ impl Backend for KmsBackendV2 {
         let time_ms = crate::clock::server_time_ms();
         let mut scroll_buf: Vec<yserver_core::core_loop::HostInputEvent> = Vec::new();
         let mut pending_motion: Option<yserver_core::core_loop::HostInputEvent> = None;
+        // Did libinput surface a device add/remove this service? If so, a
+        // sibling device's libseat open may be DEFERRED by a lagging udev ACL
+        // — arm a bounded retry window below. project_mouse_hotplug_lost_wakeup.
+        let mut device_change = false;
         // Route via `core_loop::handle_host_input` (not `self.on_host_input`
         // directly) so `update_repeat_state` arms the core's auto-repeat
         // timer for real input. The off-thread input_thread path goes
@@ -9366,6 +9395,7 @@ impl Backend for KmsBackendV2 {
             // Device add/remove — forward directly, flushing pending
             // motion first to preserve chronological order.
             if let crate::input::InputEvent::DeviceAdded(info) = ev {
+                device_change = true;
                 if let Some(m) = pending_motion.take() {
                     yserver_core::core_loop::handle_host_input(state, self, m);
                 }
@@ -9377,6 +9407,7 @@ impl Backend for KmsBackendV2 {
                 continue;
             }
             if let crate::input::InputEvent::DeviceRemoved { device_node } = ev {
+                device_change = true;
                 if let Some(m) = pending_motion.take() {
                     yserver_core::core_loop::handle_host_input(state, self, m);
                 }
@@ -9429,6 +9460,41 @@ impl Backend for KmsBackendV2 {
         if let Some(m) = pending_motion.take() {
             yserver_core::core_loop::handle_host_input(state, self, m);
         }
+        if device_change {
+            // A device add/remove just landed. The libseat open of a freshly
+            // re-enumerated sibling device can be DEFERRED by a lagging udev
+            // uaccess ACL — libinput surfaces no `DeviceAdded` for it and the
+            // idle loop would sleep without retrying until unrelated input
+            // arrives (the "mouse stuck after monitor off→on, fixed by a
+            // keypress" bug). Arm a bounded retry window so `poll_deferred_input`
+            // re-dispatches libinput and completes the open on its own. The
+            // window only extends on further device churn, so once devices
+            // settle it elapses and the idle-sleep is preserved.
+            // project_mouse_hotplug_lost_wakeup.
+            self.libinput_hotplug_retry_until =
+                Some(std::time::Instant::now() + std::time::Duration::from_millis(2500));
+        }
+    }
+
+    fn poll_deferred_input(&mut self, state: &mut ServerState) {
+        // Service the mouse-hotplug retry window. While armed and unexpired,
+        // re-dispatch the on-core libinput so a libseat open that was DEFERRED
+        // by a lagging udev ACL (on a device re-enumerated by a monitor-hub
+        // power-cycle) is retried and completes on its own — no unrelated
+        // keypress needed. `next_wakeup` returns the ~250 ms retry cadence so
+        // the loop wakes even when otherwise idle. project_mouse_hotplug_lost_wakeup.
+        let Some(until) = self.libinput_hotplug_retry_until else {
+            return;
+        };
+        if std::time::Instant::now() >= until {
+            // Window elapsed: stop retrying and let the loop idle again.
+            self.libinput_hotplug_retry_until = None;
+            return;
+        }
+        // `on_libinput_ready` re-arms/extends the window only if it surfaces a
+        // further device add/remove; a retry that finds nothing new does not,
+        // so the window converges and elapses once devices settle.
+        self.on_libinput_ready(state);
     }
 
     fn apply_device_config(
@@ -15870,6 +15936,51 @@ mod tests {
         assert!(
             deadline <= std::time::Instant::now() + std::time::Duration::from_millis(2),
             "pending PRESENT deadline should still be near-term with outputs off",
+        );
+    }
+
+    // project_mouse_hotplug_lost_wakeup: an armed hotplug-retry window makes
+    // the idle loop wake on the ~250ms retry cadence; an elapsed window is
+    // cleared so the loop returns to true idle.
+    #[test]
+    fn hotplug_retry_window_arms_next_wakeup_cadence() {
+        let mut b = KmsBackendV2::for_tests();
+        assert!(
+            b.next_wakeup().is_none(),
+            "idle backend with no retry window must not schedule a wakeup",
+        );
+        let now = std::time::Instant::now();
+        b.libinput_hotplug_retry_until = Some(now + std::time::Duration::from_secs(2));
+        let wake = b
+            .next_wakeup()
+            .expect("an armed hotplug-retry window must produce a wakeup");
+        assert!(
+            wake <= now + std::time::Duration::from_millis(260),
+            "retry cadence should be ~250ms; got {:?} out",
+            wake.saturating_duration_since(now),
+        );
+    }
+
+    #[test]
+    fn poll_deferred_input_clears_expired_hotplug_window() {
+        let mut b = KmsBackendV2::for_tests();
+        let mut state = ServerState::new();
+        // Elapsed window → cleared, so next_wakeup can fall back to None (idle).
+        b.libinput_hotplug_retry_until =
+            Some(std::time::Instant::now() - std::time::Duration::from_millis(1));
+        b.poll_deferred_input(&mut state);
+        assert!(
+            b.libinput_hotplug_retry_until.is_none(),
+            "an elapsed retry window must be cleared so the loop can idle",
+        );
+        // Unexpired window → stays armed. (core_libinput is None in the
+        // fixture, so the re-dispatch is a no-op and cannot re-arm/clear it.)
+        b.libinput_hotplug_retry_until =
+            Some(std::time::Instant::now() + std::time::Duration::from_secs(2));
+        b.poll_deferred_input(&mut state);
+        assert!(
+            b.libinput_hotplug_retry_until.is_some(),
+            "an unexpired retry window must stay armed until it elapses",
         );
     }
 

--- a/crates/yserver/src/kms/v2/backend.rs
+++ b/crates/yserver/src/kms/v2/backend.rs
@@ -8878,14 +8878,19 @@ impl Backend for KmsBackendV2 {
 
     fn next_wakeup(&self) -> Option<std::time::Instant> {
         let now = std::time::Instant::now();
-        let scene_deadline = if self.scene.scene_structure_dirty {
-            if self.scene.has_output_ready_for_submit() {
-                Some(now)
+        let allow_kms_timers = self.scanout_allowed() && self.kms_outputs_active;
+        let scene_deadline = if allow_kms_timers {
+            if self.scene.scene_structure_dirty {
+                if self.scene.has_output_ready_for_submit() {
+                    Some(now)
+                } else {
+                    self.scene.earliest_retry_deadline()
+                }
             } else {
                 self.scene.earliest_retry_deadline()
             }
         } else {
-            self.scene.earliest_retry_deadline()
+            None
         };
         let needs_present_poll = self.pending_present_batches.iter().any(|batch| {
             matches!(
@@ -8901,7 +8906,11 @@ impl Backend for KmsBackendV2 {
         scene_deadline
             .into_iter()
             .chain(present_deadline)
-            .chain(self.cursor_anim_deadline())
+            .chain(
+                allow_kms_timers
+                    .then(|| self.cursor_anim_deadline())
+                    .flatten(),
+            )
             .min()
     }
 
@@ -15818,6 +15827,52 @@ mod tests {
         );
     }
 
+    #[test]
+    fn next_wakeup_suppresses_scene_deadline_when_scanout_disallowed() {
+        use crate::seat::state::SeatState;
+
+        let mut b = KmsBackendV2::for_tests();
+        b.scene.scene_structure_dirty = true;
+        assert!(
+            b.next_wakeup()
+                .is_some_and(|wake| wake <= std::time::Instant::now()),
+            "dirty scene should wake immediately while scanout is allowed",
+        );
+
+        b.seat_state = SeatState::Suspended;
+        assert!(
+            b.next_wakeup().is_none(),
+            "dirty scene must not busy-wake while scanout is disallowed",
+        );
+    }
+
+    #[test]
+    fn present_poll_deadline_survives_outputs_off() {
+        let mut b = KmsBackendV2::for_tests();
+        b.kms_outputs_active = false;
+        b.scene.scene_structure_dirty = true;
+
+        b.enqueue_present_completion(
+            yserver_core::backend::CompletedPresentEvent {
+                client_id: yserver_protocol::x11::ClientId(0),
+                serial: 1,
+                host_xid: 0x1000,
+                dst_host_xid: 0x1001,
+                options: 0,
+                wake: yserver_core::backend::PresentWake::Pixmap { idle_fence_xid: 0 },
+            },
+            0x1001,
+        );
+
+        let deadline = b
+            .next_wakeup()
+            .expect("present poll deadline must survive DPMS-off gating");
+        assert!(
+            deadline <= std::time::Instant::now() + std::time::Duration::from_millis(2),
+            "pending PRESENT deadline should still be near-term with outputs off",
+        );
+    }
+
     /// Spec: "boots far enough to service GetGeometry / InternAtom".
     /// Backend::xid_map reflects KmsCore's root xid seed via
     /// for_tests — empty xid map is fine for this test since the
@@ -22316,6 +22371,7 @@ mod tests {
     /// active and scanout is allowed (EINVAL-storm discipline).
     #[test]
     fn anim_deadline_gated_on_outputs_active() {
+        use crate::seat::state::SeatState;
         use std::time::{Duration, Instant};
         use yserver_core::backend::{Backend, PixmapHandle};
 
@@ -22364,6 +22420,21 @@ mod tests {
         assert!(
             b.active_cursor_anim.as_ref().unwrap().next_frame > Instant::now(),
             "re-armed from now: next_frame must be a future instant after DPMS restore tick",
+        );
+
+        // VT-away / master-drop uses the same scheduler suppression.
+        b.seat_state = SeatState::Suspended;
+        b.active_cursor_anim.as_mut().unwrap().next_frame =
+            Instant::now() - Duration::from_millis(1);
+        assert!(
+            b.next_wakeup().is_none_or(|w| w > Instant::now()),
+            "stale anim deadline must not be reported while scanout is disallowed",
+        );
+        b.tick_cursor_animation();
+        assert_eq!(
+            b.active_cursor_anim.as_ref().unwrap().frame,
+            frame,
+            "tick must not advance while scanout is disallowed",
         );
     }
 

--- a/crates/yserver/src/kms/v2/scene.rs
+++ b/crates/yserver/src/kms/v2/scene.rs
@@ -125,6 +125,14 @@ struct PendingAck {
     /// committed to the screen after this flip. Failed submit
     /// → mode stays as-is.
     cursor_mode_after_retire: OutputCursorMode,
+    /// Cursor footprint that this output actually presented in the
+    /// submitted frame. Applied only on retire so a failed submit
+    /// leaves the old footprint in place for the next re-poke.
+    last_present_cursor_rect_after_retire: Option<vk::Rect2D>,
+    /// Cursor sprite version that this output actually presented in
+    /// the submitted frame. `None` when the cursor is hidden on
+    /// this output.
+    last_present_cursor_version_after_retire: Option<u64>,
 }
 
 /// Stage 5 Phase C — pure result of the cursor-plane strategy
@@ -133,9 +141,9 @@ struct PendingAck {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CursorAssignment {
     /// HW plane should display the sprite at this position. The
-    /// SW cursor draw is omitted from `scene.draws`; the SW prev
-    /// rect is still damaged so the buffer-age clipped/LOAD path
-    /// clears any prior pixels off the underlying scanout BO.
+    /// SW cursor draw is omitted from `scene.draws`. Damage is
+    /// decided later in `tick_one_output` from the transactional
+    /// presented-footprint state, not here.
     Hw {
         x: i32,
         y: i32,
@@ -144,15 +152,15 @@ pub(crate) enum CursorAssignment {
         hot_y: u16,
     },
     /// SW path — sprite drawn into the scanout BO via composite.
-    /// `scene.draws` carries the cursor entry; prev + new rect
-    /// added to projected damage. `pos` is the output-local
-    /// top-left of the cursor draw (`cursor.xy − hot − layout`)
-    /// — propagates into `OutputSceneState.cursor_prev_pos` on
-    /// successful retire so the next tick damages this rect to
-    /// clear the SW trail.
+    /// `scene.draws` carries the cursor entry. `pos` is the
+    /// output-local top-left of the cursor draw
+    /// (`cursor.xy − hot − layout`) — it propagates into
+    /// `OutputSceneState.cursor_prev_pos` on successful retire so
+    /// the next tick can clear the SW trail if the cursor moves.
     Sw { pos: (i32, i32) },
-    /// Cursor off-output / unregistered / clipped. SW path damages
-    /// the prev rect (if any) so trails clear; nothing is drawn.
+    /// Cursor off-output / unregistered / clipped. Nothing is drawn;
+    /// tick-level cursor-damage gating decides whether the last
+    /// presented footprint needs clearing.
     Hidden,
 }
 
@@ -362,6 +370,14 @@ struct OutputSceneState {
     /// successfully — a failed submit must leave the OLD prev rect
     /// in place so the next frame still clears the trail.
     cursor_prev_pos: Option<(i32, i32)>,
+    /// Cursor footprint from the last successfully presented frame
+    /// on this output. Used to decide whether the current frame
+    /// needs cursor damage and to re-poke pure HW hide/show cases.
+    last_present_cursor_rect: Option<vk::Rect2D>,
+    /// Cursor sprite version from the last successfully presented
+    /// frame on this output. Lets a stationary sprite swap damage
+    /// once, then return to idle.
+    last_present_cursor_version: Option<u64>,
     /// Diagnostic: last reason `tick_one_output` skipped a tick for
     /// this output. Logged at INFO on transition (skip→different-skip,
     /// no-skip→skip, skip→no-skip). Tracks the freeze-debug
@@ -369,9 +385,9 @@ struct OutputSceneState {
     last_skip_reason: Option<TickSkipReason>,
 }
 
-/// Diagnostic: why `tick_one_output` returned `Ok(false)` for an
-/// output. Used to identify which gate is stuck when an output
-/// stops getting page-flips. See `record_tick_skip`.
+/// Diagnostic: why `tick_one_output` skipped an output. Used to
+/// identify which gate is stuck when an output stops getting
+/// page-flips. See `record_tick_skip`.
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 enum TickSkipReason {
     /// `pending_acks` non-empty — flip in flight, KMS would EBUSY.
@@ -384,6 +400,21 @@ enum TickSkipReason {
     NoBO,
     /// `pool_ring.acquire` returned None — descriptor-pool ring exhausted.
     NoPool,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+enum TickOutcome {
+    Composed,
+    Skipped(TickSkipReason),
+}
+
+impl TickOutcome {
+    fn clears_scene_structure_dirty(self) -> bool {
+        matches!(
+            self,
+            Self::Composed | Self::Skipped(TickSkipReason::EmptyDamage)
+        )
+    }
 }
 
 // ────────────────────────────────────────────────────────────────
@@ -491,6 +522,13 @@ struct SceneBuild {
     /// tick consumes this to derive the per-output transition
     /// + new `cursor_prev_pos` and queue them on the PendingAck.
     cursor_assignment: CursorAssignment,
+    /// Clipped cursor footprint for the current frame on this
+    /// output, regardless of whether the cursor will present via
+    /// SW composite or the HW plane.
+    new_cursor_rect: Option<vk::Rect2D>,
+    /// Version of the cursor sprite contributing `new_cursor_rect`.
+    /// `None` when the cursor is hidden on this output.
+    cursor_record_version: Option<u64>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -554,6 +592,8 @@ impl SceneCompositor {
                 next_submit_retry_at: None,
                 last_frame_cursor_mode: OutputCursorMode::Hidden,
                 cursor_prev_pos: None,
+                last_present_cursor_rect: None,
+                last_present_cursor_version: None,
                 last_skip_reason: None,
             });
         }
@@ -822,6 +862,8 @@ impl SceneCompositor {
             // next frame doesn't damage a stale trail rect.
             o.last_frame_cursor_mode = OutputCursorMode::Hidden;
             o.cursor_prev_pos = None;
+            o.last_present_cursor_rect = None;
+            o.last_present_cursor_version = None;
         }
         // Phase D' — drop the deferred-upload slot WITHOUT firing
         // it (the kernel may be taking the device away; ioctl
@@ -862,6 +904,7 @@ impl SceneCompositor {
         }
         let n_outputs = inner.outputs.len();
         let mut composed = 0usize;
+        let mut clear_dirty = true;
         for output_idx in 0..n_outputs {
             match tick_one_output(
                 inner,
@@ -874,16 +917,19 @@ impl SceneCompositor {
                 hw_strategy,
                 cow_host_xid,
             ) {
-                Ok(true) => composed += 1,
-                Ok(false) => {} // skipped (no BO / empty scene)
+                Ok(TickOutcome::Composed) => composed += 1,
+                Ok(outcome) => {
+                    clear_dirty &= outcome.clears_scene_structure_dirty();
+                }
                 Err(e) => {
+                    clear_dirty = false;
                     log::warn!(
                         "v2 scene tick: output {output_idx} compose failed: {e}; continuing",
                     );
                 }
             }
         }
-        if composed > 0 {
+        if clear_dirty {
             self.scene_structure_dirty = false;
         }
         Ok(composed)
@@ -970,6 +1016,8 @@ impl SceneCompositor {
                 state.cursor_prev_pos = new_prev;
             }
             state.last_frame_cursor_mode = ack.cursor_mode_after_retire;
+            state.last_present_cursor_rect = ack.last_present_cursor_rect_after_retire;
+            state.last_present_cursor_version = ack.last_present_cursor_version_after_retire;
             // Apply the cursor transition via the platform (the
             // mode update above describes what we want; the
             // ioctl actually performs it). Per-CRTC ioctl failures
@@ -1273,6 +1321,31 @@ fn record_tick_success(state: &mut OutputSceneState, output_idx: usize) {
     }
 }
 
+fn cursor_damage_for_frame(
+    last_present_cursor_rect: Option<vk::Rect2D>,
+    last_present_cursor_version: Option<u64>,
+    new_cursor_rect: Option<vk::Rect2D>,
+    new_cursor_version: Option<u64>,
+    cursor_transition: Option<CursorTransition>,
+) -> RegionSet {
+    let mut damage = RegionSet::new();
+    let cursor_changed = new_cursor_rect != last_present_cursor_rect
+        || cursor_transition.is_some()
+        || new_cursor_version != last_present_cursor_version;
+    if !cursor_changed {
+        return damage;
+    }
+    if let Some(rect) = last_present_cursor_rect {
+        damage.add(rect);
+    }
+    if let Some(rect) = new_cursor_rect
+        && Some(rect) != last_present_cursor_rect
+    {
+        damage.add(rect);
+    }
+    damage
+}
+
 #[allow(clippy::too_many_lines)]
 fn tick_one_output(
     inner: &mut SceneCompositorInner,
@@ -1284,7 +1357,7 @@ fn tick_one_output(
     telemetry: &mut Telemetry,
     hw_strategy_enabled: bool,
     cow_host_xid: Option<u32>,
-) -> Result<bool, SceneError> {
+) -> Result<TickOutcome, SceneError> {
     // 0. **Per-output flip-pending gate.** KMS only allows one
     //    pending atomic commit per CRTC at a time; a second
     //    `drmModeAtomicCommit` while the first hasn't fired
@@ -1316,13 +1389,13 @@ fn tick_one_output(
         drain_pending_pool_releases(s, vk.as_ref());
         if !s.pending_acks.is_empty() {
             record_tick_skip(s, output_idx, TickSkipReason::PendingAcks, 0);
-            return Ok(false);
+            return Ok(TickOutcome::Skipped(TickSkipReason::PendingAcks));
         }
         if let Some(deadline) = s.next_submit_retry_at
             && std::time::Instant::now() < deadline
         {
             record_tick_skip(s, output_idx, TickSkipReason::RetryDeadline, 0);
-            return Ok(false);
+            return Ok(TickOutcome::Skipped(TickSkipReason::RetryDeadline));
         }
     }
 
@@ -1345,6 +1418,8 @@ fn tick_one_output(
     //    `cursor_prev_pos` advance happens transactionally below
     //    AFTER the per-output commit succeeds.
     let cursor_prev_pos_before = inner.outputs[output_idx].cursor_prev_pos;
+    let last_present_cursor_rect = inner.outputs[output_idx].last_present_cursor_rect;
+    let last_present_cursor_version = inner.outputs[output_idx].last_present_cursor_version;
     let hw_available = platform.cursor_plane_available();
     let hw_can_run = hw_strategy_enabled && hw_available;
     let prev_mode = inner.outputs[output_idx].last_frame_cursor_mode;
@@ -1374,6 +1449,18 @@ fn tick_one_output(
         derive_cursor_transition(prev_mode, built.cursor_assignment);
 
     let mut output_damage = built.projected_damage;
+    output_damage.union_with(&cursor_damage_for_frame(
+        last_present_cursor_rect,
+        last_present_cursor_version,
+        built.new_cursor_rect,
+        built.cursor_record_version,
+        cursor_transition_to_queue,
+    ));
+    // Always-Full repaint makes stationary SW cursors safe even when
+    // cursor_damage is empty and some unrelated damage triggers a
+    // frame. If `Repaint::Clipped` is ever re-enabled, the current SW
+    // cursor rect must also be folded into the repaint region even
+    // when it did not itself trigger the compose.
     output_damage.union_with(&scene_structure_snap);
     output_damage.union_with(&failed_repaint_snap);
     telemetry.record_scene_entries(
@@ -1385,7 +1472,7 @@ fn tick_one_output(
     if output_damage.is_empty() && !first_frame {
         let s = inner.outputs.get_mut(output_idx).expect("range");
         record_tick_skip(s, output_idx, TickSkipReason::EmptyDamage, 0);
-        return Ok(false);
+        return Ok(TickOutcome::Skipped(TickSkipReason::EmptyDamage));
     }
 
     // 4. Acquire BO.
@@ -1399,7 +1486,7 @@ fn tick_one_output(
                 TickSkipReason::NoBO,
                 output_damage.rects().len(),
             );
-            return Ok(false);
+            return Ok(TickOutcome::Skipped(TickSkipReason::NoBO));
         }
     };
 
@@ -1457,7 +1544,7 @@ fn tick_one_output(
                 TickSkipReason::NoPool,
                 output_damage.rects().len(),
             );
-            return Ok(false);
+            return Ok(TickOutcome::Skipped(TickSkipReason::NoPool));
         }
     };
     let descriptor_pool = state.pool_ring.pool_at(slot);
@@ -1511,10 +1598,12 @@ fn tick_one_output(
                 cursor_transition: cursor_transition_to_queue,
                 cursor_prev_pos_after_retire,
                 cursor_mode_after_retire,
+                last_present_cursor_rect_after_retire: built.new_cursor_rect,
+                last_present_cursor_version_after_retire: built.cursor_record_version,
             });
             state.current_generation = frame_gen;
             record_tick_success(state, output_idx);
-            Ok(true)
+            Ok(TickOutcome::Composed)
         }
         Err(e) => {
             match &e {
@@ -1684,6 +1773,30 @@ fn scene_walk_debug_enabled_for(host_xid: u32) -> bool {
     debug_scene_walk_all() || debug_scene_walk_xids().contains(&host_xid)
 }
 
+fn cursor_footprint_rect(
+    dx: i32,
+    dy: i32,
+    cursor_w: i32,
+    cursor_h: i32,
+    layout_w: i32,
+    layout_h: i32,
+) -> Option<vk::Rect2D> {
+    let x0 = dx.max(0);
+    let y0 = dy.max(0);
+    let x1 = (dx + cursor_w).min(layout_w);
+    let y1 = (dy + cursor_h).min(layout_h);
+    if x1 <= x0 || y1 <= y0 {
+        return None;
+    }
+    Some(vk::Rect2D {
+        offset: vk::Offset2D { x: x0, y: y0 },
+        extent: vk::Extent2D {
+            width: u32::try_from(x1 - x0).unwrap_or(0),
+            height: u32::try_from(y1 - y0).unwrap_or(0),
+        },
+    })
+}
+
 /// Walk window tree, build the per-output scene + collect damage
 /// snapshots.
 ///
@@ -1716,7 +1829,7 @@ fn build_scene(
     output_idx: usize,
     platform: &PlatformBackend,
     cursor: Option<CursorEntry>,
-    cursor_prev_pos: Option<(i32, i32)>,
+    _cursor_prev_pos: Option<(i32, i32)>,
     // Phase 2.6 — host xid of the materialized Composite Overlay
     // Window, if any. The top-level walk uses this to mark the COW
     // top-level (and its descendants by recursion) with
@@ -1842,16 +1955,17 @@ fn build_scene(
         n_sampled = sampled_ids.len(),
     );
 
-    // Stage 5 Phase C: pure cursor strategy decision. Produces a
-    // `CursorAssignment`; the SW draw is appended only when the
-    // strategy picks `Sw` (HW assignment omits the draw entirely
-    // since the kernel overlay covers it). Trail elimination
-    // damage for the PRIOR SW rect runs unconditionally — even
-    // after a Sw → Hw transition, the next frame must clear stale
-    // SW pixels off the scanout BO (the prior SW position is the
-    // bottom of the now-vacated SW area).
+    // Stage 5 Phase C: pure cursor strategy decision. `build_scene`
+    // decides visibility + HW/SW assignment and reports the current
+    // clipped footprint, but it does NOT emit cursor damage. The
+    // tick owns that decision because it also owns the transactional
+    // "last successfully presented cursor footprint/version" state.
     #[allow(clippy::cast_possible_truncation)]
-    let cursor_assignment: CursorAssignment = if let Some(cur) = cursor
+    let (cursor_assignment, new_cursor_rect, cursor_record_version): (
+        CursorAssignment,
+        Option<vk::Rect2D>,
+        Option<u64>,
+    ) = if let Some(cur) = cursor
         && let Some(drawable) = store.get(cur.id)
         && drawable.storage.image_view != vk::ImageView::null()
     {
@@ -1859,42 +1973,13 @@ fn build_scene(
         let ch = i32::try_from(cur.extent.height).unwrap_or(i32::MAX);
         let layout_w_i = i32::try_from(layout_w).unwrap_or(i32::MAX);
         let layout_h_i = i32::try_from(layout_h).unwrap_or(i32::MAX);
-
-        let add_cursor_damage = |projected: &mut RegionSet, dx: i32, dy: i32| {
-            let x0 = dx.max(0);
-            let y0 = dy.max(0);
-            let x1 = (dx + cw).min(layout_w_i);
-            let y1 = (dy + ch).min(layout_h_i);
-            if x1 <= x0 || y1 <= y0 {
-                return;
-            }
-            projected.add(vk::Rect2D {
-                offset: vk::Offset2D { x: x0, y: y0 },
-                extent: vk::Extent2D {
-                    width: u32::try_from(x1 - x0).unwrap_or(0),
-                    height: u32::try_from(y1 - y0).unwrap_or(0),
-                },
-            });
-        };
-
-        // Damage the previous SW rect unconditionally — even a
-        // pure-HW frame needs to clear stale SW pixels off the
-        // scanout BO. Phase D's `cursor_prev_pos_after_retire`
-        // advances `OutputSceneState.cursor_prev_pos` only when
-        // the matching commit retires; failed commits leave the
-        // OLD prev rect in place so the trail is still cleared.
-        if let Some((prev_x, prev_y)) = cursor_prev_pos {
-            add_cursor_damage(&mut projected, prev_x, prev_y);
-        }
-
         let dx = (core.cursor_x as i32) - i32::from(cur.hot_x) - layout_x0;
         let dy = (core.cursor_y as i32) - i32::from(cur.hot_y) - layout_y0;
-        let visible = !(dx + cw <= 0 || dy + ch <= 0 || dx >= layout_w_i || dy >= layout_h_i);
-        if !visible {
+        let new_rect = cursor_footprint_rect(dx, dy, cw, ch, layout_w_i, layout_h_i);
+        if new_rect.is_none() {
             // Off-output / fully-clipped — the cursor isn't on this
-            // output this frame. Phase D treats this as `Hidden`;
-            // the prev-rect damage above still clears the trail.
-            CursorAssignment::Hidden
+            // output this frame. Phase D treats this as `Hidden`.
+            (CursorAssignment::Hidden, None, None)
         } else {
             // Phase C strategy gates (codex v6-pass — pure data, no
             // DRM side effects). Hand off to HW only when the
@@ -1902,14 +1987,17 @@ fn build_scene(
             // 64×64 hardware minimum).
             let hw_fits = cur.extent.width <= 64 && cur.extent.height <= 64;
             if hw_strategy_active && hw_fits {
-                add_cursor_damage(&mut projected, dx, dy);
-                CursorAssignment::Hw {
-                    x: core.cursor_x as i32,
-                    y: core.cursor_y as i32,
-                    record_version: cur.record_version,
-                    hot_x: u16::try_from(cur.hot_x.max(0)).unwrap_or(0),
-                    hot_y: u16::try_from(cur.hot_y.max(0)).unwrap_or(0),
-                }
+                (
+                    CursorAssignment::Hw {
+                        x: core.cursor_x as i32,
+                        y: core.cursor_y as i32,
+                        record_version: cur.record_version,
+                        hot_x: u16::try_from(cur.hot_x.max(0)).unwrap_or(0),
+                        hot_y: u16::try_from(cur.hot_y.max(0)).unwrap_or(0),
+                    },
+                    new_rect,
+                    Some(cur.record_version),
+                )
             } else {
                 draws.push(CompositeDraw {
                     image_view: drawable.storage.sample_view,
@@ -1922,12 +2010,15 @@ fn build_scene(
                     alpha_passthrough: true,
                 });
                 sampled_ids.push(cur.id);
-                add_cursor_damage(&mut projected, dx, dy);
-                CursorAssignment::Sw { pos: (dx, dy) }
+                (
+                    CursorAssignment::Sw { pos: (dx, dy) },
+                    new_rect,
+                    Some(cur.record_version),
+                )
             }
         }
     } else {
-        CursorAssignment::Hidden
+        (CursorAssignment::Hidden, None, None)
     };
 
     let scene = CompositeScene {
@@ -1940,6 +2031,8 @@ fn build_scene(
         sampled_ids,
         projected_damage: projected,
         cursor_assignment,
+        new_cursor_rect,
+        cursor_record_version,
     }
 }
 
@@ -2895,6 +2988,63 @@ mod tests {
         assert_eq!(mode_after, OutputCursorMode::Hidden);
     }
 
+    #[test]
+    fn stationary_cursor_same_rect_mode_and_version_adds_no_damage() {
+        let damage = cursor_damage_for_frame(
+            Some(rect(10, 20, 16, 16)),
+            Some(7),
+            Some(rect(10, 20, 16, 16)),
+            Some(7),
+            None,
+        );
+        assert!(
+            damage.is_empty(),
+            "stationary cursor must not keep the output dirty"
+        );
+    }
+
+    #[test]
+    fn moved_sw_cursor_damages_old_and_new_rects() {
+        let old = rect(10, 20, 16, 16);
+        let new = rect(30, 40, 16, 16);
+        let damage = cursor_damage_for_frame(Some(old), Some(7), Some(new), Some(7), None);
+        let rects = damage.rects();
+        assert!(rects.contains(&old), "old rect must be cleared");
+        assert!(rects.contains(&new), "new rect must be painted");
+    }
+
+    #[test]
+    fn sprite_swap_on_stationary_cursor_damages_once() {
+        let rect = rect(10, 20, 16, 16);
+        let damage = cursor_damage_for_frame(Some(rect), Some(7), Some(rect), Some(8), None);
+        assert_eq!(damage.rects(), &[rect]);
+    }
+
+    #[test]
+    fn pure_hw_hide_still_damages_last_present_rect() {
+        let rect = rect(10, 20, 16, 16);
+        let damage = cursor_damage_for_frame(
+            Some(rect),
+            Some(7),
+            None,
+            None,
+            Some(CursorTransition::HideOnRetire),
+        );
+        assert_eq!(damage.rects(), &[rect]);
+    }
+
+    #[test]
+    fn tick_outcome_only_clears_dirty_for_compose_or_empty_skip() {
+        assert!(TickOutcome::Composed.clears_scene_structure_dirty());
+        assert!(TickOutcome::Skipped(TickSkipReason::EmptyDamage).clears_scene_structure_dirty());
+        assert!(!TickOutcome::Skipped(TickSkipReason::PendingAcks).clears_scene_structure_dirty());
+        assert!(
+            !TickOutcome::Skipped(TickSkipReason::RetryDeadline).clears_scene_structure_dirty()
+        );
+        assert!(!TickOutcome::Skipped(TickSkipReason::NoBO).clears_scene_structure_dirty());
+        assert!(!TickOutcome::Skipped(TickSkipReason::NoPool).clears_scene_structure_dirty());
+    }
+
     /// Steady-state HW: no transition queued (the bytes path
     /// flows through the synchronous `queue_steady_state_cursor_upload`
     /// instead, since v2's empty-damage skip would starve a
@@ -3330,6 +3480,16 @@ mod tests {
         let empty = RegionSet::new();
         let p = pick_repaint_region(Some(2), false, 3, &empty, &history, extent(800, 600));
         assert!(matches!(p, Repaint::Full(_)));
+    }
+
+    /// Placeholder for the eventual `Repaint::Clipped` re-enable:
+    /// a compose triggered by unrelated damage must still repaint the
+    /// current SW cursor rect, even when the cursor itself did not
+    /// trigger the frame.
+    #[test]
+    #[ignore = "Clipped repaint path is intentionally disabled"]
+    fn clipped_repaint_must_include_stationary_sw_cursor_rect() {
+        panic!("enable this when Repaint::Clipped returns again");
     }
 
     // ── Stage 3f.6: subwindow scene traversal ─────────────────────

--- a/crates/yserver/src/kms/v2/scene.rs
+++ b/crates/yserver/src/kms/v2/scene.rs
@@ -3482,14 +3482,27 @@ mod tests {
         assert!(matches!(p, Repaint::Full(_)));
     }
 
-    /// Placeholder for the eventual `Repaint::Clipped` re-enable:
-    /// a compose triggered by unrelated damage must still repaint the
-    /// current SW cursor rect, even when the cursor itself did not
-    /// trigger the frame.
+    /// Tripwire for the idle-compose cursor-damage gating
+    /// (project_idle_compose_cursor_damage): gating the cursor out of
+    /// `output_damage` is only safe because `pick_repaint_region` returns
+    /// `Repaint::Full` unconditionally today, so every compose repaints the
+    /// whole BO (cursor included). If `Repaint::Clipped` is re-enabled, the
+    /// current SW cursor rect must be folded into the repaint region even when
+    /// the cursor did not itself trigger the frame — else a fresh/older-age BO
+    /// shows a stale/missing cursor (see the gating-site comment in
+    /// `tick_one_output`). Passes today; fails the day Full stops being
+    /// unconditional, forcing that revisit. (Not `#[ignore]` + `panic!`: that
+    /// pattern breaks `cargo test --include-ignored`.)
     #[test]
-    #[ignore = "Clipped repaint path is intentionally disabled"]
-    fn clipped_repaint_must_include_stationary_sw_cursor_rect() {
-        panic!("enable this when Repaint::Clipped returns again");
+    fn clipped_reenable_must_fold_in_stationary_sw_cursor_rect() {
+        let history = BufferAgeRing::new(4);
+        let damage = RegionSet::new();
+        let p = pick_repaint_region(Some(2), false, 5, &damage, &history, extent(800, 600));
+        assert!(
+            matches!(p, Repaint::Full(_)),
+            "Repaint::Clipped re-enabled — fold the stationary SW cursor rect \
+             into the repaint region (project_idle_compose_cursor_damage)",
+        );
     }
 
     // ── Stage 3f.6: subwindow scene traversal ─────────────────────

--- a/docs/status.md
+++ b/docs/status.md
@@ -32,10 +32,12 @@ Cross-cutting bugs and followups that don't fit a stage live in
   abandoned `render-convolution-filter` branch: QueryFilters
   standard list, NameWindowPixmap diagnosis docs, Justfile xtrace
   `rm`, picom validation harness.
-- Active dev branch: `master`. All v2 work (Stages 1–4 + Stage 5
-  Task 3 + Task 4 layer 1) has been fast-forwarded from
-  `rendering-model-v2` → `cow-authoritative-mode` → `perf` into
-  `master`. **v1 retired 2026-05-26** after Phase B.3 closed
+- Active dev branch: `fix/idle-compositor` (off `master`). All v2
+  work (Stages 1–4 + Stage 5 Task 3 + Task 4 layer 1) has been
+  fast-forwarded from `rendering-model-v2` →
+  `cow-authoritative-mode` → `perf` into `master`; `master`
+  remains the integration branch. **v1 retired 2026-05-26** after
+  Phase B.3 closed
   across the hardware matrix (bee/yoga/silence/air/M2-Asahi/nvidia). The
   v1 `KmsBackend` struct + all its impl blocks, the `KmsBackendKind`
   dispatcher, the `YSERVER_RENDER_MODEL` env knob, and the
@@ -137,6 +139,22 @@ Cross-cutting bugs and followups that don't fit a stage live in
   root screenshot path is covered by unit tests and a backend
   compile-time smoke; live `xwd -root` desktop smoke still needs a real
   KMS session.
+- **2026-06-14 idle compositor / VT-away wake suppression fix**:
+  implementation is on `fix/idle-compositor`, following
+  `docs/superpowers/specs/2026-06-14-idle-compositor-cursor-damage.md`.
+  `build_scene` now reports cursor footprint facts instead of
+  unconditionally dirtying the frame; `tick_one_output` gates cursor
+  damage on actual footprint/mode/sprite changes using transactional
+  `last_present_cursor_{rect,version}` state; `scene_structure_dirty`
+  clears after all-empty ticks instead of hot-spinning on bare wakes;
+  and `next_wakeup()` suppresses KMS-only scene/cursor-anim timers
+  while scanout is disallowed or DPMS is off, while preserving
+  `PresentBatchWait::Poll` wakeups. Coverage includes stationary HW/SW
+  cursor idle, moved SW cursor old∪new damage, stationary sprite swaps,
+  pure HW hide pokes, dirty-clear gating, present-poll survival under
+  DPMS-off, and scanout-disallowed timer suppression. Validation:
+  `cargo test -p yserver --lib`, `cargo clippy -p yserver --lib --tests`,
+  `cargo +nightly fmt`.
 - **2026-06-12 HW text-cursor offset diagnosed/fixed**: `silence` was
   selecting text above the visible I-beam only with
   `YSERVER_V2_HW_CURSOR=1`; `eiger`/Asahi looked correct because the

--- a/docs/superpowers/specs/2026-06-14-idle-compositor-cursor-damage.md
+++ b/docs/superpowers/specs/2026-06-14-idle-compositor-cursor-damage.md
@@ -1,0 +1,133 @@
+# Idle compositor — stop the stationary-cursor redraw loop + idle on master-drop
+
+**Date:** 2026-06-14
+**Status:** draft (rev 4 — folded in codex review round 3: explicit gating algorithm, footprint lifecycle/teardown reset, failed-submit re-poke, vacuous-clear)
+**Branch:** `fix/idle-compositor` (new, off `master`)
+**Reference:** `crates/yserver/src/kms/v2/scene.rs` (`tick_one_output`, `build_scene`, `derive_cursor_transition`), `crates/yserver/src/kms/v2/backend.rs` (`next_wakeup`, `maybe_composite`). Related: [[project_cc_shake_render_storm]] (the long-unsolved buffer-age render-storm — this is very likely a piece of it).
+
+## Problem
+
+An **idle** desktop never stops compositing. Live evidence (idle e16, debug build, no animated client, no input, 2560×1440@60): from the first second and continuously, **~43 full composes/s, ~8000 draws/s, ~78 atomic page-flips/s**. An idle desktop must compose **0/s**.
+
+Root cause (confirmed independently by codex, gpt-5.4-mini, 2026-06-14): `build_scene` adds the cursor rect to `projected_damage` **on every frame the cursor is visible, whether or not it moved**:
+
+- the *previous* SW rect, unconditionally when `cursor_prev_pos` is `Some` (`scene.rs:1886`);
+- the *current* rect, unconditionally in **both** the HW branch (`scene.rs:1905`) and the SW branch (`scene.rs:1925`).
+
+`tick_one_output` unions `projected_damage` into `output_damage` (`scene.rs:1376`) *before* the empty-damage fast-path skip (`scene.rs:1385`), so the "nothing changed → skip compose" path is **unreachable whenever a cursor is on-screen**. `projected_damage` is recomputed fresh every `build_scene` (never subtracted on retire), so it re-seeds the same damage every frame → compose+flip every vblank, forever.
+
+Two consequences:
+1. **Overnight freeze / `DEVICE_LOST`** (the reported blocker): continuous full-screen compositing all night is a credible GPU-hammer that, on RADV/amdgpu, eventually tripped a GPU reset (`VK_ERROR_DEVICE_LOST`, "context is innocent"); the steadily-climbing client PutImage latency fits a saturated core loop. Not *proven* to cause the reset, but a strong trigger/amplifier — and after a reset it stays hot instead of settling.
+2. **No true idle** even with the screen on. Turning a monitor to standby sends yserver *no* event (DRM master not dropped, no client DPMS), so it keeps hammering — only a true idle makes screen-off benign.
+
+Separately, when **DRM master is dropped** (VT switched away) or **outputs are DPMS-off**, `maybe_composite` already short-circuits the KMS submit — but `next_wakeup()` still returns `Some(now)` whenever `scene_structure_dirty` (`backend.rs:8881`), so the core loop **hot-spins** without doing useful work instead of sleeping until the seat/VT is regained.
+
+## Goal
+
+An idle desktop (no client repaint, no cursor movement, no sprite change, no input) composes **0 frames/s**. Cursor motion, sprite changes, and mode transitions still repaint correctly with no visible artifacts (no trails, no missing/stale cursor) on both the HW-plane and SW-in-BO paths. When DRM master is dropped or outputs are DPMS-off, the core loop sleeps (no busy-wake) until a real event (seat regain, input, client) arrives, with no loss of protocol/scene state.
+
+## Non-goals
+
+- **Re-enabling the buffer-age `Clipped` path.** The `pick_repaint_region` always-`Repaint::Full` stopgap stays. This spec is correct *under* always-Full and adds an explicit follow-up note for whoever re-enables Clipped (see Risks).
+- **Fixing the post-power-cycle KMS/scene desync (codex RCA #3).** The DPMS-wake path does a shallower reinit than VT suspend/resume (it re-arms the cursor + marks damage but does not drain pending acks / reset scanout BO state / re-query outputs). That desync is a separate, secondary issue; this spec does not touch it. (Fixing the idle loop removes the GPU-hammer that is the actual overnight blocker; the desync only manifested because the VT switch was the recovery path.)
+- **udev/hotplug monitoring.** Out of scope; the monitor-standby case is handled by "true idle", not by an event.
+- **Cursor animation.** Animated cursors legitimately advance frames via `cursor_anim_deadline`; unaffected.
+
+## Design
+
+### Invariant
+
+`output_damage` must represent the **actual pixel delta** between the last-committed scanout BO and the next frame. The cursor contributes to it **only** when the on-screen cursor pixels will actually change. `cursor_prev_pos` is a transactional *trail-clear anchor* (advanced only on successful retire), **not** a perpetual dirty source.
+
+### Part A — cursor damage becomes change-gated (not presence-gated)
+
+Today `build_scene` adds the cursor rect to `projected_damage` on every visible frame: the prev-rect (`scene.rs:1886`) whenever `cursor_prev_pos` is `Some`, and the current-rect unconditionally in **both** the HW branch (`scene.rs:1905`) and SW branch (`scene.rs:1925`). The fix makes the cursor's damage contribution the **delta of its scanout footprint**, so a cursor that has not changed contributes **zero** damage.
+
+**The footprint model (resolves the HW-hide / HW-anchor problem).** Track a new per-output `last_present_cursor_rect: Option<Rect2D>` — the clipped cursor footprint of the last *presented* frame, advanced **transactionally on retire** (same rule as `cursor_prev_pos`, queued on the `PendingAck` and applied in `handle_page_flip_complete`), but for **all** modes including HW. Each frame compute `new_cursor_rect` = the clipped current footprint (`∅` if Hidden/off-output). The cursor's damage contribution is:
+
+```
+cursor_damage = last_present_cursor_rect ∪ new_cursor_rect      (either may be ∅)
+```
+
+**Exact gating algorithm (do not paraphrase as "always add the union" — that reintroduces the loop):**
+
+```
+cursor_damage_candidate = last_present_cursor_rect ∪ new_cursor_rect   // either may be ∅
+cursor_changed =
+       (new_cursor_rect != last_present_cursor_rect)     // footprint moved / appeared / disappeared
+    || cursor_transition_to_queue.is_some()              // Hidden↔Sw↔Hw this frame
+    || (record_version != last_present_cursor_version)   // sprite bitmap swapped
+if cursor_changed { output_damage ∪= cursor_damage_candidate } else { /* add nothing */ }
+```
+
+**Hard rule:** when the cursor is stationary, same mode, and same sprite (`cursor_changed == false`), the cursor contributes **`∅`**, never its unchanged rect. The candidate union is the *damage to emit when something changed*, not an unconditional per-frame contribution. The current code's unconditional adds at `scene.rs:1886/1905/1925` are exactly what this replaces — all three move behind `cursor_changed`.
+
+This yields the right behavior in every case, with no special-casing:
+- **stationary, same mode, same sprite** → `cursor_changed == false` → `∅` → empty-damage fast-path fires → **idle**;
+- **moved (SW)** → `old ∪ new` (old trail cleared + new painted);
+- **Hidden→Hw / Hidden→Sw** (show) → `∅ ∪ new`, non-empty, carries `ShowOnRetire`;
+- **Hw→Hidden / Sw→Hidden** (hide) → `old ∪ ∅`, non-empty poke that carries `HideOnRetire`. This is the case rev 2 missed: the HW current-rect lives only in the *visible* branch, so a `Hw→Hidden` frame had no rect and stranded the queued `HideOnRetire` (`derive_cursor_transition` `(Hw, Hidden)`, `scene.rs:1053`); the retained `last_present_cursor_rect` supplies the poke.
+
+**Transactional advance / failed submit.** `last_present_cursor_rect` (and `last_present_cursor_version`) advance **only on successful retire**, queued on the `PendingAck` and applied in `handle_page_flip_complete` (`scene.rs:964`) — identical to `cursor_prev_pos` today. A **failed submit means no retire, so the footprint is unchanged and the next tick re-pokes** the same transition rather than losing it.
+
+**Lifecycle / teardown.** `last_present_cursor_rect` and `last_present_cursor_version` are per-output state and must be reset everywhere `cursor_prev_pos` / `last_frame_cursor_mode` are reset: `drain_all()` (`scene.rs:793`, suspend/VT-release/device-loss teardown) clears them to `None`, and any output add/remove/reindex path resets the per-output entry. Otherwise a stale footprint can survive suspend/resume or output churn and mis-poke (or fail to poke) the first frame back. After a reset, `first_frame` already forces a full compose, so a `None` footprint is correct (show path = `∅ ∪ new`).
+
+**`moved` is SW-only by construction.** HW pointer motion is serviced directly by `cursor_plane_move` in the pointer fast-path (`backend.rs:5185`) and never enters `scene.tick`, so a pure-HW move neither needs nor triggers a compose — correct, the plane moves independently and the BO never contains the cursor. `last_present_cursor_rect` for a pure-HW cursor therefore only updates on composes (it may lag the plane), which is harmless: it is used only to produce a *non-empty poke* for the hide transition, not to position any BO pixels. SW motion does enter `scene.tick`, updates the footprint each presented frame, and gets the `old ∪ new` trail-clear.
+
+**Placement.** Compute the footprint delta + `cursor_changed` in `tick_one_output` next to the existing `derive_cursor_transition` call (`scene.rs:1373`), which already has `prev_mode`, `cursor_prev_pos_before`, and the queued transition in scope. Have `build_scene` return `new_cursor_rect` (it already computes the clipped rect) and let `tick_one_output` decide the union and whether to fold it into `output_damage`, then queue `last_present_cursor_rect`-advance on the `PendingAck`. Keeps the gating decision co-located with the transactional state, per codex RCA #4. (`cursor_prev_pos` may be subsumed by `last_present_cursor_rect`; decide during implementation — but `derive_cursor_transition`'s existing use of `cursor_prev_pos` for the SW trail must keep working.)
+
+**Sprite-version term.** `register_cursor` already sets `scene_structure_dirty` on a sprite change (`scene.rs:573`) and `display_cursor_by_handle` (`backend.rs:1361`) feeds the scene/plane path, so `record_version` supplies the *damage*, not the *wake*. Load-bearing for **SW** sprite swaps (new bitmap must re-compose into the BO); defensive for HW (plane-upload handles the bitmap; a one-frame BO compose is harmless). Confirm during implementation it isn't double-counting an already-marked damage rect.
+
+### Part B — clear `scene_structure_dirty` on an all-empty tick
+
+`tick()` clears `scene_structure_dirty` only when `composed > 0` (`scene.rs:887`). So any caller that sets the dirty **bool** without producing a damage **rect** — e.g. `register_cursor` (`scene.rs:573`), or a bare `wake_for_damage` — leaves the loop hot: tick runs, finds empty damage, skips, dirty stays set, `next_wakeup` returns `Some(now)`, repeat. After Part A removes the cursor as a perpetual damage source, this becomes the dominant idle leak.
+
+`scene_structure_dirty` is a coarse "something might have changed, go look" flag. Once a tick has *looked* (run `build_scene`) and found nothing to draw, the flag must clear. **Classify each output's tick outcome:**
+- **Composed** → drew this output (already clears today).
+- **SkippedEmpty** (`TickSkipReason::EmptyDamage`) → "checked, nothing to do" → safe to clear.
+- **SkippedDefer** (`NoBO` / `PendingAcks` / `RetryDeadline`) → "deferred, retry later" → keep dirty; the existing retry-deadline / page-flip-retire path re-drives it.
+- **Errored** (`tick_one_output` returned `Err`, which `tick()` logs and continues, `scene.rs:879`) → real damage may be un-rendered → keep dirty.
+
+**Change:** clear `scene_structure_dirty` **only when every output was Composed or SkippedEmpty** — i.e. keep it set if *any* output was SkippedDefer **or** Errored. (A zero-output / no-outputs tick clears vacuously — there is nothing to defer.) (Today `tick()` clears on `composed > 0`, which both over-clears — a defer/error on another output is lost — and under-clears — an all-SkippedEmpty tick never clears. The new rule fixes both.) This is the general true-idle guarantee: it fixes the cursor case *and* any other bare-dirty source, without dropping damage on a transient submit/platform error.
+
+**Why late-arriving damage is safe.** The compositor is single-threaded, so no damage can land *during* a tick. Damage that arrives between a submit and its retire is explicitly preserved by `handle_page_flip_complete` (it subtracts only the *submitted* snapshot, `scene.rs:920`), and that retire path re-sets the dirty flag, so clearing it here on an `EmptyDamage`/`Composed` tick cannot strand damage that has not yet been looked at.
+
+### Part C — `next_wakeup` suppresses only KMS-output timers when scanout is disallowed
+
+In `next_wakeup` (`backend.rs:8879`), when `!self.scanout_allowed()` (DRM master dropped) **or** `!self.kms_outputs_active` (DPMS-off), suppress the **`scene_deadline`** and **`cursor_anim` deadline** — these are KMS-output-bound and can't render. **Keep the `present_deadline`.** `enqueue_present_completion` can register `PresentBatchWait::Poll` batches (`backend.rs:14791`) that have **no real fd wake**; dropping their poll deadline would strand a pending client present-completion until unrelated activity happens. (If those polled batches are ever given a real wake source, the poll deadline can also be parked — out of scope here.)
+
+With the scene/cursor-anim timers suppressed, the loop sleeps on its remaining timers + **fd** events (signalfd VT-acquire, libinput, client sockets), which are unaffected:
+- VT acquire → signalfd wakes the loop → `run_resume` → `wake_for_damage` + `scanout_allowed()` true → next `next_wakeup` returns `Some(now)` → composes. No deadlock.
+- Clients keep being serviced (separate epoll sources); they render to pixmaps, just nothing scans out.
+
+This is the scheduling-layer half of codex RCA #5; the existing `maybe_composite` gates are the submit-layer half. Both are needed — the gates alone leave the hot wakeup loop.
+
+> Note: Part C does **not** help the physical-monitor-standby case (there `scanout_allowed` and `kms_outputs_active` are both still true). That case is covered entirely by Parts A+B's true-idle.
+
+## Data flow (idle, screen on, HW cursor, after fix)
+
+```
+no input, no client paint, cursor stationary
+  → core loop wakes only on its existing cadence
+  → maybe_composite: scene_structure_dirty == false  → can_submit_scene false → no tick
+     (and even if a stale dirty bit were set, tick_one_output: output_damage empty → EmptyDamage skip)
+  → next_wakeup: scene not dirty, present_deadline kept (None if no Poll batch), no cursor anim → sleeps
+  → 0 composes/s, 0 flips/s   ✅
+```
+
+## Testing
+
+- **Failing test first** ([[feedback_write_failing_test_first]]): a `tick_one_output`/`build_scene`-level unit test — steady-state HW cursor (prev_mode `Hw`, assignment `Hw`, same pos) → `output_damage` is **empty** → tick returns `Ok(false)` (skip). Must be **red** against current code (today it returns a non-empty cursor rect and composes), green after Part A.
+- SW analogue: stationary SW cursor (same pos, same version) → empty damage / skip; moved SW cursor → damage covers **both** old and new rects (no trail).
+- **Transition coverage (the cases that break if Part A over-deletes), at `tick_one_output`/`build_scene` level — not just the `derive_cursor_transition` matrix:** `Hidden→Hw` and **pure `Hw→Hidden` with no SW trail and no other damage** must each produce non-empty `output_damage` on the transition frame (so the `ShowOnRetire`/`HideOnRetire` rides a compose and retires via the footprint poke) and zero on the following stationary frame. Likewise `Hidden→Sw`, `Sw→Hw`, `Hw→Sw`.
+- **Sprite swap:** stationary SW cursor whose `record_version` changes → produces damage that frame (new bitmap re-composed), then idles.
+- **Part B (dirty-but-empty no-spin):** set `scene_structure_dirty` via a bare wake / `register_cursor` with no damage rect; one tick → `EmptyDamage` skip → `scene_structure_dirty` is now **false** and `next_wakeup()` returns `None` (no spin). A `NoBO`/`PendingAcks` defer skip must **leave** the flag set. **And** an errored tick (`tick_one_output` → `Err` on an output) must **leave** the flag set (no damage dropped).
+- **Part C unit tests:** `next_wakeup` suppresses the scene/cursor-anim deadlines when `scanout_allowed()` is false (master dropped) even with `scene_structure_dirty == true`; restores them once allowed. **And** a `PresentBatchWait::Poll` batch enqueued while `!kms_outputs_active` still yields a non-`None` present-poll deadline (not stranded).
+- **HW smoke (the real gate):** `just yserver-…-hw` with `YSERVER_LOOP_TELEMETRY=1` — idle desktop must show **0 composes/s** in the per-second log (today: ~43/s). Move the mouse → composes track motion then return to 0 at rest. Cursor sprite changes (resize-handle, text-caret) show correctly. No cursor trail, no stale/missing cursor. VT switch away → telemetry quiet (0 wake-spin), switch back → restores and idles. ([[feedback_vng_pass_not_hw_pass]] — HW-gated.) **If idle is still > 0/s after the fix, there is another per-frame damage source — hunt it, don't declare victory.**
+- Existing scene/cursor unit tests + rendercheck must stay green ([[reference_rendercheck_v1_baseline]]).
+
+## Risks
+
+- **Re-enabling the buffer-age `Clipped` path later — hard requirement, not just a warning.** Under always-Full, a compose triggered by *other* damage repaints the whole BO including the SW cursor draw, so gating cursor damage out of `output_damage` cannot drop the cursor. Under `Clipped`, the repaint *region* might not cover a stationary SW cursor on a freshly-cycled (older-age) BO → missing/stale cursor. The cursor rect plays two roles — (1) gate whether to compose, (2) be inside the repaint region when we *do* compose. This spec removes role (1) for stationary cursors; role (2) stays implicit-via-always-Full. **Requirement on whoever re-enables `Clipped`:** the *current* SW cursor rect must be folded into the repaint region even when it did not itself trigger the frame. Encode this as (a) an explicit comment at the gating site in `tick_one_output`, and (b) a test that fails if a `Clipped` repaint region omits a stationary SW cursor — added now (ignored/marked while Clipped is disabled) so it can't be silently lost.
+- **Sprite/visibility change missed → stale cursor.** Covered by the sprite-swap + transition tests; during implementation confirm which adjacent paths (`register_cursor` `scene.rs:573`, `display_cursor_by_handle` `backend.rs:1361`, cross-output) already dirty/damage so `cursor_changed` adds only load-bearing terms and doesn't double-count.
+- **Part C starving a needed wake.** Only scene + cursor-anim timers are suppressed; present-poll and all fd event sources remain (the `PresentBatchWait::Poll`-stranding hazard codex flagged). Confirm via the VT-switch smoke that acquire still wakes and composes (no black-screen-until-input).


### PR DESCRIPTION
fix: stop idle-compositor redraw loop + idle wakeups on master-drop
fix: re-acquire input devices after a deferred libseat open (hotplug retry)