### PR TITLE
Fix Plasma RandR resizing and ARGB popup transparency

### DIFF
--- a/crates/yserver-core/src/core_loop/process_request.rs
+++ b/crates/yserver-core/src/core_loop/process_request.rs
@@ -3139,6 +3139,7 @@ fn handle_randr_request(
             } else {
                 req_timestamp
             };
+            let output_bbox_before = super::run::enabled_output_bbox(state);
             match backend.apply_crtc_config(&connector, mode_spec, i32::from(x), i32::from(y)) {
                 Ok(true) => {
                     // Something actually changed. Single rebuild path: a CRTC
@@ -3156,7 +3157,10 @@ fn handle_randr_request(
                     // Fire Crtc/Output change (+ ScreenChangeNotify via
                     // RRTellChanged) → emit_randr_change_notifications.
                     super::run::emit_randr_change_notifications(state, &changed);
-                    super::run::emit_screen_resize_window_notifications_if_outputs_match(state);
+                    super::run::emit_screen_resize_window_notifications_if_outputs_caught_up(
+                        state,
+                        output_bbox_before,
+                    );
                     return reply_set_crtc_config(
                         state,
                         client_id,
@@ -46419,7 +46423,10 @@ mod tests {
             "Present pixmap height must ask Mesa/KWin to reallocate full-size buffers",
         );
 
-        super::super::run::emit_screen_resize_window_notifications_if_outputs_match(&mut state);
+        super::super::run::emit_screen_resize_window_notifications_if_outputs_caught_up(
+            &mut state,
+            Some((1680, 1050)),
+        );
         assert!(
             read_all_available(&mut peer).is_empty(),
             "a stale output bbox must not re-emit full-size configure notifications",
@@ -46427,7 +46434,10 @@ mod tests {
 
         state.randr.outputs[0].width = 3440;
         state.randr.outputs[0].height = 1440;
-        super::super::run::emit_screen_resize_window_notifications_if_outputs_match(&mut state);
+        super::super::run::emit_screen_resize_window_notifications_if_outputs_caught_up(
+            &mut state,
+            Some((1680, 1050)),
+        );
         let caught_up = read_all_available(&mut peer);
         assert_eq!(
             caught_up.len(),
@@ -46443,6 +46453,15 @@ mod tests {
         assert_eq!(
             u16::from_le_bytes(caught_up[32 + 34..32 + 36].try_into().unwrap()),
             1440,
+        );
+
+        super::super::run::emit_screen_resize_window_notifications_if_outputs_caught_up(
+            &mut state,
+            Some((3440, 1440)),
+        );
+        assert!(
+            read_all_available(&mut peer).is_empty(),
+            "an unchanged output bbox must not re-emit configure notifications",
         );
     }
 

--- a/crates/yserver-core/src/core_loop/process_request.rs
+++ b/crates/yserver-core/src/core_loop/process_request.rs
@@ -3156,6 +3156,7 @@ fn handle_randr_request(
                     // Fire Crtc/Output change (+ ScreenChangeNotify via
                     // RRTellChanged) → emit_randr_change_notifications.
                     super::run::emit_randr_change_notifications(state, &changed);
+                    super::run::emit_screen_resize_window_notifications_if_outputs_match(state);
                     return reply_set_crtc_config(
                         state,
                         client_id,
@@ -8513,7 +8514,7 @@ pub fn fire_present_completion_events(
 /// (size primarily — Mesa keys buffer reallocation on
 /// `pixmap_{width,height}` here). Mirrors the iteration shape of
 /// `fire_present_completion_events`.
-fn fire_present_configure_notify_for_window(
+pub(crate) fn fire_present_configure_notify_for_window(
     state: &mut ServerState,
     window_id: ResourceId,
     geometry: yserver_protocol::x11::Geometry,
@@ -46223,6 +46224,226 @@ mod tests {
         assert_eq!(state.randr.screen_height, 1080);
         assert_eq!(state.randr.width_mm, 527, "mm verbatim from client");
         assert_eq!(state.randr.height_mm, 296, "mm verbatim from client");
+    }
+
+    /// A compositor that renders through the Composite Overlay Window
+    /// typically backs it with DRI3/Present buffers. `RRSetScreenSize`
+    /// resizes the root and COW outside the normal `ConfigureWindow` path,
+    /// so it must still emit both core ConfigureNotify and
+    /// Present::ConfigureNotify for the materialized COW. Otherwise the
+    /// compositor can keep presenting its old smaller swap buffers after a
+    /// shrink-grow cycle, leaving the desktop in the upper-left corner while
+    /// input/RandR already use the full screen.
+    #[test]
+    fn screen_resize_notifies_materialized_cow_present_subscriber() {
+        use crate::{
+            backend::WindowHandle,
+            randr::{RandrOutput, RandrState},
+            resources::COMPOSITE_OVERLAY_WINDOW,
+            server::PresentEventSelection,
+        };
+        use yserver_protocol::x11::present as x11present;
+
+        const CLIENT_ID: u32 = 1;
+        const PRESENT_EID: u32 = 0x0010_0042;
+
+        let outputs = vec![RandrOutput {
+            name: "DP-4".into(),
+            output_id: 1,
+            crtc_id: 2,
+            mode_id: 3,
+            connected: true,
+            x: 0,
+            y: 0,
+            width: 1680,
+            height: 1050,
+            vrefresh: 100,
+            timing: None,
+            mm_width: 0,
+            mm_height: 0,
+            mode_ids: vec![3],
+            num_preferred: 1,
+        }];
+        let mut state = ServerState::new();
+        state.randr = RandrState::from_outputs(0, outputs);
+        let mut peer = install_client(&mut state, CLIENT_ID);
+        let mut backend = RecordingBackend::new();
+
+        state
+            .resources
+            .materialize_cow_resource(WindowHandle::from_raw_for_test(COMPOSITE_OVERLAY_WINDOW.0));
+        state.materialize_cow_input_shape();
+        state
+            .clients
+            .get_mut(&CLIENT_ID)
+            .unwrap()
+            .event_masks
+            .insert(COMPOSITE_OVERLAY_WINDOW, 0x0002_0000);
+        state.present_event_selections.insert(
+            PRESENT_EID,
+            PresentEventSelection {
+                owner: ClientId(CLIENT_ID),
+                window: COMPOSITE_OVERLAY_WINDOW,
+                event_mask: x11present::EVENT_MASK_CONFIGURE_NOTIFY,
+            },
+        );
+        assert_eq!(
+            crate::core_loop::fanout::subscribers_by_id(
+                &state,
+                COMPOSITE_OVERLAY_WINDOW,
+                0x0002_0000,
+            ),
+            vec![ClientId(CLIENT_ID)],
+            "COW StructureNotify subscription visible before resize",
+        );
+        assert_eq!(
+            state
+                .present_event_selections
+                .get(&PRESENT_EID)
+                .unwrap()
+                .window,
+            COMPOSITE_OVERLAY_WINDOW,
+            "Present Configure subscription visible before resize",
+        );
+
+        let mut body = Vec::with_capacity(16);
+        body.extend_from_slice(&ROOT_WINDOW.0.to_le_bytes());
+        body.extend_from_slice(&3440u16.to_le_bytes());
+        body.extend_from_slice(&1440u16.to_le_bytes());
+        body.extend_from_slice(&910u32.to_le_bytes());
+        body.extend_from_slice(&381u32.to_le_bytes());
+
+        let header = yserver_protocol::x11::RequestHeader {
+            opcode: 128,
+            data: yserver_protocol::x11::randr::RR_SET_SCREEN_SIZE,
+            length_units: 5,
+        };
+        handle_randr_request(
+            &mut state,
+            &mut backend,
+            ClientId(CLIENT_ID),
+            SequenceNumber(1),
+            header,
+            &body,
+        )
+        .expect("RRSetScreenSize grow");
+
+        assert_eq!(state.randr.screen_width, 3440, "RandR width updated");
+        assert_eq!(state.randr.screen_height, 1440, "RandR height updated");
+        let cow = state
+            .resources
+            .window(COMPOSITE_OVERLAY_WINDOW)
+            .expect("COW still materialized");
+        assert_eq!(cow.width, 3440, "COW width updated");
+        assert_eq!(cow.height, 1440, "COW height updated");
+        assert_eq!(
+            crate::core_loop::fanout::subscribers_by_id(
+                &state,
+                COMPOSITE_OVERLAY_WINDOW,
+                0x0002_0000,
+            ),
+            vec![ClientId(CLIENT_ID)],
+            "COW StructureNotify subscription still visible after resize",
+        );
+        assert_eq!(
+            state
+                .present_event_selections
+                .get(&PRESENT_EID)
+                .unwrap()
+                .window,
+            COMPOSITE_OVERLAY_WINDOW,
+            "Present Configure subscription still visible after resize",
+        );
+        assert_eq!(
+            state.clients.get(&CLIENT_ID).unwrap().outbound.len(),
+            0,
+            "small COW resize notifications should not be stuck in outbound",
+        );
+
+        let bytes = read_all_available(&mut peer);
+        assert_eq!(
+            bytes.len(),
+            32 + 40,
+            "COW subscriber should receive core ConfigureNotify plus \
+             Present::ConfigureNotify only; got {bytes:?}",
+        );
+
+        let core = &bytes[..32];
+        assert_eq!(core[0] & 0x7f, 22, "first event must be ConfigureNotify");
+        assert_eq!(
+            u32::from_le_bytes(core[4..8].try_into().unwrap()),
+            COMPOSITE_OVERLAY_WINDOW.0,
+            "ConfigureNotify event window must be COW",
+        );
+        assert_eq!(
+            u32::from_le_bytes(core[8..12].try_into().unwrap()),
+            COMPOSITE_OVERLAY_WINDOW.0,
+            "ConfigureNotify target window must be COW",
+        );
+        assert_eq!(u16::from_le_bytes(core[20..22].try_into().unwrap()), 3440);
+        assert_eq!(u16::from_le_bytes(core[22..24].try_into().unwrap()), 1440);
+
+        let present = &bytes[32..];
+        assert_eq!(present[0], 35, "second event must be GenericEvent");
+        assert_eq!(present[1], 145, "GenericEvent extension must be PRESENT");
+        assert_eq!(
+            u16::from_le_bytes(present[8..10].try_into().unwrap()),
+            u16::from(x11present::EVENT_CONFIGURE_NOTIFY),
+        );
+        assert_eq!(
+            u32::from_le_bytes(present[12..16].try_into().unwrap()),
+            PRESENT_EID,
+        );
+        assert_eq!(
+            u32::from_le_bytes(present[16..20].try_into().unwrap()),
+            COMPOSITE_OVERLAY_WINDOW.0,
+        );
+        assert_eq!(
+            u16::from_le_bytes(present[24..26].try_into().unwrap()),
+            3440,
+            "Present ConfigureNotify width must track the grown COW",
+        );
+        assert_eq!(
+            u16::from_le_bytes(present[26..28].try_into().unwrap()),
+            1440,
+            "Present ConfigureNotify height must track the grown COW",
+        );
+        assert_eq!(
+            u16::from_le_bytes(present[32..34].try_into().unwrap()),
+            3440,
+            "Present pixmap width must ask Mesa/KWin to reallocate full-size buffers",
+        );
+        assert_eq!(
+            u16::from_le_bytes(present[34..36].try_into().unwrap()),
+            1440,
+            "Present pixmap height must ask Mesa/KWin to reallocate full-size buffers",
+        );
+
+        super::super::run::emit_screen_resize_window_notifications_if_outputs_match(&mut state);
+        assert!(
+            read_all_available(&mut peer).is_empty(),
+            "a stale output bbox must not re-emit full-size configure notifications",
+        );
+
+        state.randr.outputs[0].width = 3440;
+        state.randr.outputs[0].height = 1440;
+        super::super::run::emit_screen_resize_window_notifications_if_outputs_match(&mut state);
+        let caught_up = read_all_available(&mut peer);
+        assert_eq!(
+            caught_up.len(),
+            32 + 40,
+            "matching output bbox must re-emit core and Present COW configure notifications",
+        );
+        assert_eq!(caught_up[0] & 0x7f, 22);
+        assert_eq!(caught_up[32], 35);
+        assert_eq!(
+            u16::from_le_bytes(caught_up[32 + 32..32 + 34].try_into().unwrap()),
+            3440,
+        );
+        assert_eq!(
+            u16::from_le_bytes(caught_up[32 + 34..32 + 36].try_into().unwrap()),
+            1440,
+        );
     }
 
     /// `RRSetScreenSize` validation: crop check returns BadMatch; zero-mm

--- a/crates/yserver-core/src/core_loop/run.rs
+++ b/crates/yserver-core/src/core_loop/run.rs
@@ -29,7 +29,7 @@ use super::{
         ClientIdAllocator, DRM_HOTPLUG_TOKEN, DRM_TOKEN, HOST_X11_TOKEN, LIBINPUT_TOKEN,
         LISTENER_TOKEN, NOTIFY_TOKEN, PRESENT_COMPLETION_TOKEN, client_token, token_to_client,
     },
-    process_request::{RequestOutcome, process_request},
+    process_request::{RequestOutcome, fire_present_configure_notify_for_window, process_request},
     sender::{CoreReceiver, CoreSender},
     setup_thread::{self, SetupRegistry},
 };
@@ -938,10 +938,10 @@ pub(crate) fn handle_host_container_resize(
 }
 
 /// Common side-effects of a logical-screen-size change: update root +
-/// overlay window records, emit root ConfigureNotify, fan out RANDR
-/// notifies (ScreenChange always; Crtc/Output only for entries in
-/// `changed`), and re-clamp/warp the pointer. `changed` is empty for a
-/// pure RRSetScreenSize (CRTCs unchanged).
+/// overlay window records, emit ConfigureNotify / Present ConfigureNotify,
+/// fan out RANDR notifies (ScreenChange always; Crtc/Output only for entries
+/// in `changed`), and re-clamp/warp the pointer. `changed` is empty for a pure
+/// RRSetScreenSize (CRTCs unchanged).
 pub(crate) fn apply_screen_size_side_effects(
     state: &mut ServerState,
     backend: &mut dyn Backend,
@@ -949,7 +949,6 @@ pub(crate) fn apply_screen_size_side_effects(
     height: u16,
     changed: &[(u32, u32, u32)],
 ) {
-    use yserver_protocol::x11;
     if let Some(root) = state.resources.window_mut(crate::resources::ROOT_WINDOW) {
         root.width = width;
         root.height = height;
@@ -961,6 +960,47 @@ pub(crate) fn apply_screen_size_side_effects(
         overlay.width = width;
         overlay.height = height;
     }
+
+    emit_screen_resize_window_notifications(state, width, height);
+    emit_randr_change_notifications(state, changed);
+
+    // Pointer: clamp into [0,w)×[0,h); if the screen shrank below the
+    // current cursor position, warp it inside (Xorg
+    // RRPointerScreenConfigured / ScreenRestructured). The KMS motion
+    // clamp only applies on the NEXT motion, so the explicit warp is
+    // required to avoid a stranded off-screen cursor.
+    let (px, py) = state.pointer_root;
+    let cx = i32::from(px).clamp(0, i32::from(width.saturating_sub(1)));
+    let cy = i32::from(py).clamp(0, i32::from(height.saturating_sub(1)));
+    if cx != i32::from(px) || cy != i32::from(py) {
+        let prev = state.barrier_bypass;
+        state.barrier_bypass = true;
+        backend.warp_pointer_root(state, cx, cy);
+        state.barrier_bypass = prev;
+    }
+}
+
+/// Emit the window-size notifications that clients normally get from
+/// `ConfigureWindow`, for screen-sized server windows that RandR resizes
+/// out-of-band. This intentionally does not mutate the resource geometry:
+/// callers must update root/COW first, then use this to wake clients that
+/// cache drawable or Present buffer sizes.
+pub(crate) fn emit_screen_resize_window_notifications(
+    state: &mut ServerState,
+    width: u16,
+    height: u16,
+) {
+    use yserver_protocol::x11;
+
+    let root_geometry = x11::Geometry {
+        root: crate::resources::ROOT_WINDOW,
+        x: 0,
+        y: 0,
+        width,
+        height,
+        border_width: 0,
+        depth: 24,
+    };
 
     // Core ConfigureNotify on root for non-RANDR-aware clients
     // selecting StructureNotifyMask. Spec-correct ordering: emit this
@@ -979,35 +1019,111 @@ pub(crate) fn apply_screen_size_side_effects(
                 crate::resources::ROOT_WINDOW,
                 crate::resources::ROOT_WINDOW,
                 None,
-                x11::Geometry {
-                    root: crate::resources::ROOT_WINDOW,
-                    x: 0,
-                    y: 0,
-                    width,
-                    height,
-                    border_width: 0,
-                    depth: 24,
-                },
+                root_geometry,
                 false,
             );
         },
     );
-    emit_randr_change_notifications(state, changed);
+    fire_present_configure_notify_for_window(state, crate::resources::ROOT_WINDOW, root_geometry);
 
-    // Pointer: clamp into [0,w)×[0,h); if the screen shrank below the
-    // current cursor position, warp it inside (Xorg
-    // RRPointerScreenConfigured / ScreenRestructured). The KMS motion
-    // clamp only applies on the NEXT motion, so the explicit warp is
-    // required to avoid a stranded off-screen cursor.
-    let (px, py) = state.pointer_root;
-    let cx = i32::from(px).clamp(0, i32::from(width.saturating_sub(1)));
-    let cy = i32::from(py).clamp(0, i32::from(height.saturating_sub(1)));
-    if cx != i32::from(px) || cy != i32::from(py) {
-        let prev = state.barrier_bypass;
-        state.barrier_bypass = true;
-        backend.warp_pointer_root(state, cx, cy);
-        state.barrier_bypass = prev;
+    if let Some((parent, geometry, override_redirect)) = state
+        .resources
+        .window(crate::resources::COMPOSITE_OVERLAY_WINDOW)
+        .map(|overlay| {
+            (
+                overlay.parent,
+                x11::Geometry {
+                    root: crate::resources::ROOT_WINDOW,
+                    x: overlay.x,
+                    y: overlay.y,
+                    width: overlay.width,
+                    height: overlay.height,
+                    border_width: overlay.border_width,
+                    depth: overlay.depth,
+                },
+                overlay.override_redirect,
+            )
+        })
+    {
+        let above_sibling = state
+            .resources
+            .configure_notify_above_sibling(crate::resources::COMPOSITE_OVERLAY_WINDOW);
+        let _dropped = crate::core_loop::fanout::emit_window_event_to_state(
+            state,
+            crate::resources::COMPOSITE_OVERLAY_WINDOW,
+            0x0002_0000, // StructureNotifyMask
+            |buf, seq, order| {
+                x11::encode_configure_notify_event(
+                    buf,
+                    seq,
+                    order,
+                    crate::resources::COMPOSITE_OVERLAY_WINDOW,
+                    crate::resources::COMPOSITE_OVERLAY_WINDOW,
+                    above_sibling,
+                    geometry,
+                    override_redirect,
+                );
+            },
+        );
+        let _dropped = crate::core_loop::fanout::emit_window_event_to_state(
+            state,
+            parent,
+            0x0008_0000, // SubstructureNotifyMask
+            |buf, seq, order| {
+                x11::encode_configure_notify_event(
+                    buf,
+                    seq,
+                    order,
+                    parent,
+                    crate::resources::COMPOSITE_OVERLAY_WINDOW,
+                    above_sibling,
+                    geometry,
+                    override_redirect,
+                );
+            },
+        );
+        fire_present_configure_notify_for_window(
+            state,
+            crate::resources::COMPOSITE_OVERLAY_WINDOW,
+            geometry,
+        );
     }
+}
+
+/// `RRSetCrtcConfig` can complete the physical modeset after a compositor
+/// already issued `RRSetScreenSize`. Re-emit root/COW configure notifications
+/// only when the active-output bbox has caught up with the logical screen,
+/// avoiding a premature full-size notify during the shrink half of a
+/// shrink-grow sequence.
+pub(crate) fn emit_screen_resize_window_notifications_if_outputs_match(state: &mut ServerState) {
+    let Some((bbox_w, bbox_h)) = enabled_output_bbox(state) else {
+        return;
+    };
+    if bbox_w == state.randr.screen_width && bbox_h == state.randr.screen_height {
+        emit_screen_resize_window_notifications(state, bbox_w, bbox_h);
+    }
+}
+
+fn enabled_output_bbox(state: &ServerState) -> Option<(u16, u16)> {
+    let mut any = false;
+    let mut max_x = 0i32;
+    let mut max_y = 0i32;
+    for output in state
+        .randr
+        .outputs
+        .iter()
+        .filter(|o| o.connected && o.mode_id != 0)
+    {
+        any = true;
+        max_x = max_x.max(i32::from(output.x).saturating_add(i32::from(output.width)));
+        max_y = max_y.max(i32::from(output.y).saturating_add(i32::from(output.height)));
+    }
+    any.then(|| {
+        (
+            u16::try_from(max_x.max(0)).unwrap_or(u16::MAX),
+            u16::try_from(max_y.max(0)).unwrap_or(u16::MAX),
+        )
+    })
 }
 
 /// Fan out RANDR change notifications for a topology/geometry change.

--- a/crates/yserver-core/src/core_loop/run.rs
+++ b/crates/yserver-core/src/core_loop/run.rs
@@ -1091,20 +1091,27 @@ pub(crate) fn emit_screen_resize_window_notifications(
 }
 
 /// `RRSetCrtcConfig` can complete the physical modeset after a compositor
-/// already issued `RRSetScreenSize`. Re-emit root/COW configure notifications
-/// only when the active-output bbox has caught up with the logical screen,
-/// avoiding a premature full-size notify during the shrink half of a
-/// shrink-grow sequence.
-pub(crate) fn emit_screen_resize_window_notifications_if_outputs_match(state: &mut ServerState) {
+/// already issued `RRSetScreenSize` and received its immediate configure
+/// notifications. When the active-output bbox then changes and catches up
+/// with the logical screen, re-emit root/COW notifications so clients observe
+/// the size again after the modeset. An unchanged bbox (for example, a
+/// refresh-rate-only change) needs no window-size notification.
+pub(crate) fn emit_screen_resize_window_notifications_if_outputs_caught_up(
+    state: &mut ServerState,
+    previous_bbox: Option<(u16, u16)>,
+) {
     let Some((bbox_w, bbox_h)) = enabled_output_bbox(state) else {
         return;
     };
-    if bbox_w == state.randr.screen_width && bbox_h == state.randr.screen_height {
+    if previous_bbox != Some((bbox_w, bbox_h))
+        && bbox_w == state.randr.screen_width
+        && bbox_h == state.randr.screen_height
+    {
         emit_screen_resize_window_notifications(state, bbox_w, bbox_h);
     }
 }
 
-fn enabled_output_bbox(state: &ServerState) -> Option<(u16, u16)> {
+pub(crate) fn enabled_output_bbox(state: &ServerState) -> Option<(u16, u16)> {
     let mut any = false;
     let mut max_x = 0i32;
     let mut max_y = 0i32;

--- a/crates/yserver-protocol/src/x11/mod.rs
+++ b/crates/yserver-protocol/src/x11/mod.rs
@@ -6256,8 +6256,8 @@ pub fn write_render_query_pict_formats_reply(
     argb_visual: ResourceId,
 ) -> io::Result<()> {
     // 5 formats × 28 bytes = 140 bytes
-    // 1 screen: nDepth(4) + fallback(4) + 2 depth sections (8 + 8 each)
-    //   = 40 bytes
+    // 1 screen: 8-byte prelude + 2 depth sections (8-byte header +
+    //   one 8-byte visual-format pair each) = 40 bytes
     // Total body = 180 bytes = 45 × 4-byte units
     let num_formats: u32 = 5;
     let num_screens: u32 = 1;

--- a/crates/yserver-protocol/src/x11/mod.rs
+++ b/crates/yserver-protocol/src/x11/mod.rs
@@ -6244,12 +6244,10 @@ pub fn render_composite_request(body: &[u8]) -> Option<RenderCompositeRequest> {
 }
 
 /// Write QueryPictFormats reply. Advertises 5 picture formats (A1,
-/// A8, X8R8G8B8, A8R8G8B8, **X8R8G8B8 at depth-32**) and maps the
-/// root visual (depth 24) to X8R8G8B8 and the ARGB visual (depth 32)
-/// to BOTH A8R8G8B8 (primary, with alpha) and X8R8G8B8-at-depth-32
-/// (alternate, no alpha — `RENDER_FMT_XRGB32`). The alternate lets
-/// compositors and Cairo wrap a depth-32 storage as opaque without
-/// depending on the storage's padding-alpha bytes — see audit #4.
+/// A8, X8R8G8B8, A8R8G8B8, and X8R8G8B8 at depth 32). The root visual
+/// maps to RGB24 and the depth-32 visual maps only to ARGB32. XRGB32
+/// remains available for clients that explicitly create a Picture with
+/// an opaque format, but is not a second association for the ARGB visual.
 pub fn write_render_query_pict_formats_reply(
     writer: &mut impl Write,
     byte_order: ClientByteOrder,
@@ -6258,16 +6256,14 @@ pub fn write_render_query_pict_formats_reply(
     argb_visual: ResourceId,
 ) -> io::Result<()> {
     // 5 formats × 28 bytes = 140 bytes
-    // 1 screen: nDepth(4) + fallback(4) + depth24-section(8 + 8 = 16) +
-    //   depth32-section(8 header + 2 × 8 visual-format pairs = 24) = 48 bytes
-    // Total body = 188 bytes = 47 × 4-byte units
+    // 1 screen: nDepth(4) + fallback(4) + 2 depth sections (8 + 8 each)
+    //   = 40 bytes
+    // Total body = 180 bytes = 45 × 4-byte units
     let num_formats: u32 = 5;
     let num_screens: u32 = 1;
     let num_depths: u32 = 2;
-    // Total (visual,format) pairs across all depths: depth-24 has 1,
-    // depth-32 has 2 (ARGB32 + XRGB32-depth32). Sum = 3.
-    let num_visuals: u32 = 3;
-    let body_units: u32 = (140 + 48) / 4; // 47
+    let num_visuals: u32 = 2;
+    let body_units: u32 = (140 + 40) / 4; // 45
 
     let mut out = Vec::new();
     out.push(1u8); // Reply
@@ -6368,22 +6364,73 @@ pub fn write_render_query_pict_formats_reply(
     write_u32(byte_order, &mut out, 0); // pad
     write_u32(byte_order, &mut out, root_visual.0);
     write_u32(byte_order, &mut out, RENDER_FMT_RGB24);
-    // Depth 32 entry: 8-byte header + 2 (visual, format) pairs.
-    // The same ARGB visual is listed twice — once with ARGB32 (primary,
-    // with-alpha) and once with XRGB32 (alternate, no-alpha). Per
-    // X RENDER spec, multiple format associations for the same visual
-    // are spec-legal and how Xorg advertises depth-32 — see
-    // `render/picture.c` PICT_x8r8g8b8 + PICT_a8r8g8b8 entries.
+    // Depth 32 entry: the ARGB visual has exactly one format association.
+    // Xorg also reports each VisualID once; mapping this visual again to
+    // XRGB32 can make clients treat its transparent pixels as opaque.
     out.push(32);
     out.push(0);
-    write_u16(byte_order, &mut out, 2); // 2 (visual, format) pairs
+    write_u16(byte_order, &mut out, 1); // 1 (visual, format) pair
     write_u32(byte_order, &mut out, 0); // pad
     write_u32(byte_order, &mut out, argb_visual.0);
     write_u32(byte_order, &mut out, RENDER_FMT_ARGB32);
-    write_u32(byte_order, &mut out, argb_visual.0);
-    write_u32(byte_order, &mut out, RENDER_FMT_XRGB32);
 
     writer.write_all(&out)
+}
+
+#[cfg(test)]
+mod render_query_pict_formats_tests {
+    use super::*;
+
+    fn le_u16(bytes: &[u8]) -> u16 {
+        u16::from_le_bytes(bytes.try_into().unwrap())
+    }
+
+    fn le_u32(bytes: &[u8]) -> u32 {
+        u32::from_le_bytes(bytes.try_into().unwrap())
+    }
+
+    #[test]
+    fn argb_visual_has_only_argb32_format_association() {
+        let root_visual = ResourceId(0x102);
+        let argb_visual = ResourceId(0x103);
+        let mut reply = Vec::new();
+
+        write_render_query_pict_formats_reply(
+            &mut reply,
+            ClientByteOrder::LittleEndian,
+            SequenceNumber(7),
+            root_visual,
+            argb_visual,
+        )
+        .unwrap();
+
+        assert_eq!(reply.len(), 32 + 180);
+        assert_eq!(le_u32(&reply[4..8]), 45);
+        assert_eq!(le_u32(&reply[8..12]), 5);
+        assert_eq!(le_u32(&reply[12..16]), 1);
+        assert_eq!(le_u32(&reply[16..20]), 2);
+        assert_eq!(le_u32(&reply[20..24]), 2);
+
+        let screen = 32 + 5 * 28;
+        assert_eq!(le_u32(&reply[screen..screen + 4]), 2);
+        assert_eq!(le_u32(&reply[screen + 4..screen + 8]), RENDER_FMT_RGB24);
+
+        let depth24 = screen + 8;
+        assert_eq!(reply[depth24], 24);
+        assert_eq!(le_u16(&reply[depth24 + 2..depth24 + 4]), 1);
+        assert_eq!(le_u32(&reply[depth24 + 8..depth24 + 12]), root_visual.0);
+        assert_eq!(le_u32(&reply[depth24 + 12..depth24 + 16]), RENDER_FMT_RGB24);
+
+        let depth32 = depth24 + 16;
+        assert_eq!(reply[depth32], 32);
+        assert_eq!(le_u16(&reply[depth32 + 2..depth32 + 4]), 1);
+        assert_eq!(le_u32(&reply[depth32 + 8..depth32 + 12]), argb_visual.0);
+        assert_eq!(
+            le_u32(&reply[depth32 + 12..depth32 + 16]),
+            RENDER_FMT_ARGB32
+        );
+        assert_eq!(depth32 + 16, reply.len());
+    }
 }
 
 pub fn write_render_query_pict_index_values_reply(

--- a/docs/protocol-audit-2026-05-19.md
+++ b/docs/protocol-audit-2026-05-19.md
@@ -78,7 +78,9 @@ Active 4d shadow/CSD ARGB-vs-xRGB mismatch. Real fix is Stage 4e PictFormat trac
 
 **Resolution:** added `RENDER_FMT_XRGB32` (id=5, depth=32, alpha_mask=0) — mirrors
 Xorg's `PICT_x8r8g8b8`; `write_render_query_pict_formats_reply` now advertises 5
-formats and lists the depth-32 visual with both ARGB32 + XRGB32 pairs. New engine
+formats. XRGB32 remains available for explicit Picture creation, while the depth-32
+ARGB visual is associated only with ARGB32, matching Xorg's one-format-per-visual
+screen mapping. New engine
 helpers `resolve_force_opaque_pict_format` / `swizzle_class_for_pict_format` /
 `dst_has_alpha_for_pict_format` consult `pict_format` first, falling back to the
 legacy depth heuristic when `pict_format=0` (engine-internal callers without Picture

--- a/docs/status.md
+++ b/docs/status.md
@@ -112,6 +112,28 @@ Cross-cutting bugs and followups that don't fit a stage live in
   end-to-end path has a live-Vulkan integration test and is confirmed
   by flameshot smoke on real KMS. Supersedes the tree-re-walk approach
   in PR #76.
+- **2026-07-07 RandR COW resize notifications**: Plasma/KWin on real
+  KMS exposed a shrink-then-grow failure where RandR/input returned to
+  the full screen but the composited desktop stayed at the smaller size
+  in the upper-left corner. `RRSetScreenSize` already resized root/COW
+  storage, but it bypassed the normal `ConfigureWindow` path and did
+  not emit core `ConfigureNotify` or `Present::ConfigureNotify` for a
+  materialized Composite Overlay Window. The resize side-effects now
+  notify both root and COW, including Present configure events so
+  DRI3/Present compositors reallocate full-size swap buffers; the same
+  notify is re-emitted after a real `RRSetCrtcConfig` once the output bbox
+  matches the logical screen, covering Plasma's SetScreenSize-before-
+  SetCrtcConfig grow order. Regression
+  `screen_resize_notifies_materialized_cow_present_subscriber` pins the COW
+  wire events.
+- **2026-07-13 RENDER ARGB visual mapping**: real-KMS testing with KiCad/GTK
+  exposed opaque black rectangles around otherwise correct popup menus. The
+  server advertised the same depth-32 ARGB visual twice in
+  `QueryPictFormats`, first as ARGB32 and then as XRGB32. Xorg maps each
+  VisualID once; clients retaining the last association consequently treated
+  transparent popup pixels as opaque. The visual now maps only to ARGB32,
+  while XRGB32 remains in the global format list for explicit Picture use. A
+  wire-reply regression test pins the format counts and depth associations.
 - **2026-06-17 XFIXES pointer barriers**: `PointerBarrier` storage,
   XFIXES barrier wire parsing, `CreatePointerBarrier` /
   `DeletePointerBarrier` dispatch, client-disconnect cleanup, XID

--- a/tools/run-plasma-yserver.sh
+++ b/tools/run-plasma-yserver.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: tools/run-plasma-yserver.sh [DISPLAY]
+
+Launch yserver KMS and Plasma X11 from a real Linux TTY.
+
+Arguments:
+  DISPLAY               X display number to use, default 7. Both "7" and ":7"
+                        are accepted.
+
+Environment:
+  YSERVER_DISPLAY       Display number when no argument is given.
+  YSERVER_BIN           yserver binary path, default target/release/yserver.
+  YSERVER_BUILD=0       Do not auto-build target/release/yserver if missing.
+  YSERVER_LOG_DIR       Directory for yserver.log and plasma.log.
+  RUST_LOG              yserver log filter, default info.
+  RUST_BACKTRACE        yserver backtrace setting, default 1.
+  YSERVER_DBUS_MODE     "user" uses the login user's DBus/systemd bus when
+                        available; "session" starts an isolated
+                        dbus-run-session. Default is "user", which is closer
+                        to a real TTY login session.
+  YSERVER_ALLOW_NON_TTY=1
+                        Bypass the TTY guard. Only use for debugging.
+
+Exit:
+  Ctrl-Alt-Backspace should zap yserver.
+  When Plasma exits, the script terminates yserver and prints the log path.
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+tty_name=$(tty)
+if [[ "${YSERVER_ALLOW_NON_TTY:-0}" != "1" ]]; then
+    case "$tty_name" in
+        /dev/tty[0-9]*) ;;
+        *)
+            echo "run-plasma-yserver: must be run from a real TTY, got: $tty_name" >&2
+            echo "Switch with Ctrl-Alt-F3, log in, then run this script." >&2
+            exit 1
+            ;;
+    esac
+fi
+
+repo_root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$repo_root"
+
+display=${1:-${YSERVER_DISPLAY:-7}}
+display=${display#:}
+if ! [[ "$display" =~ ^[0-9]+$ ]]; then
+    echo "run-plasma-yserver: invalid display '$display'" >&2
+    exit 1
+fi
+
+yserver_bin=${YSERVER_BIN:-target/release/yserver}
+if [[ ! -x "$yserver_bin" ]]; then
+    if [[ "${YSERVER_BUILD:-1}" == "0" ]]; then
+        echo "run-plasma-yserver: missing executable: $yserver_bin" >&2
+        exit 1
+    fi
+    echo "run-plasma-yserver: building release yserver..."
+    cargo build --release --bin yserver
+fi
+
+for cmd in dbus-run-session startplasma-x11; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "run-plasma-yserver: missing command: $cmd" >&2
+        exit 1
+    fi
+done
+
+if [[ "${YSERVER_SKIP_SESSION_WARNING:-0}" != "1" ]] && command -v pgrep >/dev/null 2>&1; then
+    if pgrep -u "$(id -u)" -x plasmashell >/dev/null 2>&1 \
+        || pgrep -u "$(id -u)" -x kwin_wayland >/dev/null 2>&1 \
+        || pgrep -u "$(id -u)" -x kwin_x11 >/dev/null 2>&1; then
+        cat >&2 <<'EOF'
+run-plasma-yserver: existing KDE/Plasma processes are running for this user.
+Running a second Plasma session can conflict through DBus, KDE services, and
+per-user runtime state. For the cleanest test, log out of the graphical Plasma
+session first, or continue for a quick smoke test.
+EOF
+        read -r -p "Press Enter to continue, or Ctrl-C to abort: " _
+    fi
+fi
+
+timestamp=$(date +%Y%m%d-%H%M%S)
+log_dir=${YSERVER_LOG_DIR:-${TMPDIR:-/tmp}/yserver-plasma-$timestamp}
+mkdir -p "$log_dir"
+yserver_log=$log_dir/yserver.log
+plasma_log=$log_dir/plasma.log
+
+ypid=
+cleanup() {
+    local status=$?
+    trap - EXIT INT TERM
+    if [[ -n "${ypid:-}" ]] && kill -0 "$ypid" >/dev/null 2>&1; then
+        echo "run-plasma-yserver: stopping yserver pid $ypid"
+        kill -TERM "$ypid" >/dev/null 2>&1 || true
+        for _ in {1..50}; do
+            if ! kill -0 "$ypid" >/dev/null 2>&1; then
+                break
+            fi
+            sleep 0.1
+        done
+        if kill -0 "$ypid" >/dev/null 2>&1; then
+            kill -KILL "$ypid" >/dev/null 2>&1 || true
+        fi
+        wait "$ypid" >/dev/null 2>&1 || true
+    fi
+    echo "run-plasma-yserver: logs in $log_dir"
+    exit "$status"
+}
+trap cleanup EXIT INT TERM
+
+echo "run-plasma-yserver: display :$display"
+echo "run-plasma-yserver: logs in $log_dir"
+echo "run-plasma-yserver: starting $yserver_bin"
+
+RUST_LOG=${RUST_LOG:-info} \
+RUST_BACKTRACE=${RUST_BACKTRACE:-1} \
+"$yserver_bin" "$display" >"$yserver_log" 2>&1 &
+ypid=$!
+
+socket=/tmp/.X11-unix/X$display
+for _ in {1..100}; do
+    if [[ -S "$socket" ]]; then
+        break
+    fi
+    if ! kill -0 "$ypid" >/dev/null 2>&1; then
+        echo "run-plasma-yserver: yserver exited before creating $socket" >&2
+        tail -n 80 "$yserver_log" >&2 || true
+        exit 1
+    fi
+    sleep 0.1
+done
+
+if [[ ! -S "$socket" ]]; then
+    echo "run-plasma-yserver: timed out waiting for $socket" >&2
+    tail -n 80 "$yserver_log" >&2 || true
+    exit 1
+fi
+
+dbus_mode=${YSERVER_DBUS_MODE:-user}
+user_bus=${DBUS_SESSION_BUS_ADDRESS:-}
+if [[ -z "$user_bus" && -n "${XDG_RUNTIME_DIR:-}" && -S "$XDG_RUNTIME_DIR/bus" ]]; then
+    user_bus="unix:path=$XDG_RUNTIME_DIR/bus"
+elif [[ -z "$user_bus" && -S "/run/user/$(id -u)/bus" ]]; then
+    user_bus="unix:path=/run/user/$(id -u)/bus"
+fi
+
+plasma_env=(
+    env
+    -u WAYLAND_DISPLAY
+    -u WAYLAND_SOCKET
+    -u SESSION_MANAGER
+    "DISPLAY=:$display"
+    "XDG_SESSION_TYPE=x11"
+    "GDK_BACKEND=x11"
+    "QT_QPA_PLATFORM=xcb"
+)
+
+if [[ "$dbus_mode" == "user" && -n "$user_bus" ]]; then
+    plasma_cmd=("${plasma_env[@]}" "DBUS_SESSION_BUS_ADDRESS=$user_bus" startplasma-x11)
+    echo "run-plasma-yserver: starting Plasma X11 on existing user DBus bus"
+else
+    plasma_cmd=("${plasma_env[@]}" dbus-run-session startplasma-x11)
+    echo "run-plasma-yserver: starting Plasma X11 under dbus-run-session"
+fi
+
+set +e
+"${plasma_cmd[@]}" >"$plasma_log" 2>&1
+plasma_status=$?
+set -e
+
+echo "run-plasma-yserver: Plasma exited with status $plasma_status"
+exit "$plasma_status"


### PR DESCRIPTION
## Summary

- emit core `ConfigureNotify` and Present `ConfigureNotify` for the root
  and materialized Composite Overlay Window after `RRSetScreenSize`
- re-emit those notifications after `RRSetCrtcConfig` once the active
  output bounding box matches the logical screen size
- associate the depth-32 ARGB visual only with `ARGB32` in
  `QueryPictFormats`, while keeping `XRGB32` available for explicit
  Picture creation
- add a real-TTY launcher for testing Plasma X11 directly on yserver KMS

## Motivation

Real-KMS testing with Plasma X11 on Kubuntu 26.04 exposed two regressions:

1. After shrinking and restoring the display resolution, RandR and input
   returned to the full screen size, but Plasma's desktop remained rendered
   at the smaller size in a corner. The RandR path resized root/COW storage
   without sending the configure notifications used by DRI3/Present
   compositors to reallocate their buffers.

2. KiCad/GTK popup menus were surrounded by opaque black rectangles.
   yserver advertised the same ARGB visual twice, first as `ARGB32` and then
   as `XRGB32`. Xorg associates each VisualID with one screen PictFormat.
   Keeping only the `ARGB32` association preserves popup transparency.

Both fixes were verified in a real Plasma X11 session running directly on
yserver KMS.

## Validation

- Plasma X11 startup on Kubuntu 26.04
- resolution shrink and restore
- KiCad popup-menu transparency
- `cargo +nightly fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --locked`
- `cargo test --all-targets --locked`
- `YSERVER_ALLOW_SOFTWARE_VULKAN=1 cargo test -p yserver --lib --locked -- --ignored`
