### PR TITLE
fix(input): refuse to start when no input device can be opened

### DIFF
--- a/crates/yserver/src/input_thread.rs
+++ b/crates/yserver/src/input_thread.rs
@@ -535,6 +535,7 @@ pub fn process_batch(
 /// Returns only on a fatal send error (channel closed = core gone).
 pub(crate) fn run(
     input_ctx: SendContext,
+    initial_events: Vec<InputEvent>,
     sender: CoreSender,
     fb_w: u32,
     fb_h: u32,
@@ -628,26 +629,21 @@ pub(crate) fn run(
         kq
     };
 
-    // Drain udev's initial device enumeration before waiting on
-    // epoll. udev_assign_seat queues DeviceAdded events synchronously
-    // but dispatch() must be called once to consume them. Without this
-    // first dispatch, the very first epoll_wait blocks until any input
-    // arrives, and the seat enumeration is silently held back. This is
+    // The initial seat enumeration was drained by the caller on the main
+    // thread (so it could verify at least one input device opened before
+    // signalling readiness — issue #64); process those events here. This is
     // also where `libinput: device added` first lands in the log.
-    {
-        let initial = match input_ctx.dispatch() {
-            Ok(evs) => evs,
-            Err(err) => {
-                log::warn!("input thread: initial libinput dispatch: {err}");
-                Vec::new()
-            }
-        };
-        if !initial.is_empty() {
-            let time_ms = current_time_ms();
-            process_batch(&mut state, &sender, &mut pending_motion, initial, time_ms)?;
-            if let Some(m) = pending_motion.take() {
-                sender.send(Message::HostInput(m))?;
-            }
+    if !initial_events.is_empty() {
+        let time_ms = current_time_ms();
+        process_batch(
+            &mut state,
+            &sender,
+            &mut pending_motion,
+            initial_events,
+            time_ms,
+        )?;
+        if let Some(m) = pending_motion.take() {
+            sender.send(Message::HostInput(m))?;
         }
     }
 

--- a/crates/yserver/src/lib.rs
+++ b/crates/yserver/src/lib.rs
@@ -40,6 +40,23 @@ fn install_backend_root_bindings(state: &mut ServerState, backend: &dyn Backend)
     }
 }
 
+/// Refuse to start when libinput's initial seat enumeration opened zero input
+/// devices. A display server with no keyboard or mouse is unusable — the only
+/// escape is to VT-switch and zap — so we fail fast with an actionable error
+/// pointing at the usual cause (issue #64) instead of coming up dead. `opened`
+/// is the count of `DeviceAdded` events from the initial dispatch.
+fn ensure_input_devices_opened(opened: usize) -> io::Result<()> {
+    if opened == 0 {
+        return Err(io::Error::other(
+            "no input devices could be opened under /dev/input.\n\
+             This usually means the user is not in the 'input' group or not \
+             active on seat0.\n\
+             See `loginctl seat-status seat0`, or add the user to the 'input' group.",
+        ));
+    }
+    Ok(())
+}
+
 pub fn run(opts: launch::LaunchOptions) -> io::Result<()> {
     #[cfg(not(any(target_os = "linux", target_os = "freebsd")))]
     panic!("yserver only supports Linux and FreeBSD (DRM/KMS, libinput, evdev)");
@@ -328,7 +345,28 @@ pub fn run(opts: launch::LaunchOptions) -> io::Result<()> {
     if backend.is_libseat_mode() {
         backend.set_input_sender(sender.clone_handle());
         log::info!("yserver: libseat mode — libinput on core thread, no input thread spawned");
-    } else if let Some(input_ctx) = backend.take_input_ctx() {
+    } else if let Some(mut input_ctx) = backend.take_input_ctx() {
+        // Drain libinput's initial seat enumeration here, on the main thread,
+        // BEFORE signalling readiness — so we can refuse to start when no input
+        // device could be opened (issue #64) rather than coming up with a dead
+        // keyboard and mouse. `udev_assign_seat` queues `DeviceAdded`
+        // synchronously and a single dispatch consumes the initial enumeration
+        // (the same contract the input thread relied on). The drained events
+        // are handed to the thread so device registration is unchanged.
+        let initial_events = match input_ctx.dispatch() {
+            Ok(evs) => evs,
+            Err(err) => {
+                log::warn!("yserver: initial libinput dispatch: {err}");
+                Vec::new()
+            }
+        };
+        let opened = initial_events
+            .iter()
+            .filter(|e| matches!(e, crate::input::InputEvent::DeviceAdded(_)))
+            .count();
+        ensure_input_devices_opened(opened)?;
+        log::info!("yserver: {opened} input device(s) opened at startup");
+
         let input_sender = sender.clone_handle();
         let input_control = std::sync::Arc::new(crate::input_thread::InputThreadControl::new()?);
         // Lock-LED relay: the core thread owns the XKB lock state, the
@@ -346,6 +384,7 @@ pub fn run(opts: launch::LaunchOptions) -> io::Result<()> {
             .spawn(move || {
                 if let Err(err) = input_thread::run(
                     input_ctx,
+                    initial_events,
                     input_sender,
                     u32::from(fb_w),
                     u32::from(fb_h),
@@ -709,7 +748,7 @@ fn block_termination_signals() -> io::Result<nix::sys::event::Kqueue> {
 
 #[cfg(test)]
 mod tests {
-    use super::install_backend_root_bindings;
+    use super::{ensure_input_devices_opened, install_backend_root_bindings};
     use yserver_core::{
         backend::Backend,
         resources::{ARGB_COLORMAP, ARGB_VISUAL, ROOT_VISUAL, ROOT_WINDOW},
@@ -743,5 +782,24 @@ mod tests {
             argb_colormap.host_colormap_xid.map(|c| c.as_raw()),
             backend.argb_colormap_xid()
         );
+    }
+
+    #[test]
+    fn ensure_input_devices_opened_rejects_zero_with_actionable_message() {
+        let err = ensure_input_devices_opened(0).expect_err("zero devices must abort startup");
+        let msg = err.to_string();
+        // The message must steer the user to the real cause, not just fail.
+        assert!(msg.contains("/dev/input"), "missing device path: {msg}");
+        assert!(
+            msg.contains("'input' group"),
+            "missing input-group hint: {msg}"
+        );
+        assert!(msg.contains("seat0"), "missing seat0 hint: {msg}");
+    }
+
+    #[test]
+    fn ensure_input_devices_opened_accepts_one_or_more() {
+        assert!(ensure_input_devices_opened(1).is_ok());
+        assert!(ensure_input_devices_opened(8).is_ok());
     }
 }


### PR DESCRIPTION
In Direct mode, libinput's open_restricted logged each failed device open as a warning and let libinput skip it; if zero devices opened (user not in the `input` group / not active on seat0) the server came up anyway with a dead keyboard and mouse — the only escape was a VT-switch zap.

Drain libinput's initial seat enumeration on the main thread, before signalling readiness, and count the DeviceAdded events. If none opened, abort startup with an actionable error pointing at the `input` group / seat0. The drained events are handed to the input thread, so device registration is unchanged; this only relocates the one initial dispatch the thread already performed. A single bad device node does not abort — only a total of zero.

Scope: Direct mode (raw /dev/input opens). Libseat mode gets device fds from the seat manager and does not hit raw EACCES.

Fixes #64. Discovered via #56.


Claude-Session: https://claude.ai/code/session_01U6kTWck4F3x7Sq83zv9Tzo