### PR TITLE
fix(xkb): clear stale keymap_overrides + broadcast legacy MappingNotify on layout switch

### DIFF
--- a/crates/yserver-core/src/backend/recording.rs
+++ b/crates/yserver-core/src/backend/recording.rs
@@ -214,6 +214,15 @@ pub struct RecordingBackend {
     /// without a real keymap; tests that exercise `_XKB_RULES_NAMES`
     /// publishing set it via `with_xkb_rules_names`.
     pub xkb_rules_names: Option<[String; 5]>,
+    /// Return value for `set_keymap_rmlvo`. `None` (the default) models
+    /// a backend without a real keymap (matches the trait default);
+    /// tests that need `apply_rules_names_change` to take its recompile
+    /// branch set it via `with_keymap_rmlvo_result`.
+    pub keymap_rmlvo_result: Option<(u8, u8)>,
+    /// Return value for `xkb_get_kbd_by_name`, seeded via
+    /// `with_kbd_by_name_result`. `None` (the default) matches the trait
+    /// default for backends without a real keymap.
+    pub kbd_by_name_result: Option<(Vec<u8>, Option<crate::backend::XkbNewKeyboardInfo>)>,
     /// Modifier state `(effective, base, latched, locked)` returned by
     /// `current_xkb_mods`. Tests set it to drive `XkbStateNotify` emission.
     pub xkb_mods: (u8, u8, u8, u8),
@@ -249,6 +258,8 @@ impl RecordingBackend {
             warped_to: None,
             gamma: std::cell::RefCell::new(std::collections::HashMap::new()),
             xkb_rules_names: None,
+            keymap_rmlvo_result: None,
+            kbd_by_name_result: None,
             xkb_mods: (0, 0, 0, 0),
             render_return_region: Vec::new(),
         }
@@ -259,6 +270,28 @@ impl RecordingBackend {
     #[must_use]
     pub fn with_xkb_rules_names(mut self, names: [String; 5]) -> Self {
         self.xkb_rules_names = Some(names);
+        self
+    }
+
+    /// Seed the value `set_keymap_rmlvo` returns, so a test can drive
+    /// `apply_rules_names_change` through its recompile branch without a
+    /// real keymap backend.
+    #[must_use]
+    pub fn with_keymap_rmlvo_result(mut self, result: (u8, u8)) -> Self {
+        self.keymap_rmlvo_result = Some(result);
+        self
+    }
+
+    /// Seed the value `xkb_get_kbd_by_name` returns, so a test can drive
+    /// `handle_xkb_request`'s minor==23 (XkbGetKbdByName) branch through
+    /// its notify-fanout path without a real keymap backend.
+    #[must_use]
+    pub fn with_kbd_by_name_result(
+        mut self,
+        bytes: Vec<u8>,
+        notify: Option<crate::backend::XkbNewKeyboardInfo>,
+    ) -> Self {
+        self.kbd_by_name_result = Some((bytes, notify));
         self
     }
 
@@ -327,6 +360,25 @@ impl Backend for RecordingBackend {
 
     fn current_xkb_rules_names(&self) -> Option<[String; 5]> {
         self.xkb_rules_names.clone()
+    }
+
+    fn set_keymap_rmlvo(
+        &mut self,
+        _rules: &str,
+        _model: &str,
+        _layout: &str,
+        _variant: &str,
+        _options: Option<&str>,
+    ) -> Option<(u8, u8)> {
+        self.keymap_rmlvo_result
+    }
+
+    fn xkb_get_kbd_by_name(
+        &mut self,
+        _body: &[u8],
+        _intern_atom: &mut dyn FnMut(&str) -> u32,
+    ) -> Option<(Vec<u8>, Option<crate::backend::XkbNewKeyboardInfo>)> {
+        self.kbd_by_name_result.clone()
     }
 
     fn composite_opcode(&self) -> Option<u8> {

--- a/crates/yserver-core/src/core_loop/key_fanout.rs
+++ b/crates/yserver-core/src/core_loop/key_fanout.rs
@@ -12,6 +12,7 @@
 //! mirrors it across clients), so the helper picks the first non-ROOT
 //! focus it sees. When every client is rooted, the event is dropped.
 
+use log::debug;
 use yserver_protocol::x11::{self, ClientId, ResourceId};
 
 use crate::{
@@ -470,6 +471,13 @@ enum KeyRoute {
 /// Apply X11 keyboard routing rules. May activate a passive grab or
 /// auto-release one on the matching key release.
 fn key_route(state: &mut ServerState, event: &HostKeyEvent) -> KeyRoute {
+    debug!(
+        "key_route keycode={} pressed={} state=0x{:x} active_grab={:?}",
+        event.keycode,
+        event.pressed,
+        event.state,
+        state.active_keyboard_grab.map(|g| (g.owner, g.grab_window))
+    );
     // Active grab in effect.
     if let Some(g) = state.active_keyboard_grab {
         let passive = matches!(g.source, ActiveKeyboardGrabSource::PassiveKey { .. });
@@ -502,6 +510,10 @@ fn key_route(state: &mut ServerState, event: &HostKeyEvent) -> KeyRoute {
             );
         }
         if passive {
+            debug!(
+                "key_route -> active passive-key grab owner={:?} window={:?}",
+                g.owner, g.grab_window
+            );
             return KeyRoute::PassiveGrabOwner {
                 owner: g.owner,
                 grab_window: g.grab_window,
@@ -517,6 +529,10 @@ fn key_route(state: &mut ServerState, event: &HostKeyEvent) -> KeyRoute {
         // (xterm secure-keyboard, XTS AllowDeviceEvents iskfrozen
         // probes). Window delivery here silently dropped keys when
         // the grabber had no KeyPressMask on the grab window.
+        debug!(
+            "key_route -> explicit GrabKeyboard owner={:?} window={:?}",
+            g.owner, g.grab_window
+        );
         return KeyRoute::PassiveGrabOwner {
             owner: g.owner,
             grab_window: g.grab_window,
@@ -551,6 +567,10 @@ fn key_route(state: &mut ServerState, event: &HostKeyEvent) -> KeyRoute {
                     )
                 })
     {
+        debug!(
+            "key_route -> new passive grab match owner={owner:?} window={grab_window:?} \
+             keyboard_mode={keyboard_mode} (0=Sync freeze, 1=Async)"
+        );
         state.active_keyboard_grab = Some(ActiveKeyboardGrab {
             owner,
             grab_window,
@@ -594,8 +614,10 @@ fn key_route(state: &mut ServerState, event: &HostKeyEvent) -> KeyRoute {
     // Focus None: keys are discarded (only grabs see them) — Xorg
     // DeliverFocusedEvent with focus->win == NoneWin.
     if focus == ResourceId(0) {
+        debug!("key_route -> dropped, no focus and no matching grab");
         return KeyRoute::Drop;
     }
+    debug!("key_route -> focused window {focus:?}, no grab involved");
     KeyRoute::Window(focus)
 }
 

--- a/crates/yserver-core/src/core_loop/process_request.rs
+++ b/crates/yserver-core/src/core_loop/process_request.rs
@@ -15237,6 +15237,42 @@ fn handle_xkb_request(
             if let Some(info) = notify {
                 let base = backend.xkb_info().map_or(0, |(_maj, ev, _err)| ev);
                 let all: Vec<ClientId> = state.clients.keys().map(|id| ClientId(*id)).collect();
+                // A full XkbGetKeyboardByName load replaces the whole
+                // key-symbol table in Xorg, so stale ChangeKeyboardMapping
+                // overrides must not keep shadowing it (see the identical
+                // fix + rationale in `apply_rules_names_change`).
+                state.keymap_overrides.clear();
+                // Legacy core MappingNotify(Keyboard) + MappingNotify(Modifier)
+                // to ALL clients, mirroring Xorg's XkbSendLegacyMapNotify
+                // companion to XkbSendNewKeyboardNotify. XKB-unaware clients
+                // (any plain-X11 WM that never calls XkbSelectEvents — e.g.
+                // one that resolves keybinds via XKeysymToKeycode once at
+                // startup) never see XkbNewKeyboardNotify, so without this
+                // they keep grabbing the pre-switch keycodes forever: typing
+                // reflects the new layout (translation is per-keystroke) but
+                // WM keyboard shortcuts stay stuck on the old one, because
+                // nothing ever told the WM to re-resolve keysym→keycode and
+                // re-`GrabKey`. This is the same pair `apply_rules_names_change`
+                // sends for the `_XKB_RULES_NAMES`-ChangeProperty path; real
+                // `setxkbmap` goes through *this* XkbGetKbdByName path instead,
+                // so it needs the same legacy fanout here.
+                let count = info
+                    .max_keycode
+                    .saturating_sub(info.min_keycode)
+                    .saturating_add(1);
+                let _dropped = fanout_event_to_clients(state, &all, |buf, seq, order| {
+                    let _ = x11::write_mapping_notify_event(
+                        buf,
+                        order,
+                        seq,
+                        1,
+                        info.min_keycode,
+                        count,
+                    );
+                });
+                let _dropped = fanout_event_to_clients(state, &all, |buf, seq, order| {
+                    let _ = x11::write_mapping_notify_event(buf, order, seq, 0, 0, 0);
+                });
                 let _dropped = fanout_event_to_clients(state, &all, |buf, seq, order| {
                     let _ = x11::write_xkb_new_keyboard_notify(
                         buf,
@@ -48913,6 +48949,77 @@ mod tests {
             reply.len() >= 32 && reply[reply_start] == 1 && reply[reply_start + 8] == 0,
             "combo grab reply must be Success (0), not AlreadyGrabbed (1); got {:?}",
             &reply[..reply.len().min(12)]
+        );
+    }
+
+    #[test]
+    fn xkb_get_kbd_by_name_also_broadcasts_legacy_mapping_notify() {
+        // Real `setxkbmap` loads a layout via XkbGetKeyboardByName (minor
+        // 23), not by writing `_XKB_RULES_NAMES`. A plain-X11 client (any
+        // WM that never calls XkbSelectEvents and only understands core
+        // events — e.g. one resolving keybinds via XKeysymToKeycode once
+        // at startup) relies on the legacy MappingNotify event to know
+        // when to re-resolve its keysym-based key grabs. Without it, the
+        // WM's shortcuts stay bound to the pre-switch keycodes forever
+        // even though per-keystroke translation (and thus typing) already
+        // reflects the new layout.
+        let mut state = ServerState::new();
+        let mut peer = install_client(&mut state, 1);
+        // Stale ChangeKeyboardMapping row from before the switch — must
+        // not keep shadowing the freshly loaded keymap either.
+        state.keymap_overrides.insert(38, vec![0x0071]);
+
+        let mut reply = vec![0u8; 32];
+        reply[0] = 1; // X_Reply
+        let mut backend = RecordingBackend::new().with_kbd_by_name_result(
+            reply,
+            Some(crate::backend::XkbNewKeyboardInfo {
+                min_keycode: 8,
+                max_keycode: 255,
+                old_min_keycode: 8,
+                old_max_keycode: 255,
+                changed: 0x0001,
+            }),
+        );
+
+        handle_xkb_request(
+            &mut state,
+            &mut backend,
+            None,
+            ClientId(1),
+            SequenceNumber(1),
+            RequestHeader {
+                opcode: 136,
+                data: 23,
+                length_units: 2,
+            },
+            &[],
+        )
+        .expect("XkbGetKbdByName");
+
+        assert!(
+            state.keymap_overrides.is_empty(),
+            "a full XkbGetKeyboardByName load must drop stale ChangeKeyboardMapping rows too"
+        );
+
+        let bytes = read_all_available(&mut peer);
+        let mapping_notify_count = bytes
+            .chunks(32)
+            .filter(
+                |chunk| chunk.len() == 32 && chunk[0] == 34, /* MappingNotify */
+            )
+            .count();
+        assert!(
+            mapping_notify_count >= 2,
+            "expected legacy MappingNotify(Keyboard) + MappingNotify(Modifier) \
+             alongside XkbNewKeyboardNotify, got {mapping_notify_count} in {bytes:02x?}"
+        );
+        let keyboard_mapping_notify = bytes
+            .chunks(32)
+            .find(|chunk| chunk.len() == 32 && chunk[0] == 34 && chunk[4] == 1);
+        assert!(
+            keyboard_mapping_notify.is_some(),
+            "expected a MappingNotify with request=Keyboard(1): {bytes:02x?}"
         );
     }
 }

--- a/crates/yserver-core/src/core_loop/xkb_layout.rs
+++ b/crates/yserver-core/src/core_loop/xkb_layout.rs
@@ -119,6 +119,16 @@ pub fn apply_rules_names_change(state: &mut ServerState, backend: &mut dyn Backe
     let xkb_event_base = backend.xkb_info().map_or(0, |(_maj, ev, _err)| ev);
     let count = max_kc.saturating_sub(min_kc).saturating_add(1);
 
+    // A full RMLVO reload replaces the whole key-symbol table in Xorg
+    // (XkbGetKeyboardByName), so any keycodes previously overridden by
+    // `ChangeKeyboardMapping` must NOT keep shadowing the new backend
+    // keymap — otherwise those keycodes stay stuck on the pre-switch
+    // layout forever, while every other key correctly reflects the new
+    // one. Without this, `fetch_merged_keymap` (GetKeyboardMapping)
+    // keeps layering the stale rows on top of the freshly recompiled
+    // keymap for any keycode an app ever remapped.
+    state.keymap_overrides.clear();
+
     // 1. Core MappingNotify(Keyboard) + MappingNotify(Modifier) to ALL
     //    clients — mirrors Xorg's XkbSendLegacyMapNotify on a keymap reload.
     let all: Vec<ClientId> = state.clients.keys().map(|id| ClientId(*id)).collect();
@@ -288,6 +298,32 @@ mod tests {
         assert!(
             state.resources.window_property(ROOT_WINDOW, atom).is_none(),
             "no property published when the backend has no keymap"
+        );
+    }
+
+    #[test]
+    fn apply_rules_names_change_clears_stale_keymap_overrides() {
+        // A client (e.g. xmodmap) had previously overridden keycode 38
+        // via ChangeKeyboardMapping. Model that directly on `keymap_overrides`
+        // rather than going through the request handler — this test only
+        // needs to prove the recompile path clears it.
+        let mut state = ServerState::new();
+        state.keymap_overrides.insert(38, vec![0x0071]); // stale 'q' row
+        assert!(
+            !state.keymap_overrides.is_empty(),
+            "precondition: an override is staged before the layout switch"
+        );
+
+        let mut backend = RecordingBackend::new().with_keymap_rmlvo_result((8, 255));
+
+        apply_rules_names_change(&mut state, &mut backend, b"evdev\0pc105\0us\0dvorak\0\0");
+
+        assert!(
+            state.keymap_overrides.is_empty(),
+            "a full RMLVO reload must drop stale ChangeKeyboardMapping rows, \
+             the way Xorg's XkbGetKeyboardByName replaces the whole key-symbol \
+             table — otherwise keycode 38 stays stuck on the pre-switch layout \
+             forever while every other key correctly reflects the new one"
         );
     }
 


### PR DESCRIPTION
Two related bugs in layout-switch handling:

1. \`apply_rules_names_change\` never cleared \`keymap_overrides\`, so keycodes previously overridden via \`ChangeKeyboardMapping\` kept shadowing every subsequent RMLVO reload indefinitely.
2. The real \`XkbGetKbdByName\` (minor 23) path only ever broadcast \`XkbNewKeyboardNotify\`. Any client that doesn't speak the XKB extension (plain-core WMs resolving keybinds via \`XKeysymToKeycode\` once at startup) never gets told to re-grab, so their shortcuts stay bound to the pre-switch keycodes forever even though translation already reflects the new layout.

Added regression tests for both in \`xkb_layout.rs\` / \`process_request.rs\`. Not a rendering/KMS change, so no HW testing note needed.