### PR TITLE
chore: demote per-op INFO logs to debug/trace (quieten production logs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ We support the following extensions:
 - X-Resource
 - XFIXES
 - XInputExtension
+- XC-MISC
 - XKEYBOARD
 - XTEST
 

--- a/crates/yserver-core/src/core_loop/process_request.rs
+++ b/crates/yserver-core/src/core_loop/process_request.rs
@@ -2656,7 +2656,7 @@ fn handle_sync_request(
                     .get(&client_id.0)
                     .map(String::as_str)
                     .unwrap_or("<unknown>");
-                log::info!(
+                log::trace!(
                     "sync: client {}/{class:?} CreateAlarm 0x{alarm:x} \
                      counter={cname}(0x{counter:x}) test={test} \
                      wait_value={wait} delta={delta} events={events}",
@@ -2698,7 +2698,7 @@ fn handle_sync_request(
                     .get(&client_id.0)
                     .map(String::as_str)
                     .unwrap_or("<unknown>");
-                log::info!(
+                log::trace!(
                     "sync: client {}/{class:?} ChangeAlarm 0x{alarm:x} \
                      counter={cname}(0x{counter:x}) test={test} \
                      wait_value={wait} delta={delta} events={events}",
@@ -5116,7 +5116,7 @@ fn handle_mit_shm_put_image(
             .get(&client_id.0)
             .map(String::as_str)
             .unwrap_or("<unknown>");
-        log::info!(
+        log::debug!(
             "MIT-SHM PutImage perf: total={total_us}us \
              [extract={ext_us}us clear_clip+={cc_us}us put_image+={pi_us}us] \
              {w}x{h} depth={depth} bytes={bytes} borrowed={borrowed} \
@@ -21717,7 +21717,7 @@ fn handle_change_property(
         if prop_name == "WM_CLASS" && req.format == 8 {
             let s = String::from_utf8_lossy(&req.data).replace('\0', " | ");
             let trimmed = s.trim_end_matches(" | ").to_string();
-            log::info!(
+            log::debug!(
                 "client {} WM_CLASS on 0x{:x}: {}",
                 client_id.0,
                 req.window.0,
@@ -21730,7 +21730,7 @@ fn handle_change_property(
             state.client_wm_class.entry(client_id.0).or_insert(trimmed);
         } else if prop_name == "_NET_WM_PID" && req.format == 32 && req.data.len() >= 4 {
             let pid = u32::from_le_bytes([req.data[0], req.data[1], req.data[2], req.data[3]]);
-            log::info!(
+            log::debug!(
                 "client {} _NET_WM_PID on 0x{:x}: {}",
                 client_id.0,
                 req.window.0,

--- a/crates/yserver-core/src/core_loop/setup_thread.rs
+++ b/crates/yserver-core/src/core_loop/setup_thread.rs
@@ -29,7 +29,7 @@ use std::{
 };
 
 use crossbeam_channel::bounded;
-use log::{info, warn};
+use log::{debug, warn};
 
 use yserver_protocol::x11::{self, ClientId};
 
@@ -125,7 +125,7 @@ fn run_setup(id: ClientId, mut stream: UnixStream, sender: &CoreSender) -> io::R
     stream.set_write_timeout(Some(SETUP_TIMEOUT))?;
 
     let setup = x11::read_setup_request(&mut stream)?;
-    info!(
+    debug!(
         "client {} setup: byte_order={:?} protocol {}.{}",
         id.0, setup.byte_order, setup.protocol_major, setup.protocol_minor
     );
@@ -149,7 +149,7 @@ fn run_setup(id: ClientId, mut stream: UnixStream, sender: &CoreSender) -> io::R
         return Ok(());
     }
 
-    info!(
+    debug!(
         "client {} setup: protocol {}.{}, base=0x{:x}",
         id.0, setup.protocol_major, setup.protocol_minor, resp.resource_id_base
     );

--- a/crates/yserver/src/input/context.rs
+++ b/crates/yserver/src/input/context.rs
@@ -52,7 +52,7 @@ impl LibinputInterface for Interface {
             .open(path);
         match result {
             Ok(file) => {
-                log::info!("libinput: open_restricted ok: {}", path.display());
+                log::debug!("libinput: open_restricted ok: {}", path.display());
                 Ok(file.into())
             }
             Err(err) => {
@@ -451,7 +451,7 @@ fn log_input_devnodes() {
         }
         let path = entry.path();
         match OpenOptions::new().read(true).open(&path) {
-            Ok(_f) => log::info!("/dev/input/{name_str}: open(O_RDONLY) ok"),
+            Ok(_f) => log::debug!("/dev/input/{name_str}: open(O_RDONLY) ok"),
             Err(err) => log::warn!("/dev/input/{name_str}: open(O_RDONLY) failed: {err}"),
         }
     }


### PR DESCRIPTION
A full lightdm session's yserver log was ~6.7k INFO lines, ~95% of them per-request/per-op spam that buried the useful lifecycle breadcrumbs (and grows unbounded over a day). Tallied from a real production x-0.log:

  3616  sync: ... ChangeAlarm   (cinnamon idle-monitor re-arming IDLETIME)  -> trace
    15  sync: ... CreateAlarm                                                -> trace
   538  MIT-SHM PutImage perf: ... (per-PutImage perf-cliff diagnostic)      -> debug
   112  client _NET_WM_PID on ...                                            -> debug
   178  client setup: protocol / byte_order  (2 per connect)                -> debug
    88  libinput: open_restricted ok: /dev/input/eventN                     -> debug
    22  /dev/input/eventN: open(O_RDONLY) ok                                 -> debug
     5  client WM_CLASS on ...                                               -> debug

Kept at INFO — the postmortem breadcrumbs that are low-volume and were load-bearing for the hotplug/VT debugging: libinput/xi-device add+remove, VT release/acquire, resume rearm_cursor, SIGUSR VT forwarding, modeset/scanout, seat transitions, warnings/errors. (Per-keystroke `cook_host_key` INFO was already stripped earlier.)

Loop/vk/pixmap telemetry stays INFO but is already gated behind YSERVER_LOOP_TELEMETRY, so it never reaches a normal production log.