### PR TITLE
Fix stable build on Ubuntu 26.04

### DIFF
--- a/crates/yserver-core/src/core_loop/run.rs
+++ b/crates/yserver-core/src/core_loop/run.rs
@@ -584,33 +584,6 @@ pub fn run_core(
                 SEAT_TOKEN => {
                     backend.on_seat_ready(state);
                 }
-                tok if let Some(client_id) = token_to_client(tok) => {
-                    // I3: WRITABLE-readiness on a client writer fd.
-                    // Drain the outbound buffer; if it empties, the
-                    // post-loop interest reconciliation drops
-                    // WRITABLE. If the peer disappeared, mark the
-                    // client for disconnect.
-                    if !ev.is_writable() {
-                        // mio always reports both READABLE+WRITABLE
-                        // as readiness even when only one was asked
-                        // for; the writer fd's READABLE wakeups are
-                        // ignored — the reader thread owns reads.
-                        continue;
-                    }
-                    let Some(client) = state.clients.get_mut(&client_id.0) else {
-                        // Already removed by a prior disconnect; the
-                        // poller will be deregistered after.
-                        continue;
-                    };
-                    match client_io::drain_outbound(client) {
-                        Ok(WriteOutcome::Done | WriteOutcome::WouldBlock) => {}
-                        Ok(WriteOutcome::Disconnect) | Err(_) => {
-                            crate::core_loop::process_disconnect::process_disconnect(
-                                state, backend, client_id,
-                            );
-                        }
-                    }
-                }
                 NOTIFY_TOKEN => {
                     for msg in rx.try_recv_all() {
                         match msg {
@@ -720,7 +693,36 @@ pub fn run_core(
                     }
                 }
                 tok => {
-                    warn!("core_loop::run: unhandled poll token {tok:?}");
+                    let Some(client_id) = token_to_client(tok) else {
+                        warn!("core_loop::run: unhandled poll token {tok:?}");
+                        continue;
+                    };
+
+                    // I3: WRITABLE-readiness on a client writer fd.
+                    // Drain the outbound buffer; if it empties, the
+                    // post-loop interest reconciliation drops
+                    // WRITABLE. If the peer disappeared, mark the
+                    // client for disconnect.
+                    if !ev.is_writable() {
+                        // mio always reports both READABLE+WRITABLE
+                        // as readiness even when only one was asked
+                        // for; the writer fd's READABLE wakeups are
+                        // ignored — the reader thread owns reads.
+                        continue;
+                    }
+                    let Some(client) = state.clients.get_mut(&client_id.0) else {
+                        // Already removed by a prior disconnect; the
+                        // poller will be deregistered after.
+                        continue;
+                    };
+                    match client_io::drain_outbound(client) {
+                        Ok(WriteOutcome::Done | WriteOutcome::WouldBlock) => {}
+                        Ok(WriteOutcome::Disconnect) | Err(_) => {
+                            crate::core_loop::process_disconnect::process_disconnect(
+                                state, backend, client_id,
+                            );
+                        }
+                    }
                 }
             }
         }

--- a/crates/yserver-core/src/server.rs
+++ b/crates/yserver-core/src/server.rs
@@ -1719,7 +1719,7 @@ impl MitShmSegment {
             unsafe { libc::shmdt(addr) };
             return Err(err);
         }
-        let size = info.shm_segsz as usize;
+        let size = info.shm_segsz;
         if size == 0 {
             unsafe { libc::shmdt(addr) };
             return Err(std::io::Error::new(


### PR DESCRIPTION
## Summary
- avoid the unstable `if let` match guard in the core poll loop so the project builds on stable Rust
- remove a platform-specific redundant `shm_segsz as usize` cast that fails the CI clippy gate on Ubuntu 26.04

## Validation
- `cargo +nightly fmt`
- `cargo check --bin yserver`
- `cargo clippy --all-targets -- -D warnings`