### PR TITLE
fix(v2): reclaim GPU render resources from a per-iteration block handler

### DIFF
--- a/crates/yserver-core/src/backend/recording.rs
+++ b/crates/yserver-core/src/backend/recording.rs
@@ -145,6 +145,10 @@ pub struct RecordingBackend {
     /// PageFlipReady dispatches do not get suppressed by the run_core
     /// dispatch loop.
     pub page_flip_count: std::sync::atomic::AtomicU32,
+    /// Counter — incremented every time `before_block` is invoked. Tests
+    /// assert the core loop drives per-iteration reclamation even when no
+    /// page-flip ever occurs (project_reclamation_starvation_leak).
+    pub before_block_count: std::sync::atomic::AtomicU32,
     /// Stage 4d COW: lets tests pretend this backend tracks COW
     /// lifecycle. When true, the next `release_overlay_window` call
     /// returns `Ok(true)` (final release, COW destroyed); otherwise
@@ -207,6 +211,7 @@ impl RecordingBackend {
             fake_root_visual_xid: 0x0000_0021,
             xid_map: HostXidMap::new(),
             page_flip_count: std::sync::atomic::AtomicU32::new(0),
+            before_block_count: std::sync::atomic::AtomicU32::new(0),
             cow_next_release_is_final: false,
             cow_materialized: false,
             redirect_activation_supported: false,
@@ -303,6 +308,11 @@ impl Backend for RecordingBackend {
 
     fn on_page_flip_ready(&mut self, _state: &mut crate::server::ServerState) {
         self.page_flip_count
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn before_block(&mut self) {
+        self.before_block_count
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
 

--- a/crates/yserver-core/src/backend/trait_def.rs
+++ b/crates/yserver-core/src/backend/trait_def.rs
@@ -347,6 +347,22 @@ pub trait Backend: Send {
     /// for it). Default: no-op. project_mouse_hotplug_lost_wakeup.
     fn poll_deferred_input(&mut self, _state: &mut ServerState) {}
 
+    /// Called once per core-loop iteration, immediately before the loop
+    /// blocks in `poll`. This is the BlockHandler analog (cf. Xorg
+    /// `glamor_block_handler` → `glamor_flush`): the backend reaps GPU
+    /// render-op resources whose fences have signaled, INDEPENDENT of the
+    /// page-flip cadence. Default: no-op.
+    ///
+    /// Why this exists: the KMS v2 backend's per-op command buffers /
+    /// retired images live in an engine `submitted` queue drained only by
+    /// `poll_retired`, which was driven solely by `on_page_flip_ready`.
+    /// While the display is dark (DPMS-off / monitor standby / VT-away)
+    /// page-flips stop, but clients keep submitting render ops — so the
+    /// queue grew unbounded until the GPU ran out of command-submission
+    /// memory and the device was lost (project_reclamation_starvation_leak).
+    /// Reclamation must therefore ride the dispatch loop, not scanout.
+    fn before_block(&mut self) {}
+
     /// Drain libinput's INITIAL device enumeration and seed the XI2
     /// device registry (`state.xi_devices`) BEFORE the core serves any
     /// client — the Xorg model of probing input at startup.

--- a/crates/yserver-core/src/core_loop/run.rs
+++ b/crates/yserver-core/src/core_loop/run.rs
@@ -1571,10 +1571,11 @@ mod tests {
         // No PageFlipReady — only a Shutdown. The loop must still run at
         // least one iteration, calling before_block before it blocks.
         sender.send(Message::Shutdown).unwrap();
-        for _ in 0..50 {
-            if handle.is_finished() {
-                break;
-            }
+        // Generous deadline so a slow/loaded CI box can't spuriously fail:
+        // the loop breaks the instant the thread finishes, so this only
+        // bounds the pathological-hang case.
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !handle.is_finished() && Instant::now() < deadline {
             std::thread::sleep(Duration::from_millis(10));
         }
         assert!(handle.is_finished(), "run_core did not return");

--- a/crates/yserver-core/src/core_loop/run.rs
+++ b/crates/yserver-core/src/core_loop/run.rs
@@ -434,6 +434,14 @@ pub fn run_core(
                         .unwrap_or(Duration::ZERO)
                 })
         };
+        // BlockHandler analog (cf. Xorg glamor_block_handler → glamor_flush):
+        // reap GPU render-op resources whose fences have signaled right
+        // before we block. Driving this here — not from on_page_flip_ready —
+        // is what keeps the KMS backend's engine `submitted` queue bounded
+        // while the display is dark and clients keep drawing
+        // (project_reclamation_starvation_leak). No-op for backends without
+        // GPU resources to reap.
+        backend.before_block();
         poll.poll(&mut events, poll_timeout)?;
         let iter_start = if telemetry.enabled {
             Some(Instant::now())
@@ -1526,6 +1534,61 @@ mod tests {
             backend.page_flip_count.load(Ordering::Relaxed),
             3,
             "expected 3 on_page_flip_ready dispatches",
+        );
+    }
+
+    /// Regression (project_reclamation_starvation_leak): the core loop
+    /// must drive backend GPU-resource reclamation (`before_block`) every
+    /// iteration, INDEPENDENT of page-flips. The KMS v2 backend reaped
+    /// per-op command buffers only from `on_page_flip_ready`; while the
+    /// display was dark (DPMS-off / standby / VT-away) no flips occurred,
+    /// so a client that kept drawing grew the engine `submitted` queue
+    /// without bound until the GPU lost its device. Here we run the loop
+    /// with ZERO `PageFlipReady` messages and assert `before_block` still
+    /// fired — i.e. reclamation rides the dispatch loop, not scanout.
+    #[test]
+    fn before_block_runs_without_any_page_flip() {
+        use crate::backend::recording::RecordingBackend;
+        use std::sync::atomic::Ordering;
+
+        let (poll, sender, rx) = channel().unwrap();
+        let sender_for_core = sender.clone_handle();
+        let mut backend = RecordingBackend::new();
+        let handle = std::thread::spawn(move || {
+            let mut state = ServerState::new();
+            let alloc = ClientIdAllocator::new();
+            let result = run_core(
+                poll,
+                rx,
+                sender_for_core,
+                &mut state,
+                &mut backend,
+                None,
+                &alloc,
+            );
+            (result, backend)
+        });
+        // No PageFlipReady — only a Shutdown. The loop must still run at
+        // least one iteration, calling before_block before it blocks.
+        sender.send(Message::Shutdown).unwrap();
+        for _ in 0..50 {
+            if handle.is_finished() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(handle.is_finished(), "run_core did not return");
+        let (result, backend) = handle.join().unwrap();
+        result.unwrap();
+        assert_eq!(
+            backend.page_flip_count.load(Ordering::Relaxed),
+            0,
+            "test must exercise the no-page-flip path",
+        );
+        assert!(
+            backend.before_block_count.load(Ordering::Relaxed) >= 1,
+            "before_block must run each iteration even with no page-flips \
+             (reclamation must not be gated on scanout)",
         );
     }
 

--- a/crates/yserver/src/kms/v2/backend.rs
+++ b/crates/yserver/src/kms/v2/backend.rs
@@ -8903,18 +8903,16 @@ impl Backend for KmsBackendV2 {
         // queue, so running it every iteration costs nothing at idle.
         self.engine.poll_retired(&self.platform);
         self.poll_pending_retire_with_invalidate();
-        // Diagnostic: publish the `submitted`-queue depth and drive the
-        // 1Hz telemetry emit from here too. maybe_emit() self-gates to 1Hz
-        // and is a no-op below threshold, but running it every dispatch
-        // iteration means the `v2_telemetry:` line (and the submit-trace
-        // flush) keep ticking even while the display is dark — exactly
-        // when `submitted_queue_depth` is the number worth watching
-        // (project_reclamation_starvation_leak). Without this, the only
-        // other maybe_emit caller is on the compose path, which is gated
-        // off when dark, so telemetry went silent in the leak window.
-        self.telemetry
-            .record_submitted_depth(self.engine.pending_count());
-        self.telemetry.maybe_emit();
+        // Diagnostic: drive the 1Hz telemetry emit from here too,
+        // publishing the live `submitted`-queue depth. maybe_emit()
+        // self-gates to 1Hz and is a no-op below threshold, but running
+        // it every dispatch iteration means the `v2_telemetry:` line (and
+        // the submit-trace flush) keep ticking even while the display is
+        // dark — exactly when `submitted_queue_depth` is the number worth
+        // watching (project_reclamation_starvation_leak). Without this,
+        // the only other maybe_emit caller is on the compose path, which
+        // is gated off when dark, so telemetry went silent in the window.
+        self.telemetry.maybe_emit(self.engine.pending_count());
     }
 
     fn mark_dirty(&mut self) {
@@ -9127,7 +9125,7 @@ impl Backend for KmsBackendV2 {
         // Phase B.1 Task 21: drain frame-builder close events into telemetry.
         self.drain_frame_builder_telemetry();
         // Per-second telemetry summary emission.
-        self.telemetry.maybe_emit();
+        self.telemetry.maybe_emit(self.engine.pending_count());
         result
     }
 

--- a/crates/yserver/src/kms/v2/backend.rs
+++ b/crates/yserver/src/kms/v2/backend.rs
@@ -8884,6 +8884,39 @@ impl Backend for KmsBackendV2 {
         }
     }
 
+    fn before_block(&mut self) {
+        // BlockHandler analog (cf. Xorg glamor_block_handler → glamor_flush):
+        // every dispatch-loop iteration, just before the core loop blocks,
+        // reap render-op resources whose fences have signaled. This is the
+        // reclaim half of `on_page_flip_ready` (the scanout / compose / flush
+        // half stays page-flip-driven), lifted onto the dispatch loop so it
+        // runs even when no page-flip occurs.
+        //
+        // Without this, the engine `submitted` queue (one per-op command
+        // buffer + any displaced images each) is drained ONLY on page-flip.
+        // While the display is dark (DPMS-off / monitor standby / VT-away)
+        // page-flips stop, but clients keep submitting render ops, so the
+        // queue grows without bound until amdgpu can't allocate command-
+        // submission memory and the device is lost
+        // (project_reclamation_starvation_leak). poll_retired only frees
+        // ops whose fence has signaled and is a cheap no-op on an empty
+        // queue, so running it every iteration costs nothing at idle.
+        self.engine.poll_retired(&self.platform);
+        self.poll_pending_retire_with_invalidate();
+        // Diagnostic: publish the `submitted`-queue depth and drive the
+        // 1Hz telemetry emit from here too. maybe_emit() self-gates to 1Hz
+        // and is a no-op below threshold, but running it every dispatch
+        // iteration means the `v2_telemetry:` line (and the submit-trace
+        // flush) keep ticking even while the display is dark — exactly
+        // when `submitted_queue_depth` is the number worth watching
+        // (project_reclamation_starvation_leak). Without this, the only
+        // other maybe_emit caller is on the compose path, which is gated
+        // off when dark, so telemetry went silent in the leak window.
+        self.telemetry
+            .record_submitted_depth(self.engine.pending_count());
+        self.telemetry.maybe_emit();
+    }
+
     fn mark_dirty(&mut self) {
         // Wake the compositor without inventing full-output damage.
         // Paint paths already record per-drawable presentation

--- a/crates/yserver/src/kms/v2/telemetry.rs
+++ b/crates/yserver/src/kms/v2/telemetry.rs
@@ -191,15 +191,6 @@ pub struct Telemetry {
     /// current value, so paint events recorded between ticks
     /// share the surrounding tick's id.
     frame_id: u64,
-    /// Instantaneous gauge (not a per-second rate): depth of the
-    /// engine's `submitted` queue at the last `maybe_emit`. This is
-    /// the reclamation-starvation leak gauge — it climbs without
-    /// bound on a build that drains `submitted` only on page-flip
-    /// once the display goes dark while clients keep drawing
-    /// (project_reclamation_starvation_leak). With the `before_block`
-    /// reclaim drive it stays flat. Set via `record_submitted_depth`
-    /// right before each emit.
-    submitted_depth: usize,
 }
 
 impl Telemetry {
@@ -223,17 +214,7 @@ impl Telemetry {
             lifetime: Bucket::default(),
             submit_trace: SubmitTrace::from_env(),
             frame_id: 0,
-            submitted_depth: 0,
         }
-    }
-
-    /// Record the engine `submitted`-queue depth (an instantaneous
-    /// gauge) so the next `v2_telemetry:` line reports it. Called from
-    /// `before_block`, i.e. every dispatch iteration — including while
-    /// the display is dark — so the leak gauge stays observable when
-    /// no page-flips occur. project_reclamation_starvation_leak.
-    pub(crate) fn record_submitted_depth(&mut self, depth: usize) {
-        self.submitted_depth = depth;
     }
 
     /// Stage 5 Task 3 diagnostic: log one submit event to the
@@ -273,7 +254,15 @@ impl Telemetry {
     /// hard reboot) to ≤ 1s and lets `tail -f` work during a live
     /// capture. The cost is one `write(2)` syscall per second when
     /// tracing — negligible.
-    pub(crate) fn maybe_emit(&mut self) {
+    /// `submitted_depth` is the engine's `submitted`-queue depth at
+    /// call time (an instantaneous gauge, not a per-second rate),
+    /// passed in by every caller so it can't go stale or be forgotten:
+    /// it's the reclamation-starvation leak gauge, which climbs without
+    /// bound on a build that drains `submitted` only on page-flip once
+    /// the display goes dark while clients keep drawing, and stays flat
+    /// with the `before_block` reclaim drive
+    /// (project_reclamation_starvation_leak).
+    pub(crate) fn maybe_emit(&mut self, submitted_depth: usize) {
         let now = Instant::now();
         let dt = now.duration_since(self.last_emit);
         if dt < std::time::Duration::from_secs(1) {
@@ -380,7 +369,7 @@ impl Telemetry {
             self.lifetime.active_scratch_bytes_high_water,
             b.cursor_move_ebusy,
             self.lifetime.cursor_move_ebusy,
-            self.submitted_depth,
+            submitted_depth,
         );
         #[allow(clippy::cast_precision_loss)]
         let fb_ops_avg =
@@ -918,7 +907,7 @@ mod tests {
         // (logging is suppressed when env var unset, but bucket
         // reset still happens).
         t.enabled = true;
-        t.maybe_emit();
+        t.maybe_emit(0);
         assert_eq!(t.bucket.paint_submits, 0);
         assert_eq!(t.bucket.compose_cb_record_ns, 0);
         // Lifetime preserved.

--- a/crates/yserver/src/kms/v2/telemetry.rs
+++ b/crates/yserver/src/kms/v2/telemetry.rs
@@ -191,6 +191,15 @@ pub struct Telemetry {
     /// current value, so paint events recorded between ticks
     /// share the surrounding tick's id.
     frame_id: u64,
+    /// Instantaneous gauge (not a per-second rate): depth of the
+    /// engine's `submitted` queue at the last `maybe_emit`. This is
+    /// the reclamation-starvation leak gauge — it climbs without
+    /// bound on a build that drains `submitted` only on page-flip
+    /// once the display goes dark while clients keep drawing
+    /// (project_reclamation_starvation_leak). With the `before_block`
+    /// reclaim drive it stays flat. Set via `record_submitted_depth`
+    /// right before each emit.
+    submitted_depth: usize,
 }
 
 impl Telemetry {
@@ -214,7 +223,17 @@ impl Telemetry {
             lifetime: Bucket::default(),
             submit_trace: SubmitTrace::from_env(),
             frame_id: 0,
+            submitted_depth: 0,
         }
+    }
+
+    /// Record the engine `submitted`-queue depth (an instantaneous
+    /// gauge) so the next `v2_telemetry:` line reports it. Called from
+    /// `before_block`, i.e. every dispatch iteration — including while
+    /// the display is dark — so the leak gauge stays observable when
+    /// no page-flips occur. project_reclamation_starvation_leak.
+    pub(crate) fn record_submitted_depth(&mut self, depth: usize) {
+        self.submitted_depth = depth;
     }
 
     /// Stage 5 Task 3 diagnostic: log one submit event to the
@@ -319,7 +338,8 @@ impl Telemetry {
              active_descriptor_pool_count_high_water={} \
              active_staging_bytes_high_water={} \
              active_scratch_bytes_high_water={} \
-             cursor_move_ebusy/s={} cursor_move_ebusy(lifetime)={}",
+             cursor_move_ebusy/s={} cursor_move_ebusy(lifetime)={} \
+             submitted_queue_depth={}",
             b.paint_submits,
             b.composite_submits,
             b.one_shot_submits,
@@ -360,6 +380,7 @@ impl Telemetry {
             self.lifetime.active_scratch_bytes_high_water,
             b.cursor_move_ebusy,
             self.lifetime.cursor_move_ebusy,
+            self.submitted_depth,
         );
         #[allow(clippy::cast_precision_loss)]
         let fb_ops_avg =


### PR DESCRIPTION
The engine's `submitted` queue (one command buffer + any displaced images per op) was drained only by `poll_retired`, which ran solely from `on_page_flip_ready`. While the display is dark (DPMS-off / monitor standby / VT-away) page-flips stop, but clients keep submitting render ops — so the queue grew without bound until amdgpu could not allocate command-submission memory and the device was lost (`VK_ERROR_DEVICE_LOST`), latching `renderer_failed` and hanging the server. The leak was latent for a long time; recent idle/DPMS correctness work (PR #30 true-idle, the 05-30 DPMS compose-gate) removed the continuous idle page-flips that had incidentally kept reclamation alive.

Fix matches Xorg: render-resource reclamation rides the dispatch loop (glamor reaps from its BlockHandler via `glamor_flush`), while scanout-buffer recycling stays on page-flip. Add a `Backend::before_block` hook (default no-op) called once per core-loop iteration immediately before `poll`; `KmsBackendV2::before_block` runs the reclaim half of `on_page_flip_ready` (`poll_retired` + `poll_pending_retire_with_invalidate`). Both are pure fence-check sweeps that no-op on empty queues, so this adds no idle spin and does not re-introduce the #30 storm. The submit side is deliberately untouched (gating it would break GetImage readback).

Also add a `submitted_queue_depth` gauge to the v2 telemetry line and drive `maybe_emit()` from `before_block`, so the leak gauge stays observable while the display is dark (its previous emitter is on the gated compose path).

Test: `before_block_runs_without_any_page_flip` drives the core loop with zero PageFlipReady and asserts the reclaim drive still fires. HW-verified on bee (APU/RADV) under MATE: ~9 min VT-away with clients drawing at 12-14 submits/s and page_flip/s=0 held submitted_queue_depth at max 1 (vs unbounded growth -> DEVICE_LOST on master), clean resume.