### PR TITLE
feat(vidmode): support Mesa OML MSC rate queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,18 @@ We support the following extensions:
 - XINERAMA
 - XInputExtension
 - XC-MISC
+- XFree86-VidModeExtension
 - XKEYBOARD
 - XTEST
+
+### GLX_OML_sync_control
+
+Mesa implements `glXGetMscRateOML()` on the client side by reading the current
+mode through `XFree86-VidModeExtension`. Yserver implements the read-only
+`QueryVersion` and `GetModeLine` requests, plus `SetClientVersion`, with the
+Xorg wire layouts and real DRM/RANDR mode timings. This lets Mesa and
+ANGLE-based Flatpak clients derive the display MSC rate without exposing the
+legacy mode-setting operations of VidMode.
 
 ### GLX_EXT_texture_from_pixmap
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ We support the following extensions:
 Mesa implements `glXGetMscRateOML()` on the client side by reading the current
 mode through `XFree86-VidModeExtension`. Yserver implements Xorg's read surface
 with the correct legacy/v2 wire layouts and the selected output's real
-DRM/RANDR timing, monitor identity, dot clock, viewport and gamma ramp. This
+DRM/RANDR timing, monitor identity, programmable clock capability, viewport
+and gamma ramp. This
 lets Mesa and ANGLE-based Flatpak clients derive the display MSC rate while
 other VidMode readers see data consistent with RANDR instead of unexpected
 `BadRequest` errors.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ Xorg wire layouts and real DRM/RANDR mode timings. This lets Mesa and
 ANGLE-based Flatpak clients derive the display MSC rate without exposing the
 legacy mode-setting operations of VidMode.
 
+`GetAllModeLines`, `GetGammaRampSize` and `GetPermissions` are answered too, so
+a client that probes VidMode for something other than the MSC rate gets a
+truthful read-only picture — one mode, no gamma ramp, `XF86VM_READ_PERMISSION`
+without write — rather than an unexpected `BadRequest` from an extension it
+just saw advertised. Everything else — mode setting, gamma, viewport and the
+remaining monitor queries — is deliberately not implemented and returns
+`BadRequest`; RANDR is the supported way to change modes.
+
 ### GLX_EXT_texture_from_pixmap
 
 Implemented and tested on AMD, intel, Asahi and Qualcomm. It can NOT (read: NEVER) work on nvidia proprietary driver, and on

--- a/README.md
+++ b/README.md
@@ -47,19 +47,19 @@ We support the following extensions:
 ### GLX_OML_sync_control
 
 Mesa implements `glXGetMscRateOML()` on the client side by reading the current
-mode through `XFree86-VidModeExtension`. Yserver implements the read-only
-`QueryVersion` and `GetModeLine` requests, plus `SetClientVersion`, with the
-Xorg wire layouts and real DRM/RANDR mode timings. This lets Mesa and
-ANGLE-based Flatpak clients derive the display MSC rate without exposing the
-legacy mode-setting operations of VidMode.
+mode through `XFree86-VidModeExtension`. Yserver implements Xorg's read surface
+with the correct legacy/v2 wire layouts and the selected output's real
+DRM/RANDR timing, monitor identity, dot clock, viewport and gamma ramp. This
+lets Mesa and ANGLE-based Flatpak clients derive the display MSC rate while
+other VidMode readers see data consistent with RANDR instead of unexpected
+`BadRequest` errors.
 
-`GetAllModeLines`, `GetGammaRampSize` and `GetPermissions` are answered too, so
-a client that probes VidMode for something other than the MSC rate gets a
-truthful read-only picture — one mode, no gamma ramp, `XF86VM_READ_PERMISSION`
-without write — rather than an unexpected `BadRequest` from an extension it
-just saw advertised. Everything else — mode setting, gamma, viewport and the
-remaining monitor queries — is deliberately not implemented and returns
-`BadRequest`; RANDR is the supported way to change modes.
+VidMode remains deliberately read-only because RANDR owns display
+configuration. `GetPermissions` advertises only `XF86VM_READ_PERMISSION`, and
+known mode/gamma writes fail with VidMode's `ClientNotLocal` error — the same
+coherent fallback branch Xorg exposes to a client without write permission.
+Yserver clients are physically local Unix-socket peers, so this is an explicit
+server policy rather than a claim that they are remote.
 
 ### GLX_EXT_texture_from_pixmap
 

--- a/crates/yserver-core/src/core_loop/process_disconnect.rs
+++ b/crates/yserver-core/src/core_loop/process_disconnect.rs
@@ -331,6 +331,7 @@ pub fn process_disconnect(state: &mut ServerState, backend: &mut dyn Backend, cl
     state
         .mit_shm_segments
         .retain(|_, seg| seg.owner != client_id);
+    state.vidmode_client_versions.remove(&client_id);
     state
         .randr_select_masks
         .retain(|(owner, window), _| *owner != client_id.0 && !dead_windows.contains(window));

--- a/crates/yserver-core/src/core_loop/process_disconnect.rs
+++ b/crates/yserver-core/src/core_loop/process_disconnect.rs
@@ -866,6 +866,28 @@ mod tests {
     }
 
     #[test]
+    fn disconnect_removes_only_the_dead_clients_vidmode_version() {
+        // The VidMode reply layout is per-client state keyed by ClientId.
+        // Leaking it means a recycled id inherits the previous client's
+        // v2-vs-legacy choice and gets a reply of the wrong length.
+        let mut state = ServerState::new();
+        install_client(&mut state, 7);
+        install_client(&mut state, 8);
+        state.vidmode_client_versions.insert(ClientId(7), (2, 2));
+        state.vidmode_client_versions.insert(ClientId(8), (1, 0));
+
+        let mut backend = RecordingBackend::new();
+        process_disconnect(&mut state, &mut backend, ClientId(7));
+
+        assert!(!state.vidmode_client_versions.contains_key(&ClientId(7)));
+        assert_eq!(
+            state.vidmode_client_versions.get(&ClientId(8)),
+            Some(&(1, 0)),
+            "a surviving client must keep its negotiated version"
+        );
+    }
+
+    #[test]
     fn disconnect_removes_client_from_screensaver_state_and_restarts_timer_if_last_suspender() {
         use std::time::Duration;
         let mut state = ServerState::new();

--- a/crates/yserver-core/src/core_loop/process_request.rs
+++ b/crates/yserver-core/src/core_loop/process_request.rs
@@ -11440,6 +11440,7 @@ fn handle_xf86vidmode_request(
                 x11vm::GET_VIEW_PORT => {
                     x11vm::encode_get_view_port_reply(byte_order, sequence, 0, 0)
                 }
+                x11vm::GET_DOT_CLOCKS => x11vm::encode_get_dot_clocks_reply(byte_order, sequence),
                 _ => {
                     let Some(current) = current_vidmode_output(state) else {
                         // Xorg: VidModeGetCurrentModeline failure => BadValue.
@@ -11470,11 +11471,6 @@ fn handle_xf86vidmode_request(
                                 byte_order, sequence, &vendor, &model, &hsync, &vsync,
                             )
                         }
-                        x11vm::GET_DOT_CLOCKS => x11vm::encode_get_dot_clocks_reply(
-                            byte_order,
-                            sequence,
-                            &[current.mode.dot_clock],
-                        ),
                         x11vm::GET_MODE_LINE | x11vm::GET_ALL_MODE_LINES => {
                             debug!(
                                 "client {} #{} XFree86-VidMode::{} \
@@ -35984,12 +35980,15 @@ mod tests {
         assert_eq!(&viewport[8..16], &[0; 8]);
 
         let clocks = dispatch_vidmode(&mut state, &mut peer, 3, x11vm::GET_DOT_CLOCKS, &[0; 4]);
-        assert_eq!(clocks.len(), 36);
-        assert_eq!(u32::from_le_bytes(clocks[12..16].try_into().unwrap()), 1);
-        assert_eq!(u32::from_le_bytes(clocks[16..20].try_into().unwrap()), 1);
+        assert_eq!(clocks.len(), 32);
         assert_eq!(
-            u32::from_le_bytes(clocks[32..36].try_into().unwrap()),
-            current.mode.dot_clock
+            u32::from_le_bytes(clocks[8..12].try_into().unwrap()),
+            x11vm::CLOCK_FLAG_PROGRAMMABLE
+        );
+        assert_eq!(u32::from_le_bytes(clocks[12..16].try_into().unwrap()), 0);
+        assert_eq!(
+            u32::from_le_bytes(clocks[16..20].try_into().unwrap()),
+            x11vm::MAX_CLOCKS
         );
 
         let legacy_validate = dispatch_vidmode(
@@ -36023,6 +36022,30 @@ mod tests {
         assert_eq!(
             u32::from_le_bytes(v2_validate[8..12].try_into().unwrap()),
             x11vm::MODE_OK
+        );
+    }
+
+    #[test]
+    fn xf86vidmode_dotclocks_reports_programmable_clock_when_headless() {
+        use yserver_protocol::x11::xf86vidmode as x11vm;
+
+        let mut state = ServerState::new();
+        state.randr.outputs.clear();
+        let mut peer = install_client(&mut state, 1);
+
+        // Xorg's modesetting driver advertises a programmable clock even
+        // without an active output; the active dot clock belongs to
+        // GetModeLine rather than the legacy fixed-clock table.
+        let clocks = dispatch_vidmode(&mut state, &mut peer, 1, x11vm::GET_DOT_CLOCKS, &[0; 4]);
+        assert_eq!(clocks.len(), 32);
+        assert_eq!(
+            u32::from_le_bytes(clocks[8..12].try_into().unwrap()),
+            x11vm::CLOCK_FLAG_PROGRAMMABLE
+        );
+        assert_eq!(u32::from_le_bytes(clocks[12..16].try_into().unwrap()), 0);
+        assert_eq!(
+            u32::from_le_bytes(clocks[16..20].try_into().unwrap()),
+            x11vm::MAX_CLOCKS
         );
     }
 

--- a/crates/yserver-core/src/core_loop/process_request.rs
+++ b/crates/yserver-core/src/core_loop/process_request.rs
@@ -423,6 +423,8 @@ pub fn process_request(
         150 => handle_screen_saver_request(state, backend, client_id, sequence, header, body),
         // ── XC-MISC extension dispatcher ──
         152 => handle_xcmisc_request(state, client_id, sequence, header, body),
+        // ── XFree86-VidModeExtension dispatcher ──
+        153 => handle_xf86vidmode_request(state, client_id, sequence, header, body),
         opcode => {
             debug!(
                 "client {} #{} unknown opcode {} ({} bytes) -> BadRequest",
@@ -11059,6 +11061,197 @@ fn handle_x_resource_request(
         return Ok(RequestOutcome::Handled);
     };
     Ok(write_to_client(client, client_id, &reply))
+}
+
+fn current_vidmode_mode_line(
+    state: &ServerState,
+) -> Option<yserver_protocol::x11::xf86vidmode::ModeLine> {
+    use yserver_protocol::x11::xf86vidmode::ModeLine;
+
+    // Xwayland's VidMode shim uses its fixed output, or otherwise the first
+    // output. Yserver's configured primary is the closest equivalent; if it
+    // is off, fall back to the first enabled output.
+    let output = state
+        .randr
+        .outputs
+        .iter()
+        .find(|output| {
+            output.output_id == state.randr.primary_output
+                && output.connected
+                && output.mode_id != 0
+        })
+        .or_else(|| {
+            state
+                .randr
+                .outputs
+                .iter()
+                .find(|output| output.connected && output.mode_id != 0)
+        })?;
+
+    if let Some(timing) = output.timing {
+        return Some(ModeLine {
+            dot_clock: timing.clock_khz,
+            hdisplay: output.width,
+            hsync_start: timing.hsync_start,
+            hsync_end: timing.hsync_end,
+            htotal: timing.htotal,
+            hskew: 0,
+            vdisplay: output.height,
+            vsync_start: timing.vsync_start,
+            vsync_end: timing.vsync_end,
+            vtotal: timing.vtotal,
+            flags: timing.mode_flags,
+        });
+    }
+
+    // Keep the no-kernel-timing fallback consistent with RandrState's
+    // synthetic ModeInfo. VidMode carries the pixel clock in whole kHz, so
+    // round the exact synthetic Hz value to the nearest representable kHz.
+    if output.vrefresh == 0 {
+        return None;
+    }
+    let htotal = output.width.saturating_add(264);
+    let vtotal = output.height.saturating_add(28);
+    let clock_hz = u64::from(htotal) * u64::from(vtotal) * u64::from(output.vrefresh);
+    let dot_clock = u32::try_from((clock_hz + 500) / 1000).unwrap_or(u32::MAX);
+    Some(ModeLine {
+        dot_clock,
+        hdisplay: output.width,
+        hsync_start: output.width.saturating_add(40),
+        hsync_end: output.width.saturating_add(168),
+        htotal,
+        hskew: 0,
+        vdisplay: output.height,
+        vsync_start: output.height.saturating_add(1),
+        vsync_end: output.height.saturating_add(4),
+        vtotal,
+        flags: 0,
+    })
+}
+
+fn handle_xf86vidmode_request(
+    state: &mut ServerState,
+    client_id: ClientId,
+    sequence: SequenceNumber,
+    header: RequestHeader,
+    body: &[u8],
+) -> io::Result<RequestOutcome> {
+    use crate::nested::XF86VIDMODE_MAJOR_OPCODE;
+    use yserver_protocol::x11::{ClientByteOrder, xf86vidmode as x11vm};
+
+    let byte_order = state
+        .clients
+        .get(&client_id.0)
+        .map_or(ClientByteOrder::LittleEndian, |client| client.byte_order);
+
+    match header.data {
+        x11vm::QUERY_VERSION => {
+            if !body.is_empty() {
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    x11::error::BAD_LENGTH,
+                    0,
+                    u16::from(header.data),
+                    XF86VIDMODE_MAJOR_OPCODE,
+                );
+            }
+            let reply = x11vm::encode_query_version_reply(byte_order, sequence);
+            let Some(client) = state.clients.get_mut(&client_id.0) else {
+                return Ok(RequestOutcome::Handled);
+            };
+            return Ok(write_to_client(client, client_id, &reply));
+        }
+        x11vm::SET_CLIENT_VERSION => {
+            let Some(version) = x11vm::parse_client_version(body) else {
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    x11::error::BAD_LENGTH,
+                    0,
+                    u16::from(header.data),
+                    XF86VIDMODE_MAJOR_OPCODE,
+                );
+            };
+            state
+                .vidmode_client_versions
+                .insert(client_id, (version.major, version.minor));
+            debug!(
+                "client {} #{} XFree86-VidMode::SetClientVersion {}.{}",
+                client_id.0, sequence.0, version.major, version.minor
+            );
+        }
+        x11vm::GET_MODE_LINE => {
+            let Some(screen) = x11vm::parse_screen(body) else {
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    x11::error::BAD_LENGTH,
+                    0,
+                    u16::from(header.data),
+                    XF86VIDMODE_MAJOR_OPCODE,
+                );
+            };
+            if screen != 0 {
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    x11::error::BAD_VALUE,
+                    u32::from(screen),
+                    u16::from(header.data),
+                    XF86VIDMODE_MAJOR_OPCODE,
+                );
+            }
+            let Some(mode) = current_vidmode_mode_line(state) else {
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    x11::error::BAD_VALUE,
+                    u32::from(screen),
+                    u16::from(header.data),
+                    XF86VIDMODE_MAJOR_OPCODE,
+                );
+            };
+            let version_2 = state
+                .vidmode_client_versions
+                .get(&client_id)
+                .is_some_and(|(major, _)| *major >= 2);
+            let reply = x11vm::encode_get_mode_line_reply(byte_order, sequence, mode, version_2);
+            debug!(
+                "client {} #{} XFree86-VidMode::GetModeLine \
+                 {}x{} clock={}kHz totals={}x{} flags=0x{:x}",
+                client_id.0,
+                sequence.0,
+                mode.hdisplay,
+                mode.vdisplay,
+                mode.dot_clock,
+                mode.htotal,
+                mode.vtotal,
+                mode.flags
+            );
+            let Some(client) = state.clients.get_mut(&client_id.0) else {
+                return Ok(RequestOutcome::Handled);
+            };
+            return Ok(write_to_client(client, client_id, &reply));
+        }
+        _ => {
+            return emit_x11_error_with_minor(
+                state,
+                client_id,
+                sequence,
+                x11::error::BAD_REQUEST,
+                0,
+                u16::from(header.data),
+                XF86VIDMODE_MAJOR_OPCODE,
+            );
+        }
+    }
+    Ok(RequestOutcome::Handled)
 }
 
 fn handle_glx_request(
@@ -27357,6 +27550,17 @@ mod tests {
         out
     }
 
+    fn read_all_or_buffered(
+        state: &mut ServerState,
+        client_id: u32,
+        peer: &mut UnixStream,
+    ) -> Vec<u8> {
+        let mut out = read_all_available(peer);
+        let client = state.clients.get_mut(&client_id).expect("test client");
+        out.extend(client.outbound.drain(..));
+        out
+    }
+
     fn poly_fill_rectangle_body(drawable: u32, gc: u32) -> Vec<u8> {
         let mut body = Vec::with_capacity(16);
         body.extend_from_slice(&drawable.to_le_bytes());
@@ -34984,6 +35188,7 @@ mod tests {
             (150, "MIT-SCREEN-SAVER"),
             (151, "XINERAMA"),
             (152, "XC-MISC"),
+            (153, "XFree86-VidModeExtension"),
         ];
 
         for (opcode, name) in extensions {
@@ -35023,6 +35228,195 @@ mod tests {
             );
             assert_eq!(error[10], opcode, "{name}: major opcode");
         }
+    }
+
+    #[test]
+    fn xf86vidmode_v2_mode_line_round_trips_current_randr_timing() {
+        use crate::randr::{ModeTiming, RandrOutput, RandrState};
+        use yserver_protocol::x11::xf86vidmode as x11vm;
+
+        let mut state = ServerState::new();
+        state.randr = RandrState::from_outputs(
+            1,
+            vec![RandrOutput {
+                name: "DP-1".to_string(),
+                output_id: 1,
+                crtc_id: 2,
+                mode_id: 3,
+                connected: true,
+                x: 0,
+                y: 0,
+                width: 2560,
+                height: 1440,
+                vrefresh: 60,
+                timing: Some(ModeTiming {
+                    clock_khz: 241_500,
+                    hsync_start: 2608,
+                    hsync_end: 2640,
+                    htotal: 2720,
+                    vsync_start: 1443,
+                    vsync_end: 1448,
+                    vtotal: 1481,
+                    mode_flags: 5,
+                }),
+                mm_width: 600,
+                mm_height: 340,
+                mode_ids: vec![3],
+                num_preferred: 1,
+            }],
+        );
+        let expected = current_vidmode_mode_line(&state).expect("active RandR mode");
+        assert_eq!(
+            expected,
+            x11vm::ModeLine {
+                dot_clock: 241_500,
+                hdisplay: 2560,
+                hsync_start: 2608,
+                hsync_end: 2640,
+                htotal: 2720,
+                hskew: 0,
+                vdisplay: 1440,
+                vsync_start: 1443,
+                vsync_end: 1448,
+                vtotal: 1481,
+                flags: 5,
+            }
+        );
+        let mut peer = install_client(&mut state, 1);
+        let mut backend = RecordingBackend::new();
+
+        process_request(
+            &mut state,
+            &mut backend,
+            ClientId(1),
+            SequenceNumber(1),
+            RequestHeader {
+                opcode: crate::nested::XF86VIDMODE_MAJOR_OPCODE,
+                data: x11vm::QUERY_VERSION,
+                length_units: 1,
+            },
+            &[],
+            None,
+        )
+        .expect("QueryVersion");
+        let version = read_all_or_buffered(&mut state, 1, &mut peer);
+        assert_eq!(version.len(), 32);
+        assert_eq!(&version[8..12], &[2, 0, 2, 0]);
+
+        process_request(
+            &mut state,
+            &mut backend,
+            ClientId(1),
+            SequenceNumber(2),
+            RequestHeader {
+                opcode: crate::nested::XF86VIDMODE_MAJOR_OPCODE,
+                data: x11vm::SET_CLIENT_VERSION,
+                length_units: 2,
+            },
+            &[2, 0, 2, 0],
+            None,
+        )
+        .expect("SetClientVersion");
+        assert!(read_all_or_buffered(&mut state, 1, &mut peer).is_empty());
+        assert_eq!(
+            state.vidmode_client_versions.get(&ClientId(1)),
+            Some(&(2, 2))
+        );
+
+        process_request(
+            &mut state,
+            &mut backend,
+            ClientId(1),
+            SequenceNumber(3),
+            RequestHeader {
+                opcode: crate::nested::XF86VIDMODE_MAJOR_OPCODE,
+                data: x11vm::GET_MODE_LINE,
+                length_units: 2,
+            },
+            &[0; 4],
+            None,
+        )
+        .expect("GetModeLine");
+        let mode = read_all_or_buffered(&mut state, 1, &mut peer);
+        assert_eq!(mode.len(), 52);
+        assert_eq!(u32::from_le_bytes(mode[4..8].try_into().unwrap()), 5);
+        assert_eq!(
+            u32::from_le_bytes(mode[8..12].try_into().unwrap()),
+            expected.dot_clock
+        );
+        assert_eq!(
+            u16::from_le_bytes(mode[12..14].try_into().unwrap()),
+            expected.hdisplay
+        );
+        assert_eq!(
+            u16::from_le_bytes(mode[18..20].try_into().unwrap()),
+            expected.htotal
+        );
+        assert_eq!(
+            u16::from_le_bytes(mode[22..24].try_into().unwrap()),
+            expected.vdisplay
+        );
+        assert_eq!(
+            u16::from_le_bytes(mode[28..30].try_into().unwrap()),
+            expected.vtotal
+        );
+        assert_eq!(
+            u32::from_le_bytes(mode[32..36].try_into().unwrap()),
+            expected.flags
+        );
+        assert_eq!(&mode[36..52], &[0; 16]);
+    }
+
+    #[test]
+    fn xf86vidmode_defaults_to_legacy_reply_and_rejects_unknown_screen() {
+        use yserver_protocol::x11::xf86vidmode as x11vm;
+
+        let mut state = ServerState::new();
+        let mut peer = install_client(&mut state, 1);
+        let mut backend = RecordingBackend::new();
+
+        process_request(
+            &mut state,
+            &mut backend,
+            ClientId(1),
+            SequenceNumber(1),
+            RequestHeader {
+                opcode: crate::nested::XF86VIDMODE_MAJOR_OPCODE,
+                data: x11vm::GET_MODE_LINE,
+                length_units: 2,
+            },
+            &[0; 4],
+            None,
+        )
+        .expect("legacy GetModeLine");
+        let legacy = read_all_or_buffered(&mut state, 1, &mut peer);
+        assert_eq!(legacy.len(), 36);
+        assert_eq!(u32::from_le_bytes(legacy[4..8].try_into().unwrap()), 1);
+
+        process_request(
+            &mut state,
+            &mut backend,
+            ClientId(1),
+            SequenceNumber(2),
+            RequestHeader {
+                opcode: crate::nested::XF86VIDMODE_MAJOR_OPCODE,
+                data: x11vm::GET_MODE_LINE,
+                length_units: 2,
+            },
+            &[1, 0, 0, 0],
+            None,
+        )
+        .expect("bad-screen GetModeLine");
+        let error = read_all_or_buffered(&mut state, 1, &mut peer);
+        assert_eq!(error.len(), 32);
+        assert_eq!(error[0], 0);
+        assert_eq!(error[1], x11::error::BAD_VALUE);
+        assert_eq!(u32::from_le_bytes(error[4..8].try_into().unwrap()), 1);
+        assert_eq!(
+            u16::from_le_bytes(error[8..10].try_into().unwrap()),
+            u16::from(x11vm::GET_MODE_LINE)
+        );
+        assert_eq!(error[10], crate::nested::XF86VIDMODE_MAJOR_OPCODE);
     }
 
     // ---- L2 plan B.1: COMPOSITE redirect dispatch policy --------

--- a/crates/yserver-core/src/core_loop/process_request.rs
+++ b/crates/yserver-core/src/core_loop/process_request.rs
@@ -11128,6 +11128,15 @@ fn current_vidmode_mode_line(
     current_vidmode_output(state).map(|output| output.mode)
 }
 
+fn vidmode_timing_order_is_valid(mode: yserver_protocol::x11::xf86vidmode::ModeLine) -> bool {
+    mode.hdisplay <= mode.hsync_start
+        && mode.hsync_start <= mode.hsync_end
+        && mode.hsync_end <= mode.htotal
+        && mode.vdisplay <= mode.vsync_start
+        && mode.vsync_start <= mode.vsync_end
+        && mode.vsync_end <= mode.vtotal
+}
+
 /// Derive VidMode's old monitor strings from the same raw EDID RANDR exposes.
 /// A missing/invalid EDID leaves the vendor empty and uses the connector name
 /// as the model, which is more useful than inventing an identity.
@@ -11285,7 +11294,8 @@ fn handle_xf86vidmode_request(
             );
         }
         x11vm::VALIDATE_MODE_LINE => {
-            let Some(screen) = x11vm::parse_validate_mode_line_screen(byte_order, body, version_2)
+            let Some(request) =
+                x11vm::parse_validate_mode_line_request(byte_order, body, version_2)
             else {
                 return emit_x11_error_with_minor(
                     state,
@@ -11297,7 +11307,7 @@ fn handle_xf86vidmode_request(
                     XF86VIDMODE_MAJOR_OPCODE,
                 );
             };
-            if let Err((code, bad_value)) = vidmode_screen_number(screen) {
+            if let Err((code, bad_value)) = vidmode_screen_number(request.screen) {
                 return emit_x11_error_with_minor(
                     state,
                     client_id,
@@ -11308,10 +11318,7 @@ fn handle_xf86vidmode_request(
                     XF86VIDMODE_MAJOR_OPCODE,
                 );
             }
-            // Xorg asks the active driver's mode validator. Yserver advertises
-            // only the already-active hardware mode and has no separate
-            // VidMode mode-setting path, so a well-formed line is acceptable.
-            if current_vidmode_output(state).is_none() {
+            let Some(current) = current_vidmode_output(state) else {
                 return emit_x11_error_with_minor(
                     state,
                     client_id,
@@ -11321,9 +11328,24 @@ fn handle_xf86vidmode_request(
                     u16::from(header.data),
                     XF86VIDMODE_MAJOR_OPCODE,
                 );
+            };
+
+            // Xorg rejects inverted timing order before invoking the monitor
+            // and driver validators. Yserver exposes only the active mode, so
+            // that exact advertised line is the only one its read-only
+            // VidMode surface can truthfully validate. Legacy clients cannot
+            // carry hskew, matching the legacy GetModeLine reply.
+            let mut advertised = current.mode;
+            if !version_2 {
+                advertised.hskew = 0;
             }
-            let reply =
-                x11vm::encode_validate_mode_line_reply(byte_order, sequence, x11vm::MODE_OK);
+            let status =
+                if vidmode_timing_order_is_valid(request.mode) && request.mode == advertised {
+                    x11vm::MODE_OK
+                } else {
+                    x11vm::MODE_BAD
+                };
+            let reply = x11vm::encode_validate_mode_line_reply(byte_order, sequence, status);
             return write_vidmode_reply(state, client_id, &reply);
         }
         x11vm::GET_GAMMA => {
@@ -35763,6 +35785,50 @@ mod tests {
         assert_eq!(reply[10], crate::nested::XF86VIDMODE_MAJOR_OPCODE);
     }
 
+    fn validate_mode_line_body(
+        mode: yserver_protocol::x11::xf86vidmode::ModeLine,
+        version_2: bool,
+        byte_order: ClientByteOrder,
+    ) -> Vec<u8> {
+        fn put_u16(body: &mut [u8], offset: usize, value: u16, order: ClientByteOrder) {
+            let bytes = match order {
+                ClientByteOrder::LittleEndian => value.to_le_bytes(),
+                ClientByteOrder::BigEndian => value.to_be_bytes(),
+            };
+            body[offset..offset + 2].copy_from_slice(&bytes);
+        }
+
+        fn put_u32(body: &mut [u8], offset: usize, value: u32, order: ClientByteOrder) {
+            let bytes = match order {
+                ClientByteOrder::LittleEndian => value.to_le_bytes(),
+                ClientByteOrder::BigEndian => value.to_be_bytes(),
+            };
+            body[offset..offset + 4].copy_from_slice(&bytes);
+        }
+
+        let mut body = vec![0; if version_2 { 48 } else { 32 }];
+        put_u32(&mut body, 4, mode.dot_clock, byte_order);
+        put_u16(&mut body, 8, mode.hdisplay, byte_order);
+        put_u16(&mut body, 10, mode.hsync_start, byte_order);
+        put_u16(&mut body, 12, mode.hsync_end, byte_order);
+        put_u16(&mut body, 14, mode.htotal, byte_order);
+        if version_2 {
+            put_u16(&mut body, 16, mode.hskew, byte_order);
+            put_u16(&mut body, 18, mode.vdisplay, byte_order);
+            put_u16(&mut body, 20, mode.vsync_start, byte_order);
+            put_u16(&mut body, 22, mode.vsync_end, byte_order);
+            put_u16(&mut body, 24, mode.vtotal, byte_order);
+            put_u32(&mut body, 28, mode.flags, byte_order);
+        } else {
+            put_u16(&mut body, 16, mode.vdisplay, byte_order);
+            put_u16(&mut body, 18, mode.vsync_start, byte_order);
+            put_u16(&mut body, 20, mode.vsync_end, byte_order);
+            put_u16(&mut body, 22, mode.vtotal, byte_order);
+            put_u32(&mut body, 24, mode.flags, byte_order);
+        }
+        body
+    }
+
     /// Known writes must use the same Xorg non-local branch advertised by
     /// GetPermissions; truly unknown minors remain BadRequest.
     #[test]
@@ -35991,12 +36057,14 @@ mod tests {
             x11vm::MAX_CLOCKS
         );
 
+        let legacy_body =
+            validate_mode_line_body(current.mode, false, ClientByteOrder::LittleEndian);
         let legacy_validate = dispatch_vidmode(
             &mut state,
             &mut peer,
             4,
             x11vm::VALIDATE_MODE_LINE,
-            &[0; 32],
+            &legacy_body,
         );
         assert_eq!(legacy_validate.len(), 32);
         assert_eq!(
@@ -36004,24 +36072,68 @@ mod tests {
             x11vm::MODE_OK
         );
 
-        dispatch_vidmode(
+        let invalid_validate = dispatch_vidmode(
             &mut state,
             &mut peer,
             5,
-            x11vm::SET_CLIENT_VERSION,
-            &[2, 0, 2, 0],
+            x11vm::VALIDATE_MODE_LINE,
+            &[0; 32],
         );
-        let v2_validate = dispatch_vidmode(
+        assert_eq!(
+            u32::from_le_bytes(invalid_validate[8..12].try_into().unwrap()),
+            x11vm::MODE_BAD
+        );
+
+        let mut inverted_mode = current.mode;
+        inverted_mode.hsync_start = inverted_mode.hdisplay - 1;
+        let inverted_body =
+            validate_mode_line_body(inverted_mode, false, ClientByteOrder::LittleEndian);
+        let inverted_validate = dispatch_vidmode(
             &mut state,
             &mut peer,
             6,
             x11vm::VALIDATE_MODE_LINE,
-            &[0; 48],
+            &inverted_body,
+        );
+        assert_eq!(
+            u32::from_le_bytes(inverted_validate[8..12].try_into().unwrap()),
+            x11vm::MODE_BAD
+        );
+
+        dispatch_vidmode(
+            &mut state,
+            &mut peer,
+            7,
+            x11vm::SET_CLIENT_VERSION,
+            &[2, 0, 2, 0],
+        );
+        let v2_body = validate_mode_line_body(current.mode, true, ClientByteOrder::LittleEndian);
+        let v2_validate = dispatch_vidmode(
+            &mut state,
+            &mut peer,
+            8,
+            x11vm::VALIDATE_MODE_LINE,
+            &v2_body,
         );
         assert_eq!(v2_validate.len(), 32);
         assert_eq!(
             u32::from_le_bytes(v2_validate[8..12].try_into().unwrap()),
             x11vm::MODE_OK
+        );
+
+        let mut other_mode = current.mode;
+        other_mode.dot_clock += 1;
+        let other_body = validate_mode_line_body(other_mode, true, ClientByteOrder::LittleEndian);
+        let other_validate = dispatch_vidmode(
+            &mut state,
+            &mut peer,
+            9,
+            x11vm::VALIDATE_MODE_LINE,
+            &other_body,
+        );
+        assert_eq!(
+            u32::from_le_bytes(other_validate[8..12].try_into().unwrap()),
+            x11vm::MODE_BAD
         );
     }
 
@@ -36220,9 +36332,7 @@ mod tests {
         assert_eq!(error[1], x11::error::BAD_VALUE);
         assert_eq!(&error[4..8], &1_u32.to_be_bytes());
 
-        let mut validate = vec![0u8; 48];
-        validate[0..4].copy_from_slice(&0u32.to_be_bytes());
-        validate[44..48].copy_from_slice(&0u32.to_be_bytes());
+        let validate = validate_mode_line_body(expected, true, ClientByteOrder::BigEndian);
         let validated = dispatch_vidmode(
             &mut state,
             &mut peer,

--- a/crates/yserver-core/src/core_loop/process_request.rs
+++ b/crates/yserver-core/src/core_loop/process_request.rs
@@ -424,7 +424,7 @@ pub fn process_request(
         // ── XC-MISC extension dispatcher ──
         152 => handle_xcmisc_request(state, client_id, sequence, header, body),
         // ── XFree86-VidModeExtension dispatcher ──
-        153 => handle_xf86vidmode_request(state, client_id, sequence, header, body),
+        153 => handle_xf86vidmode_request(state, backend, client_id, sequence, header, body),
         opcode => {
             debug!(
                 "client {} #{} unknown opcode {} ({} bytes) -> BadRequest",
@@ -11063,9 +11063,14 @@ fn handle_x_resource_request(
     Ok(write_to_client(client, client_id, &reply))
 }
 
-fn current_vidmode_mode_line(
-    state: &ServerState,
-) -> Option<yserver_protocol::x11::xf86vidmode::ModeLine> {
+#[derive(Debug)]
+struct CurrentVidModeOutput {
+    output_id: u32,
+    connector: String,
+    mode: yserver_protocol::x11::xf86vidmode::ModeLine,
+}
+
+fn current_vidmode_output(state: &ServerState) -> Option<CurrentVidModeOutput> {
     use yserver_protocol::x11::xf86vidmode::ModeLine;
 
     // Xwayland's VidMode shim uses its fixed output, or otherwise the first
@@ -11097,19 +11102,101 @@ fn current_vidmode_mode_line(
     if timing.dot_clock_hz == 0 {
         return None;
     }
-    Some(ModeLine {
-        dot_clock: timing.dot_clock_khz(),
-        hdisplay: output.width,
-        hsync_start: timing.hsync_start,
-        hsync_end: timing.hsync_end,
-        htotal: timing.htotal,
-        hskew: timing.hskew,
-        vdisplay: output.height,
-        vsync_start: timing.vsync_start,
-        vsync_end: timing.vsync_end,
-        vtotal: timing.vtotal,
-        flags: timing.mode_flags,
+    Some(CurrentVidModeOutput {
+        output_id: output.output_id,
+        connector: output.name.clone(),
+        mode: ModeLine {
+            dot_clock: timing.dot_clock_khz(),
+            hdisplay: output.width,
+            hsync_start: timing.hsync_start,
+            hsync_end: timing.hsync_end,
+            htotal: timing.htotal,
+            hskew: timing.hskew,
+            vdisplay: output.height,
+            vsync_start: timing.vsync_start,
+            vsync_end: timing.vsync_end,
+            vtotal: timing.vtotal,
+            flags: timing.mode_flags,
+        },
     })
+}
+
+#[cfg(test)]
+fn current_vidmode_mode_line(
+    state: &ServerState,
+) -> Option<yserver_protocol::x11::xf86vidmode::ModeLine> {
+    current_vidmode_output(state).map(|output| output.mode)
+}
+
+/// Derive VidMode's old monitor strings from the same raw EDID RANDR exposes.
+/// A missing/invalid EDID leaves the vendor empty and uses the connector name
+/// as the model, which is more useful than inventing an identity.
+fn vidmode_monitor_identity(edid: &[u8], connector: &str) -> (Vec<u8>, Vec<u8>) {
+    let vendor = edid
+        .get(8..10)
+        .and_then(|bytes| {
+            let code = u16::from_be_bytes(bytes.try_into().ok()?);
+            let letters = [
+                u8::try_from((code >> 10) & 0x1f).ok()?,
+                u8::try_from((code >> 5) & 0x1f).ok()?,
+                u8::try_from(code & 0x1f).ok()?,
+            ];
+            letters
+                .iter()
+                .all(|letter| (1..=26).contains(letter))
+                .then(|| {
+                    letters
+                        .into_iter()
+                        .map(|letter| b'A' + letter - 1)
+                        .collect()
+                })
+        })
+        .unwrap_or_default();
+
+    let model = [54usize, 72, 90, 108]
+        .into_iter()
+        .filter_map(|offset| edid.get(offset..offset + 18))
+        .find_map(|descriptor| {
+            if descriptor.get(..5) != Some(&[0, 0, 0, 0xfc, 0]) {
+                return None;
+            }
+            let name = descriptor.get(5..18)?;
+            let end = name
+                .iter()
+                .rposition(|byte| !matches!(byte, 0 | b'\n' | b'\r' | b' '))
+                .map_or(0, |index| index + 1);
+            (end != 0
+                && name[..end]
+                    .iter()
+                    .all(|byte| byte.is_ascii_graphic() || *byte == b' '))
+            .then(|| name[..end].to_vec())
+        })
+        .unwrap_or_else(|| connector.as_bytes().to_vec());
+    (vendor, model)
+}
+
+fn vidmode_sync_ranges(mode: yserver_protocol::x11::xf86vidmode::ModeLine) -> ([u32; 1], [u32; 1]) {
+    fn rounded_hundredths(numerator: u64, denominator: u64) -> u16 {
+        if denominator == 0 {
+            return 0;
+        }
+        let value = numerator.saturating_add(denominator / 2) / denominator;
+        u16::try_from(value).unwrap_or(u16::MAX)
+    }
+    fn singleton_range(value: u16) -> u32 {
+        u32::from(value) | (u32::from(value) << 16)
+    }
+
+    // Horizontal range is kHz * 100. Vertical range is Hz * 100.
+    let hsync = rounded_hundredths(
+        u64::from(mode.dot_clock).saturating_mul(100),
+        u64::from(mode.htotal),
+    );
+    let vsync = rounded_hundredths(
+        u64::from(mode.dot_clock).saturating_mul(100_000),
+        u64::from(mode.htotal).saturating_mul(u64::from(mode.vtotal)),
+    );
+    ([singleton_range(hsync)], [singleton_range(vsync)])
 }
 
 /// Validate the `screen(u16) + pad(u16)` body shared by VidMode's
@@ -11117,29 +11204,49 @@ fn current_vidmode_mode_line(
 ///
 /// Xorg checks `screen >= screenInfo.numScreens => BadValue`; yserver
 /// drives exactly one X screen, so anything but 0 is out of range.
-fn vidmode_screen(body: &[u8]) -> Result<(), (u8, u32)> {
-    let screen = yserver_protocol::x11::xf86vidmode::parse_screen(body)
-        .ok_or((x11::error::BAD_LENGTH, 0))?;
+fn vidmode_screen_number(screen: u32) -> Result<(), (u8, u32)> {
     if screen != 0 {
-        return Err((x11::error::BAD_VALUE, u32::from(screen)));
+        return Err((x11::error::BAD_VALUE, screen));
     }
     Ok(())
 }
 
+fn vidmode_screen(body: &[u8]) -> Result<(), (u8, u32)> {
+    let screen = yserver_protocol::x11::xf86vidmode::parse_screen(body)
+        .ok_or((x11::error::BAD_LENGTH, 0))?;
+    vidmode_screen_number(u32::from(screen))
+}
+
+fn write_vidmode_reply(
+    state: &mut ServerState,
+    client_id: ClientId,
+    reply: &[u8],
+) -> io::Result<RequestOutcome> {
+    let Some(client) = state.clients.get_mut(&client_id.0) else {
+        return Ok(RequestOutcome::Handled);
+    };
+    Ok(write_to_client(client, client_id, reply))
+}
+
 fn handle_xf86vidmode_request(
     state: &mut ServerState,
+    backend: &mut dyn Backend,
     client_id: ClientId,
     sequence: SequenceNumber,
     header: RequestHeader,
     body: &[u8],
 ) -> io::Result<RequestOutcome> {
-    use crate::nested::XF86VIDMODE_MAJOR_OPCODE;
+    use crate::nested::{XF86VIDMODE_FIRST_ERROR, XF86VIDMODE_MAJOR_OPCODE};
     use yserver_protocol::x11::{ClientByteOrder, xf86vidmode as x11vm};
 
     let byte_order = state
         .clients
         .get(&client_id.0)
         .map_or(ClientByteOrder::LittleEndian, |client| client.byte_order);
+    let version_2 = state
+        .vidmode_client_versions
+        .get(&client_id)
+        .is_some_and(|(major, _)| *major >= 2);
 
     match header.data {
         x11vm::QUERY_VERSION => {
@@ -11155,10 +11262,7 @@ fn handle_xf86vidmode_request(
                 );
             }
             let reply = x11vm::encode_query_version_reply(byte_order, sequence);
-            let Some(client) = state.clients.get_mut(&client_id.0) else {
-                return Ok(RequestOutcome::Handled);
-            };
-            return Ok(write_to_client(client, client_id, &reply));
+            return write_vidmode_reply(state, client_id, &reply);
         }
         x11vm::SET_CLIENT_VERSION => {
             let Some(version) = x11vm::parse_client_version(body) else {
@@ -11180,10 +11284,144 @@ fn handle_xf86vidmode_request(
                 client_id.0, sequence.0, version.major, version.minor
             );
         }
-        // The read-only screen-scoped requests. All four carry the same
-        // `screen(u16) + pad(u16)` body, so validate it once.
+        x11vm::VALIDATE_MODE_LINE => {
+            let Some(screen) = x11vm::parse_validate_mode_line_screen(byte_order, body, version_2)
+            else {
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    x11::error::BAD_LENGTH,
+                    0,
+                    u16::from(header.data),
+                    XF86VIDMODE_MAJOR_OPCODE,
+                );
+            };
+            if let Err((code, bad_value)) = vidmode_screen_number(screen) {
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    code,
+                    bad_value,
+                    u16::from(header.data),
+                    XF86VIDMODE_MAJOR_OPCODE,
+                );
+            }
+            // Xorg asks the active driver's mode validator. Yserver advertises
+            // only the already-active hardware mode and has no separate
+            // VidMode mode-setting path, so a well-formed line is acceptable.
+            if current_vidmode_output(state).is_none() {
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    x11::error::BAD_VALUE,
+                    0,
+                    u16::from(header.data),
+                    XF86VIDMODE_MAJOR_OPCODE,
+                );
+            }
+            let reply =
+                x11vm::encode_validate_mode_line_reply(byte_order, sequence, x11vm::MODE_OK);
+            return write_vidmode_reply(state, client_id, &reply);
+        }
+        x11vm::GET_GAMMA => {
+            let Some(screen) = x11vm::parse_gamma_screen(body) else {
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    x11::error::BAD_LENGTH,
+                    0,
+                    u16::from(header.data),
+                    XF86VIDMODE_MAJOR_OPCODE,
+                );
+            };
+            if let Err((code, bad_value)) = vidmode_screen_number(u32::from(screen)) {
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    code,
+                    bad_value,
+                    u16::from(header.data),
+                    XF86VIDMODE_MAJOR_OPCODE,
+                );
+            }
+            let reply = x11vm::encode_get_gamma_reply(byte_order, sequence);
+            return write_vidmode_reply(state, client_id, &reply);
+        }
+        x11vm::GET_GAMMA_RAMP => {
+            let Some(request) = x11vm::parse_gamma_ramp_request(body) else {
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    x11::error::BAD_LENGTH,
+                    0,
+                    u16::from(header.data),
+                    XF86VIDMODE_MAJOR_OPCODE,
+                );
+            };
+            if let Err((code, bad_value)) = vidmode_screen_number(u32::from(request.screen)) {
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    code,
+                    bad_value,
+                    u16::from(header.data),
+                    XF86VIDMODE_MAJOR_OPCODE,
+                );
+            }
+            let Some(current) = current_vidmode_output(state) else {
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    x11::error::BAD_VALUE,
+                    0,
+                    u16::from(header.data),
+                    XF86VIDMODE_MAJOR_OPCODE,
+                );
+            };
+            let expected = backend.crtc_gamma_size(&current.connector);
+            if request.size != expected {
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    x11::error::BAD_VALUE,
+                    u32::from(request.size),
+                    u16::from(header.data),
+                    XF86VIDMODE_MAJOR_OPCODE,
+                );
+            }
+            let (red, green, blue) = backend.get_crtc_gamma(&current.connector);
+            let expected = usize::from(expected);
+            if red.len() != expected || green.len() != expected || blue.len() != expected {
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    x11::error::BAD_VALUE,
+                    0,
+                    u16::from(header.data),
+                    XF86VIDMODE_MAJOR_OPCODE,
+                );
+            }
+            let reply =
+                x11vm::encode_get_gamma_ramp_reply(byte_order, sequence, &red, &green, &blue);
+            return write_vidmode_reply(state, client_id, &reply);
+        }
+        // The ordinary read-only screen-scoped requests all carry
+        // `screen(u16) + pad(u16)`.
         x11vm::GET_MODE_LINE
+        | x11vm::GET_MONITOR
         | x11vm::GET_ALL_MODE_LINES
+        | x11vm::GET_VIEW_PORT
+        | x11vm::GET_DOT_CLOCKS
         | x11vm::GET_GAMMA_RAMP_SIZE
         | x11vm::GET_PERMISSIONS => {
             if let Err((code, bad_value)) = vidmode_screen(body) {
@@ -11199,12 +11437,11 @@ fn handle_xf86vidmode_request(
             }
             let reply = match header.data {
                 x11vm::GET_PERMISSIONS => x11vm::encode_get_permissions_reply(byte_order, sequence),
-                x11vm::GET_GAMMA_RAMP_SIZE => {
-                    x11vm::encode_get_gamma_ramp_size_reply(byte_order, sequence)
+                x11vm::GET_VIEW_PORT => {
+                    x11vm::encode_get_view_port_reply(byte_order, sequence, 0, 0)
                 }
-                // GetModeLine / GetAllModeLines both need the active mode.
                 _ => {
-                    let Some(mode) = current_vidmode_mode_line(state) else {
+                    let Some(current) = current_vidmode_output(state) else {
                         // Xorg: VidModeGetCurrentModeline failure => BadValue.
                         return emit_x11_error_with_minor(
                             state,
@@ -11216,40 +11453,90 @@ fn handle_xf86vidmode_request(
                             XF86VIDMODE_MAJOR_OPCODE,
                         );
                     };
-                    let version_2 = state
-                        .vidmode_client_versions
-                        .get(&client_id)
-                        .is_some_and(|(major, _)| *major >= 2);
-                    debug!(
-                        "client {} #{} XFree86-VidMode::{} \
-                         {}x{} clock={}kHz totals={}x{} flags=0x{:x}",
-                        client_id.0,
-                        sequence.0,
-                        if header.data == x11vm::GET_MODE_LINE {
-                            "GetModeLine"
-                        } else {
-                            "GetAllModeLines"
-                        },
-                        mode.hdisplay,
-                        mode.vdisplay,
-                        mode.dot_clock,
-                        mode.htotal,
-                        mode.vtotal,
-                        mode.flags
-                    );
-                    if header.data == x11vm::GET_MODE_LINE {
-                        x11vm::encode_get_mode_line_reply(byte_order, sequence, mode, version_2)
-                    } else {
-                        x11vm::encode_get_all_mode_lines_reply(
-                            byte_order, sequence, mode, version_2,
-                        )
+                    match header.data {
+                        x11vm::GET_GAMMA_RAMP_SIZE => x11vm::encode_get_gamma_ramp_size_reply(
+                            byte_order,
+                            sequence,
+                            backend.crtc_gamma_size(&current.connector),
+                        ),
+                        x11vm::GET_MONITOR => {
+                            let edid = backend
+                                .output_identity(current.output_id)
+                                .map_or_else(Vec::new, |(edid, _)| edid);
+                            let (vendor, model) =
+                                vidmode_monitor_identity(&edid, &current.connector);
+                            let (hsync, vsync) = vidmode_sync_ranges(current.mode);
+                            x11vm::encode_get_monitor_reply(
+                                byte_order, sequence, &vendor, &model, &hsync, &vsync,
+                            )
+                        }
+                        x11vm::GET_DOT_CLOCKS => x11vm::encode_get_dot_clocks_reply(
+                            byte_order,
+                            sequence,
+                            &[current.mode.dot_clock],
+                        ),
+                        x11vm::GET_MODE_LINE | x11vm::GET_ALL_MODE_LINES => {
+                            debug!(
+                                "client {} #{} XFree86-VidMode::{} \
+                                 {}x{} clock={}kHz totals={}x{} flags=0x{:x}",
+                                client_id.0,
+                                sequence.0,
+                                if header.data == x11vm::GET_MODE_LINE {
+                                    "GetModeLine"
+                                } else {
+                                    "GetAllModeLines"
+                                },
+                                current.mode.hdisplay,
+                                current.mode.vdisplay,
+                                current.mode.dot_clock,
+                                current.mode.htotal,
+                                current.mode.vtotal,
+                                current.mode.flags
+                            );
+                            if header.data == x11vm::GET_MODE_LINE {
+                                x11vm::encode_get_mode_line_reply(
+                                    byte_order,
+                                    sequence,
+                                    current.mode,
+                                    version_2,
+                                )
+                            } else {
+                                x11vm::encode_get_all_mode_lines_reply(
+                                    byte_order,
+                                    sequence,
+                                    current.mode,
+                                    version_2,
+                                )
+                            }
+                        }
+                        _ => unreachable!("screen-scoped VidMode read"),
                     }
                 }
             };
-            let Some(client) = state.clients.get_mut(&client_id.0) else {
-                return Ok(RequestOutcome::Handled);
-            };
-            return Ok(write_to_client(client, client_id, &reply));
+            return write_vidmode_reply(state, client_id, &reply);
+        }
+        // Yserver is Unix-socket-only, so these clients are physically local.
+        // We nevertheless expose Xorg's coherent non-local/read-only VidMode
+        // policy: RANDR owns all writes, permissions omit WRITE, and known
+        // write minors fail with the matching extension error.
+        x11vm::MOD_MODE_LINE
+        | x11vm::SWITCH_MODE
+        | x11vm::LOCK_MODE_SWITCH
+        | x11vm::ADD_MODE_LINE
+        | x11vm::DELETE_MODE_LINE
+        | x11vm::SWITCH_TO_MODE
+        | x11vm::SET_VIEW_PORT
+        | x11vm::SET_GAMMA
+        | x11vm::SET_GAMMA_RAMP => {
+            return emit_x11_error_with_minor(
+                state,
+                client_id,
+                sequence,
+                XF86VIDMODE_FIRST_ERROR + x11vm::CLIENT_NOT_LOCAL,
+                0,
+                u16::from(header.data),
+                XF86VIDMODE_MAJOR_OPCODE,
+            );
         }
         _ => {
             return emit_x11_error_with_minor(
@@ -35440,10 +35727,21 @@ mod tests {
         body: &[u8],
     ) -> Vec<u8> {
         let mut backend = RecordingBackend::new();
+        dispatch_vidmode_with_backend(state, &mut backend, peer, sequence, minor, body)
+    }
+
+    fn dispatch_vidmode_with_backend(
+        state: &mut ServerState,
+        backend: &mut dyn Backend,
+        peer: &mut UnixStream,
+        sequence: u16,
+        minor: u8,
+        body: &[u8],
+    ) -> Vec<u8> {
         let length_units = u32::try_from(4 + body.len()).expect("test body") / 4;
         process_request(
             state,
-            &mut backend,
+            backend,
             ClientId(1),
             SequenceNumber(sequence),
             RequestHeader {
@@ -35469,25 +35767,30 @@ mod tests {
         assert_eq!(reply[10], crate::nested::XF86VIDMODE_MAJOR_OPCODE);
     }
 
-    /// The documented read-only surface only holds if every unsupported
-    /// minor is actually refused — `docs/status.md` claims exactly this.
+    /// Known writes must use the same Xorg non-local branch advertised by
+    /// GetPermissions; truly unknown minors remain BadRequest.
     #[test]
-    fn xf86vidmode_rejects_unimplemented_requests_with_bad_request() {
+    fn xf86vidmode_rejects_writes_with_client_not_local() {
         let mut state = ServerState::new();
         let mut peer = install_client(&mut state, 1);
 
-        // ModModeLine, SwitchMode, GetMonitor, LockModeSwitch, AddModeLine,
-        // DeleteModeLine, ValidateModeLine, SwitchToMode, Get/SetViewPort,
-        // GetDotClocks, Set/GetGamma, Get/SetGammaRamp, and past-the-end.
-        for (seq, minor) in [
-            2u8, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 15, 16, 17, 18, 21, 255,
-        ]
-        .into_iter()
-        .enumerate()
-        {
+        for (seq, minor) in [2u8, 3, 5, 7, 8, 10, 12, 15, 18].into_iter().enumerate() {
             #[allow(clippy::cast_possible_truncation)]
             let seq = seq as u16 + 1;
-            let reply = dispatch_vidmode(&mut state, &mut peer, seq, minor, &[0; 4]);
+            // The locality gate runs before per-request length parsing in Xorg.
+            let reply = dispatch_vidmode(&mut state, &mut peer, seq, minor, &[]);
+            assert_vidmode_error(
+                &reply,
+                crate::nested::XF86VIDMODE_FIRST_ERROR
+                    + yserver_protocol::x11::xf86vidmode::CLIENT_NOT_LOCAL,
+                minor,
+            );
+        }
+
+        for (seq, minor) in [21u8, 255].into_iter().enumerate() {
+            #[allow(clippy::cast_possible_truncation)]
+            let seq = seq as u16 + 20;
+            let reply = dispatch_vidmode(&mut state, &mut peer, seq, minor, &[]);
             assert_vidmode_error(&reply, x11::error::BAD_REQUEST, minor);
         }
     }
@@ -35506,7 +35809,10 @@ mod tests {
         // The screen-scoped requests need exactly `screen + pad`.
         for (seq, minor) in [
             x11vm::GET_MODE_LINE,
+            x11vm::GET_MONITOR,
             x11vm::GET_ALL_MODE_LINES,
+            x11vm::GET_VIEW_PORT,
+            x11vm::GET_DOT_CLOCKS,
             x11vm::GET_GAMMA_RAMP_SIZE,
             x11vm::GET_PERMISSIONS,
         ]
@@ -35519,8 +35825,32 @@ mod tests {
             assert_vidmode_error(&reply, x11::error::BAD_LENGTH, minor);
         }
 
+        // The legacy gamma scalar request is padded to 32 bytes total.
+        let reply = dispatch_vidmode(&mut state, &mut peer, 12, x11vm::GET_GAMMA, &[0; 4]);
+        assert_vidmode_error(&reply, x11::error::BAD_LENGTH, x11vm::GET_GAMMA);
+
+        // GetGammaRamp carries exactly screen + requested size.
+        let reply = dispatch_vidmode(&mut state, &mut peer, 13, x11vm::GET_GAMMA_RAMP, &[0; 8]);
+        assert_vidmode_error(&reply, x11::error::BAD_LENGTH, x11vm::GET_GAMMA_RAMP);
+
+        // A legacy ValidateModeLine body is 32 bytes after the X header.
+        let reply = dispatch_vidmode(
+            &mut state,
+            &mut peer,
+            14,
+            x11vm::VALIDATE_MODE_LINE,
+            &[0; 4],
+        );
+        assert_vidmode_error(&reply, x11::error::BAD_LENGTH, x11vm::VALIDATE_MODE_LINE);
+
         // SetClientVersion needs exactly `major + minor`.
-        let reply = dispatch_vidmode(&mut state, &mut peer, 9, x11vm::SET_CLIENT_VERSION, &[2, 0]);
+        let reply = dispatch_vidmode(
+            &mut state,
+            &mut peer,
+            15,
+            x11vm::SET_CLIENT_VERSION,
+            &[2, 0],
+        );
         assert_vidmode_error(&reply, x11::error::BAD_LENGTH, x11vm::SET_CLIENT_VERSION);
         assert!(
             !state.vidmode_client_versions.contains_key(&ClientId(1)),
@@ -35529,13 +35859,37 @@ mod tests {
     }
 
     #[test]
-    fn xf86vidmode_read_only_stubs_report_no_gamma_and_no_write_permission() {
+    fn xf86vidmode_read_only_gamma_matches_selected_randr_crtc() {
         use yserver_protocol::x11::xf86vidmode as x11vm;
 
         let mut state = ServerState::new();
         let mut peer = install_client(&mut state, 1);
+        let connector = current_vidmode_output(&state)
+            .expect("active output")
+            .connector;
+        let mut backend = RecordingBackend::new();
 
-        let perms = dispatch_vidmode(&mut state, &mut peer, 1, x11vm::GET_PERMISSIONS, &[0; 4]);
+        let mut red = vec![0u16; 256];
+        let mut green = vec![0u16; 256];
+        let mut blue = vec![0u16; 256];
+        red[0] = 0x1111;
+        green[0] = 0x2222;
+        blue[0] = 0x3333;
+        red[255] = 0xaaaa;
+        green[255] = 0xbbbb;
+        blue[255] = 0xcccc;
+        backend
+            .set_crtc_gamma(&connector, &red, &green, &blue)
+            .expect("seed selected connector gamma");
+
+        let perms = dispatch_vidmode_with_backend(
+            &mut state,
+            &mut backend,
+            &mut peer,
+            1,
+            x11vm::GET_PERMISSIONS,
+            &[0; 4],
+        );
         assert_eq!(perms.len(), 32);
         assert_eq!(perms[0], 1, "reply, not an error");
         assert_eq!(
@@ -35544,8 +35898,9 @@ mod tests {
             "READ only — granting WRITE would advertise mode setting we do not implement"
         );
 
-        let size = dispatch_vidmode(
+        let size = dispatch_vidmode_with_backend(
             &mut state,
+            &mut backend,
             &mut peer,
             2,
             x11vm::GET_GAMMA_RAMP_SIZE,
@@ -35553,7 +35908,139 @@ mod tests {
         );
         assert_eq!(size.len(), 32);
         assert_eq!(size[0], 1);
-        assert_eq!(u16::from_le_bytes(size[8..10].try_into().unwrap()), 0);
+        assert_eq!(u16::from_le_bytes(size[8..10].try_into().unwrap()), 256);
+
+        let gamma = dispatch_vidmode_with_backend(
+            &mut state,
+            &mut backend,
+            &mut peer,
+            3,
+            x11vm::GET_GAMMA,
+            &[0; 28],
+        );
+        assert_eq!(gamma.len(), 32);
+        for offset in [8usize, 12, 16] {
+            assert_eq!(
+                u32::from_le_bytes(gamma[offset..offset + 4].try_into().unwrap()),
+                10_000,
+                "GetGamma is the independent per-screen 1.0 scalar"
+            );
+        }
+
+        let ramp = dispatch_vidmode_with_backend(
+            &mut state,
+            &mut backend,
+            &mut peer,
+            4,
+            x11vm::GET_GAMMA_RAMP,
+            &[0, 0, 0, 1], // screen=0, size=256
+        );
+        assert_eq!(ramp.len(), 32 + 256 * 3 * 2);
+        assert_eq!(
+            u32::from_le_bytes(ramp[4..8].try_into().unwrap()),
+            256 * 3 * 2 / 4
+        );
+        assert_eq!(u16::from_le_bytes(ramp[8..10].try_into().unwrap()), 256);
+        assert_eq!(u16::from_le_bytes(ramp[32..34].try_into().unwrap()), 0x1111);
+        assert_eq!(
+            u16::from_le_bytes(ramp[544..546].try_into().unwrap()),
+            0x2222
+        );
+        assert_eq!(
+            u16::from_le_bytes(ramp[1056..1058].try_into().unwrap()),
+            0x3333
+        );
+
+        let wrong_size = dispatch_vidmode_with_backend(
+            &mut state,
+            &mut backend,
+            &mut peer,
+            5,
+            x11vm::GET_GAMMA_RAMP,
+            &[0, 0, 128, 0],
+        );
+        assert_vidmode_error(&wrong_size, x11::error::BAD_VALUE, x11vm::GET_GAMMA_RAMP);
+    }
+
+    #[test]
+    fn xf86vidmode_monitor_viewport_dotclocks_and_validation_are_readable() {
+        use yserver_protocol::x11::xf86vidmode as x11vm;
+
+        let mut state = ServerState::new();
+        let current = current_vidmode_output(&state).expect("active output");
+        let connector = current.connector.clone();
+        let mut peer = install_client(&mut state, 1);
+
+        let monitor = dispatch_vidmode(&mut state, &mut peer, 1, x11vm::GET_MONITOR, &[0; 4]);
+        assert_eq!(monitor[0], 1);
+        assert_eq!(monitor[8], 0, "no synthetic EDID vendor");
+        assert_eq!(usize::from(monitor[9]), connector.len());
+        assert_eq!(monitor[10], 1, "one active hsync range");
+        assert_eq!(monitor[11], 1, "one active vsync range");
+        assert_eq!(&monitor[40..40 + connector.len()], connector.as_bytes());
+
+        let viewport = dispatch_vidmode(&mut state, &mut peer, 2, x11vm::GET_VIEW_PORT, &[0; 4]);
+        assert_eq!(viewport.len(), 32);
+        assert_eq!(&viewport[8..16], &[0; 8]);
+
+        let clocks = dispatch_vidmode(&mut state, &mut peer, 3, x11vm::GET_DOT_CLOCKS, &[0; 4]);
+        assert_eq!(clocks.len(), 36);
+        assert_eq!(u32::from_le_bytes(clocks[12..16].try_into().unwrap()), 1);
+        assert_eq!(u32::from_le_bytes(clocks[16..20].try_into().unwrap()), 1);
+        assert_eq!(
+            u32::from_le_bytes(clocks[32..36].try_into().unwrap()),
+            current.mode.dot_clock
+        );
+
+        let legacy_validate = dispatch_vidmode(
+            &mut state,
+            &mut peer,
+            4,
+            x11vm::VALIDATE_MODE_LINE,
+            &[0; 32],
+        );
+        assert_eq!(legacy_validate.len(), 32);
+        assert_eq!(
+            u32::from_le_bytes(legacy_validate[8..12].try_into().unwrap()),
+            x11vm::MODE_OK
+        );
+
+        dispatch_vidmode(
+            &mut state,
+            &mut peer,
+            5,
+            x11vm::SET_CLIENT_VERSION,
+            &[2, 0, 2, 0],
+        );
+        let v2_validate = dispatch_vidmode(
+            &mut state,
+            &mut peer,
+            6,
+            x11vm::VALIDATE_MODE_LINE,
+            &[0; 48],
+        );
+        assert_eq!(v2_validate.len(), 32);
+        assert_eq!(
+            u32::from_le_bytes(v2_validate[8..12].try_into().unwrap()),
+            x11vm::MODE_OK
+        );
+    }
+
+    #[test]
+    fn xf86vidmode_monitor_identity_decodes_edid_and_falls_back_to_connector() {
+        let mut edid = vec![0u8; 128];
+        // DEL manufacturer code: D=4, E=5, L=12.
+        edid[8..10].copy_from_slice(&0x10ac_u16.to_be_bytes());
+        edid[54..59].copy_from_slice(&[0, 0, 0, 0xfc, 0]);
+        edid[59..72].copy_from_slice(b"U2723QE\n     ");
+        assert_eq!(
+            vidmode_monitor_identity(&edid, "DP-1"),
+            (b"DEL".to_vec(), b"U2723QE".to_vec())
+        );
+        assert_eq!(
+            vidmode_monitor_identity(&[], "Virtual-1"),
+            (Vec::new(), b"Virtual-1".to_vec())
+        );
     }
 
     #[test]
@@ -35662,8 +36149,9 @@ mod tests {
         assert_eq!(u32::from_le_bytes(focus[4..8].try_into().unwrap()), 0);
     }
 
-    /// `client_reader` swaps request bodies before dispatch, so the handler
-    /// only owes the client a reply in *its* byte order.
+    /// `client_reader` swaps ordinary request bodies before dispatch.
+    /// ValidateModeLine remains in original client order for its
+    /// version-dependent parser; replies and errors always use client order.
     #[test]
     fn xf86vidmode_big_endian_client_gets_a_byte_swapped_reply() {
         use yserver_protocol::x11::xf86vidmode as x11vm;
@@ -35708,6 +36196,20 @@ mod tests {
         assert_eq!(error[0], 0);
         assert_eq!(error[1], x11::error::BAD_VALUE);
         assert_eq!(&error[4..8], &1_u32.to_be_bytes());
+
+        let mut validate = vec![0u8; 48];
+        validate[0..4].copy_from_slice(&0u32.to_be_bytes());
+        validate[44..48].copy_from_slice(&0u32.to_be_bytes());
+        let validated = dispatch_vidmode(
+            &mut state,
+            &mut peer,
+            6,
+            x11vm::VALIDATE_MODE_LINE,
+            &validate,
+        );
+        assert_eq!(validated.len(), 32);
+        assert_eq!(&validated[2..4], &6u16.to_be_bytes());
+        assert_eq!(&validated[8..12], &x11vm::MODE_OK.to_be_bytes());
     }
 
     /// The VidMode mode line and RANDR's `ModeInfo` describe the same

--- a/crates/yserver-core/src/core_loop/process_request.rs
+++ b/crates/yserver-core/src/core_loop/process_request.rs
@@ -11088,45 +11088,42 @@ fn current_vidmode_mode_line(
                 .find(|output| output.connected && output.mode_id != 0)
         })?;
 
-    if let Some(timing) = output.timing {
-        return Some(ModeLine {
-            dot_clock: timing.clock_khz,
-            hdisplay: output.width,
-            hsync_start: timing.hsync_start,
-            hsync_end: timing.hsync_end,
-            htotal: timing.htotal,
-            hskew: 0,
-            vdisplay: output.height,
-            vsync_start: timing.vsync_start,
-            vsync_end: timing.vsync_end,
-            vtotal: timing.vtotal,
-            flags: timing.mode_flags,
-        });
-    }
-
-    // Keep the no-kernel-timing fallback consistent with RandrState's
-    // synthetic ModeInfo. VidMode carries the pixel clock in whole kHz, so
-    // round the exact synthetic Hz value to the nearest representable kHz.
-    if output.vrefresh == 0 {
+    // Same resolved timing RANDR's ModeInfo reports, so the two extensions
+    // can never describe the same mode differently. VidMode carries the
+    // pixel clock in whole kHz rather than RANDR's Hz.
+    let timing = output.effective_timing();
+    // A zero clock would make Mesa derive a zero MSC rate; Xorg's
+    // VidModeGetCurrentModeline fails the same way and yields BadValue.
+    if timing.dot_clock_hz == 0 {
         return None;
     }
-    let htotal = output.width.saturating_add(264);
-    let vtotal = output.height.saturating_add(28);
-    let clock_hz = u64::from(htotal) * u64::from(vtotal) * u64::from(output.vrefresh);
-    let dot_clock = u32::try_from((clock_hz + 500) / 1000).unwrap_or(u32::MAX);
     Some(ModeLine {
-        dot_clock,
+        dot_clock: timing.dot_clock_khz(),
         hdisplay: output.width,
-        hsync_start: output.width.saturating_add(40),
-        hsync_end: output.width.saturating_add(168),
-        htotal,
-        hskew: 0,
+        hsync_start: timing.hsync_start,
+        hsync_end: timing.hsync_end,
+        htotal: timing.htotal,
+        hskew: timing.hskew,
         vdisplay: output.height,
-        vsync_start: output.height.saturating_add(1),
-        vsync_end: output.height.saturating_add(4),
-        vtotal,
-        flags: 0,
+        vsync_start: timing.vsync_start,
+        vsync_end: timing.vsync_end,
+        vtotal: timing.vtotal,
+        flags: timing.mode_flags,
     })
+}
+
+/// Validate the `screen(u16) + pad(u16)` body shared by VidMode's
+/// read-only requests. `Err` carries `(error code, errorValue)`.
+///
+/// Xorg checks `screen >= screenInfo.numScreens => BadValue`; yserver
+/// drives exactly one X screen, so anything but 0 is out of range.
+fn vidmode_screen(body: &[u8]) -> Result<(), (u8, u32)> {
+    let screen = yserver_protocol::x11::xf86vidmode::parse_screen(body)
+        .ok_or((x11::error::BAD_LENGTH, 0))?;
+    if screen != 0 {
+        return Err((x11::error::BAD_VALUE, u32::from(screen)));
+    }
+    Ok(())
 }
 
 fn handle_xf86vidmode_request(
@@ -11183,57 +11180,72 @@ fn handle_xf86vidmode_request(
                 client_id.0, sequence.0, version.major, version.minor
             );
         }
-        x11vm::GET_MODE_LINE => {
-            let Some(screen) = x11vm::parse_screen(body) else {
+        // The read-only screen-scoped requests. All four carry the same
+        // `screen(u16) + pad(u16)` body, so validate it once.
+        x11vm::GET_MODE_LINE
+        | x11vm::GET_ALL_MODE_LINES
+        | x11vm::GET_GAMMA_RAMP_SIZE
+        | x11vm::GET_PERMISSIONS => {
+            if let Err((code, bad_value)) = vidmode_screen(body) {
                 return emit_x11_error_with_minor(
                     state,
                     client_id,
                     sequence,
-                    x11::error::BAD_LENGTH,
-                    0,
-                    u16::from(header.data),
-                    XF86VIDMODE_MAJOR_OPCODE,
-                );
-            };
-            if screen != 0 {
-                return emit_x11_error_with_minor(
-                    state,
-                    client_id,
-                    sequence,
-                    x11::error::BAD_VALUE,
-                    u32::from(screen),
+                    code,
+                    bad_value,
                     u16::from(header.data),
                     XF86VIDMODE_MAJOR_OPCODE,
                 );
             }
-            let Some(mode) = current_vidmode_mode_line(state) else {
-                return emit_x11_error_with_minor(
-                    state,
-                    client_id,
-                    sequence,
-                    x11::error::BAD_VALUE,
-                    u32::from(screen),
-                    u16::from(header.data),
-                    XF86VIDMODE_MAJOR_OPCODE,
-                );
+            let reply = match header.data {
+                x11vm::GET_PERMISSIONS => x11vm::encode_get_permissions_reply(byte_order, sequence),
+                x11vm::GET_GAMMA_RAMP_SIZE => {
+                    x11vm::encode_get_gamma_ramp_size_reply(byte_order, sequence)
+                }
+                // GetModeLine / GetAllModeLines both need the active mode.
+                _ => {
+                    let Some(mode) = current_vidmode_mode_line(state) else {
+                        // Xorg: VidModeGetCurrentModeline failure => BadValue.
+                        return emit_x11_error_with_minor(
+                            state,
+                            client_id,
+                            sequence,
+                            x11::error::BAD_VALUE,
+                            0,
+                            u16::from(header.data),
+                            XF86VIDMODE_MAJOR_OPCODE,
+                        );
+                    };
+                    let version_2 = state
+                        .vidmode_client_versions
+                        .get(&client_id)
+                        .is_some_and(|(major, _)| *major >= 2);
+                    debug!(
+                        "client {} #{} XFree86-VidMode::{} \
+                         {}x{} clock={}kHz totals={}x{} flags=0x{:x}",
+                        client_id.0,
+                        sequence.0,
+                        if header.data == x11vm::GET_MODE_LINE {
+                            "GetModeLine"
+                        } else {
+                            "GetAllModeLines"
+                        },
+                        mode.hdisplay,
+                        mode.vdisplay,
+                        mode.dot_clock,
+                        mode.htotal,
+                        mode.vtotal,
+                        mode.flags
+                    );
+                    if header.data == x11vm::GET_MODE_LINE {
+                        x11vm::encode_get_mode_line_reply(byte_order, sequence, mode, version_2)
+                    } else {
+                        x11vm::encode_get_all_mode_lines_reply(
+                            byte_order, sequence, mode, version_2,
+                        )
+                    }
+                }
             };
-            let version_2 = state
-                .vidmode_client_versions
-                .get(&client_id)
-                .is_some_and(|(major, _)| *major >= 2);
-            let reply = x11vm::encode_get_mode_line_reply(byte_order, sequence, mode, version_2);
-            debug!(
-                "client {} #{} XFree86-VidMode::GetModeLine \
-                 {}x{} clock={}kHz totals={}x{} flags=0x{:x}",
-                client_id.0,
-                sequence.0,
-                mode.hdisplay,
-                mode.vdisplay,
-                mode.dot_clock,
-                mode.htotal,
-                mode.vtotal,
-                mode.flags
-            );
             let Some(client) = state.clients.get_mut(&client_id.0) else {
                 return Ok(RequestOutcome::Handled);
             };
@@ -35417,6 +35429,309 @@ mod tests {
             u16::from(x11vm::GET_MODE_LINE)
         );
         assert_eq!(error[10], crate::nested::XF86VIDMODE_MAJOR_OPCODE);
+    }
+
+    /// Drive one VidMode request and return whatever went back to the client.
+    fn dispatch_vidmode(
+        state: &mut ServerState,
+        peer: &mut UnixStream,
+        sequence: u16,
+        minor: u8,
+        body: &[u8],
+    ) -> Vec<u8> {
+        let mut backend = RecordingBackend::new();
+        let length_units = u32::try_from(4 + body.len()).expect("test body") / 4;
+        process_request(
+            state,
+            &mut backend,
+            ClientId(1),
+            SequenceNumber(sequence),
+            RequestHeader {
+                opcode: crate::nested::XF86VIDMODE_MAJOR_OPCODE,
+                data: minor,
+                length_units,
+            },
+            body,
+            None,
+        )
+        .expect("vidmode dispatch");
+        read_all_or_buffered(state, 1, peer)
+    }
+
+    fn assert_vidmode_error(reply: &[u8], code: u8, minor: u8) {
+        assert_eq!(reply.len(), 32, "X errors are always 32 bytes");
+        assert_eq!(reply[0], 0, "error, not a reply");
+        assert_eq!(reply[1], code);
+        assert_eq!(
+            u16::from_le_bytes(reply[8..10].try_into().unwrap()),
+            u16::from(minor)
+        );
+        assert_eq!(reply[10], crate::nested::XF86VIDMODE_MAJOR_OPCODE);
+    }
+
+    /// The documented read-only surface only holds if every unsupported
+    /// minor is actually refused — `docs/status.md` claims exactly this.
+    #[test]
+    fn xf86vidmode_rejects_unimplemented_requests_with_bad_request() {
+        let mut state = ServerState::new();
+        let mut peer = install_client(&mut state, 1);
+
+        // ModModeLine, SwitchMode, GetMonitor, LockModeSwitch, AddModeLine,
+        // DeleteModeLine, ValidateModeLine, SwitchToMode, Get/SetViewPort,
+        // GetDotClocks, Set/GetGamma, Get/SetGammaRamp, and past-the-end.
+        for (seq, minor) in [
+            2u8, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 15, 16, 17, 18, 21, 255,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            #[allow(clippy::cast_possible_truncation)]
+            let seq = seq as u16 + 1;
+            let reply = dispatch_vidmode(&mut state, &mut peer, seq, minor, &[0; 4]);
+            assert_vidmode_error(&reply, x11::error::BAD_REQUEST, minor);
+        }
+    }
+
+    #[test]
+    fn xf86vidmode_rejects_malformed_bodies_with_bad_length() {
+        use yserver_protocol::x11::xf86vidmode as x11vm;
+
+        let mut state = ServerState::new();
+        let mut peer = install_client(&mut state, 1);
+
+        // QueryVersion takes no body at all.
+        let reply = dispatch_vidmode(&mut state, &mut peer, 1, x11vm::QUERY_VERSION, &[0; 4]);
+        assert_vidmode_error(&reply, x11::error::BAD_LENGTH, x11vm::QUERY_VERSION);
+
+        // The screen-scoped requests need exactly `screen + pad`.
+        for (seq, minor) in [
+            x11vm::GET_MODE_LINE,
+            x11vm::GET_ALL_MODE_LINES,
+            x11vm::GET_GAMMA_RAMP_SIZE,
+            x11vm::GET_PERMISSIONS,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            #[allow(clippy::cast_possible_truncation)]
+            let seq = seq as u16 + 2;
+            let reply = dispatch_vidmode(&mut state, &mut peer, seq, minor, &[0; 8]);
+            assert_vidmode_error(&reply, x11::error::BAD_LENGTH, minor);
+        }
+
+        // SetClientVersion needs exactly `major + minor`.
+        let reply = dispatch_vidmode(&mut state, &mut peer, 9, x11vm::SET_CLIENT_VERSION, &[2, 0]);
+        assert_vidmode_error(&reply, x11::error::BAD_LENGTH, x11vm::SET_CLIENT_VERSION);
+        assert!(
+            !state.vidmode_client_versions.contains_key(&ClientId(1)),
+            "a rejected SetClientVersion must not record a version"
+        );
+    }
+
+    #[test]
+    fn xf86vidmode_read_only_stubs_report_no_gamma_and_no_write_permission() {
+        use yserver_protocol::x11::xf86vidmode as x11vm;
+
+        let mut state = ServerState::new();
+        let mut peer = install_client(&mut state, 1);
+
+        let perms = dispatch_vidmode(&mut state, &mut peer, 1, x11vm::GET_PERMISSIONS, &[0; 4]);
+        assert_eq!(perms.len(), 32);
+        assert_eq!(perms[0], 1, "reply, not an error");
+        assert_eq!(
+            u32::from_le_bytes(perms[8..12].try_into().unwrap()),
+            x11vm::PERMISSION_READ,
+            "READ only — granting WRITE would advertise mode setting we do not implement"
+        );
+
+        let size = dispatch_vidmode(
+            &mut state,
+            &mut peer,
+            2,
+            x11vm::GET_GAMMA_RAMP_SIZE,
+            &[0; 4],
+        );
+        assert_eq!(size.len(), 32);
+        assert_eq!(size[0], 1);
+        assert_eq!(u16::from_le_bytes(size[8..10].try_into().unwrap()), 0);
+    }
+
+    #[test]
+    fn xf86vidmode_get_all_mode_lines_reports_only_the_active_mode() {
+        use yserver_protocol::x11::xf86vidmode as x11vm;
+
+        let mut state = ServerState::new();
+        let mut peer = install_client(&mut state, 1);
+
+        // Legacy client: 32-byte header + one 28-byte xXF86OldVidModeModeInfo.
+        let legacy = dispatch_vidmode(&mut state, &mut peer, 1, x11vm::GET_ALL_MODE_LINES, &[0; 4]);
+        assert_eq!(legacy.len(), 60);
+        assert_eq!(u32::from_le_bytes(legacy[8..12].try_into().unwrap()), 1);
+
+        dispatch_vidmode(
+            &mut state,
+            &mut peer,
+            2,
+            x11vm::SET_CLIENT_VERSION,
+            &[2, 0, 2, 0],
+        );
+
+        // v2 client: 32-byte header + one 48-byte xXF86VidModeModeInfo.
+        let v2 = dispatch_vidmode(&mut state, &mut peer, 3, x11vm::GET_ALL_MODE_LINES, &[0; 4]);
+        assert_eq!(v2.len(), 80);
+        assert_eq!(u32::from_le_bytes(v2[4..8].try_into().unwrap()), 12);
+        assert_eq!(u32::from_le_bytes(v2[8..12].try_into().unwrap()), 1);
+        // Same active mode GetModeLine reports.
+        let expected = current_vidmode_mode_line(&state).expect("active mode");
+        assert_eq!(
+            u32::from_le_bytes(v2[32..36].try_into().unwrap()),
+            expected.dot_clock
+        );
+        assert_eq!(
+            u16::from_le_bytes(v2[42..44].try_into().unwrap()),
+            expected.htotal
+        );
+    }
+
+    #[test]
+    fn xf86vidmode_v2_mode_list_keeps_the_core_stream_aligned() {
+        use yserver_protocol::x11::xf86vidmode as x11vm;
+
+        let mut state = ServerState::new();
+        let mut peer = install_client(&mut state, 1);
+        let mut backend = RecordingBackend::new();
+
+        process_request(
+            &mut state,
+            &mut backend,
+            ClientId(1),
+            SequenceNumber(1),
+            RequestHeader {
+                opcode: crate::nested::XF86VIDMODE_MAJOR_OPCODE,
+                data: x11vm::SET_CLIENT_VERSION,
+                length_units: 2,
+            },
+            &[2, 0, 2, 0],
+            None,
+        )
+        .expect("SetClientVersion");
+        process_request(
+            &mut state,
+            &mut backend,
+            ClientId(1),
+            SequenceNumber(2),
+            RequestHeader {
+                opcode: crate::nested::XF86VIDMODE_MAJOR_OPCODE,
+                data: x11vm::GET_ALL_MODE_LINES,
+                length_units: 2,
+            },
+            &[0; 4],
+            None,
+        )
+        .expect("GetAllModeLines");
+        process_request(
+            &mut state,
+            &mut backend,
+            ClientId(1),
+            SequenceNumber(3),
+            RequestHeader {
+                opcode: 43, // GetInputFocus
+                data: 0,
+                length_units: 1,
+            },
+            &[],
+            None,
+        )
+        .expect("GetInputFocus");
+
+        let stream = read_all_or_buffered(&mut state, 1, &mut peer);
+        assert_eq!(
+            stream.len(),
+            80 + 32,
+            "complete VidMode reply followed by core reply"
+        );
+
+        assert_eq!(stream[0], 1);
+        assert_eq!(u16::from_le_bytes(stream[2..4].try_into().unwrap()), 2);
+        assert_eq!(u32::from_le_bytes(stream[4..8].try_into().unwrap()), 12);
+        assert_eq!(u32::from_le_bytes(stream[8..12].try_into().unwrap()), 1);
+
+        let focus = &stream[80..];
+        assert_eq!(focus[0], 1);
+        assert_eq!(u16::from_le_bytes(focus[2..4].try_into().unwrap()), 3);
+        assert_eq!(u32::from_le_bytes(focus[4..8].try_into().unwrap()), 0);
+    }
+
+    /// `client_reader` swaps request bodies before dispatch, so the handler
+    /// only owes the client a reply in *its* byte order.
+    #[test]
+    fn xf86vidmode_big_endian_client_gets_a_byte_swapped_reply() {
+        use yserver_protocol::x11::xf86vidmode as x11vm;
+
+        let mut state = ServerState::new();
+        let mut peer = install_client(&mut state, 1);
+        state.clients.get_mut(&1).expect("test client").byte_order = ClientByteOrder::BigEndian;
+
+        // Bodies arrive already in host order — as `swap_request_body` left
+        // them — so this is still a little-endian `2.2`.
+        dispatch_vidmode(
+            &mut state,
+            &mut peer,
+            1,
+            x11vm::SET_CLIENT_VERSION,
+            &[2, 0, 2, 0],
+        );
+        assert_eq!(
+            state.vidmode_client_versions.get(&ClientId(1)),
+            Some(&(2, 2)),
+            "the swapped body must parse as 2.2, not 512.512"
+        );
+
+        let expected = current_vidmode_mode_line(&state).expect("active mode");
+        let reply = dispatch_vidmode(&mut state, &mut peer, 0x1234, x11vm::GET_MODE_LINE, &[0; 4]);
+        assert_eq!(reply.len(), 52);
+        assert_eq!(&reply[2..4], &0x1234_u16.to_be_bytes());
+        assert_eq!(&reply[4..8], &5_u32.to_be_bytes());
+        assert_eq!(&reply[8..12], &expected.dot_clock.to_be_bytes());
+        assert_eq!(&reply[18..20], &expected.htotal.to_be_bytes());
+        assert_eq!(&reply[28..30], &expected.vtotal.to_be_bytes());
+
+        // Errors follow the client's byte order too. `screen = 1` is still
+        // spelled little-endian in the already-swapped body.
+        let error = dispatch_vidmode(
+            &mut state,
+            &mut peer,
+            5,
+            x11vm::GET_MODE_LINE,
+            &[1, 0, 0, 0],
+        );
+        assert_eq!(error[0], 0);
+        assert_eq!(error[1], x11::error::BAD_VALUE);
+        assert_eq!(&error[4..8], &1_u32.to_be_bytes());
+    }
+
+    /// The VidMode mode line and RANDR's `ModeInfo` describe the same
+    /// hardware mode; they must agree on blanking, and their pixel clocks
+    /// must agree once RANDR's Hz is reduced to VidMode's kHz.
+    #[test]
+    fn xf86vidmode_mode_line_agrees_with_randr_mode_info() {
+        let state = ServerState::new();
+        let mode = current_vidmode_mode_line(&state).expect("active mode");
+        let resources = state.randr.screen_resources_current();
+        let info = resources
+            .modes
+            .iter()
+            .find(|m| m.width == mode.hdisplay && m.height == mode.vdisplay)
+            .expect("matching RANDR mode");
+
+        assert_eq!(mode.htotal, info.htotal);
+        assert_eq!(mode.vtotal, info.vtotal);
+        assert_eq!(mode.hsync_start, info.hsync_start);
+        assert_eq!(mode.hsync_end, info.hsync_end);
+        assert_eq!(mode.vsync_start, info.vsync_start);
+        assert_eq!(mode.vsync_end, info.vsync_end);
+        assert_eq!(mode.flags, info.mode_flags);
+        assert_eq!(mode.dot_clock, (info.dot_clock + 500) / 1000);
     }
 
     // ---- L2 plan B.1: COMPOSITE redirect dispatch policy --------

--- a/crates/yserver-core/src/nested.rs
+++ b/crates/yserver-core/src/nested.rs
@@ -112,7 +112,7 @@ pub(crate) const GLX_FIRST_ERROR: u8 = 169; // 13 errors (169-181); routed past 
 
 pub(crate) const X_RESOURCE_MAJOR_OPCODE: u8 = 149;
 pub(crate) const XF86VIDMODE_MAJOR_OPCODE: u8 = 153;
-const XF86VIDMODE_FIRST_ERROR: u8 = 182;
+pub(crate) const XF86VIDMODE_FIRST_ERROR: u8 = 182;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ExtensionAvailability {

--- a/crates/yserver-core/src/nested.rs
+++ b/crates/yserver-core/src/nested.rs
@@ -29,7 +29,8 @@ use crate::{
 // Current allocation (error counts in parens):
 //   RANDR 147 (5) · RENDER 152 (5) · XInput 157 (5) · [host XKB 162 (1)]
 //   · XFIXES 163 (1) · SYNC 164 (3) · DAMAGE 167 (1) · MIT-SHM 168 (1)
-//   · GLX 169 (13, →181). SHAPE/Composite/Present/DPMS/screensaver: 0.
+//   · GLX 169 (13, →181) · XFree86-VidMode 182 (7, →188).
+//   SHAPE/Composite/Present/DPMS/screensaver: 0.
 // Do NOT pack these 1 apart — a multi-error extension (RENDER=5, GLX=13)
 // would then overlap its neighbours.
 const RANDR_MAJOR_OPCODE: u8 = 128;
@@ -110,6 +111,8 @@ pub(crate) const GLX_FIRST_EVENT: u8 = 95; // matches Xorg: Pbuffer=95, BufferSw
 pub(crate) const GLX_FIRST_ERROR: u8 = 169; // 13 errors (169-181); routed past host XKB error base 162
 
 pub(crate) const X_RESOURCE_MAJOR_OPCODE: u8 = 149;
+pub(crate) const XF86VIDMODE_MAJOR_OPCODE: u8 = 153;
+const XF86VIDMODE_FIRST_ERROR: u8 = 182;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ExtensionAvailability {
@@ -329,6 +332,15 @@ pub(crate) const EXTENSIONS: &[ExtensionMetadata] = &[
         first_event: 0,
         event_count: 0,
         first_error: 0,
+        availability: ExtensionAvailability::Always,
+        unsupported_minor_policy: UnsupportedMinorPolicy::HandledInline,
+    },
+    ExtensionMetadata {
+        name: "XFree86-VidModeExtension",
+        major_opcode: XF86VIDMODE_MAJOR_OPCODE,
+        first_event: 0,
+        event_count: 0,
+        first_error: XF86VIDMODE_FIRST_ERROR,
         availability: ExtensionAvailability::Always,
         unsupported_minor_policy: UnsupportedMinorPolicy::HandledInline,
     },
@@ -1035,6 +1047,17 @@ mod tests {
         assert_eq!(ext.major_opcode, 151);
         assert_eq!(ext.first_event, 0);
         assert_eq!(ext.first_error, 0);
+    }
+
+    #[test]
+    fn xf86vidmode_is_advertised_with_xorg_error_range() {
+        let ext = EXTENSIONS
+            .iter()
+            .find(|ext| ext.name == "XFree86-VidModeExtension")
+            .expect("XFree86-VidModeExtension in EXTENSIONS");
+        assert_eq!(ext.major_opcode, 153);
+        assert_eq!(ext.first_event, 0);
+        assert_eq!(ext.first_error, 182);
     }
 
     mod render {

--- a/crates/yserver-core/src/randr.rs
+++ b/crates/yserver-core/src/randr.rs
@@ -95,8 +95,15 @@ pub struct ModeTiming {
     pub vsync_start: u16,
     pub vsync_end: u16,
     pub vtotal: u16,
-    /// RANDR mode flags (already mapped from DRM sync/interlace bits;
-    /// the low 7 bits of `DRM_MODE_FLAG_*` coincide with `RR_*`).
+    /// RANDR mode flags. The backend masks the kernel value to the low 6
+    /// bits (`& 0x3F`), where `DRM_MODE_FLAG_*`, `RR_*` and VidMode's
+    /// `V_*` all agree: P/N HSync, P/N VSync, Interlace, DoubleScan.
+    ///
+    /// The three namespaces diverge above bit 10 (`V_PIXMUX` is 0x1000
+    /// while `RR_PixelMultiplex` is 0x800), so widening that mask would
+    /// need a real DRM→`V_*` mapping before VidMode's `GetModeLine` may
+    /// keep forwarding this field verbatim. Mesa reads `V_INTERLACE`
+    /// (0x10) and `V_DBLSCAN` (0x20) from it to scale the MSC rate.
     pub mode_flags: u32,
 }
 
@@ -109,6 +116,99 @@ pub struct RandrMode {
     pub vrefresh: u32,
     /// Real kernel timing; `None` => synthesise (see [`ModeTiming`]).
     pub timing: Option<ModeTiming>,
+}
+
+/// A mode's timing after the `Option<ModeTiming>` fallback has been
+/// resolved: either the real kernel numbers or the historical synthesis.
+///
+/// Single source of truth for both consumers — RANDR `GetScreenResources`
+/// (`ModeInfo`) and XFree86-VidMode `GetModeLine`/`GetAllModeLines`. They
+/// describe the same hardware mode, so they must never disagree; deriving
+/// blanking twice is how they would drift.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EffectiveTiming {
+    /// Pixel clock in **Hz**. RANDR `ModeInfo.dot_clock` reports this
+    /// verbatim; VidMode carries whole kHz and rounds it.
+    pub dot_clock_hz: u32,
+    pub hsync_start: u16,
+    pub hsync_end: u16,
+    pub htotal: u16,
+    /// Always 0: neither the kernel mode nor the synthesis carries a sync
+    /// skew, and both replies have historically hardcoded it here.
+    pub hskew: u16,
+    pub vsync_start: u16,
+    pub vsync_end: u16,
+    pub vtotal: u16,
+    pub mode_flags: u32,
+}
+
+impl EffectiveTiming {
+    /// Resolve `timing`, falling back to the synthetic blanking.
+    ///
+    /// Real timing (Xorg `drmmode_ConvertFromKMode` + `xf86RandR12`):
+    /// `dot_clock = Clock*1000`, blanking verbatim. Clients compute
+    /// `refresh = dot_clock / (htotal*vtotal)`, reproducing the exact
+    /// fractional rate (e.g. 59.95) the hardware mode carries and that
+    /// GNOME/MATE stored in `monitors.xml`.
+    ///
+    /// Fallback (nested/virtio: no real timing). The synthetic blanking is
+    /// kept consistent with `dot_clock` so that same formula back-computes
+    /// to exactly the integer `vrefresh`. (Using `width*height` instead
+    /// reported ≈ 51–53 Hz.)
+    #[must_use]
+    pub fn resolve(width: u16, height: u16, vrefresh: u32, timing: Option<ModeTiming>) -> Self {
+        if let Some(t) = timing {
+            return Self {
+                dot_clock_hz: t.clock_khz.saturating_mul(1000),
+                hsync_start: t.hsync_start,
+                hsync_end: t.hsync_end,
+                htotal: t.htotal,
+                hskew: 0,
+                vsync_start: t.vsync_start,
+                vsync_end: t.vsync_end,
+                vtotal: t.vtotal,
+                mode_flags: t.mode_flags,
+            };
+        }
+        let htotal = width.saturating_add(264);
+        let vtotal = height.saturating_add(28);
+        // u64 intermediate: 8K@240 overflows a u32 product.
+        let dot_clock_hz = u64::from(htotal) * u64::from(vtotal) * u64::from(vrefresh);
+        Self {
+            dot_clock_hz: u32::try_from(dot_clock_hz).unwrap_or(u32::MAX),
+            hsync_start: width.saturating_add(40),
+            hsync_end: width.saturating_add(168),
+            htotal,
+            hskew: 0,
+            vsync_start: height.saturating_add(1),
+            vsync_end: height.saturating_add(4),
+            vtotal,
+            mode_flags: 0,
+        }
+    }
+
+    /// Pixel clock rounded to whole kHz, the unit
+    /// `xXF86VidModeGetModeLineReply` carries.
+    #[must_use]
+    pub fn dot_clock_khz(&self) -> u32 {
+        self.dot_clock_hz.saturating_add(500) / 1000
+    }
+}
+
+impl RandrMode {
+    /// This mode's timing, real or synthesised.
+    #[must_use]
+    pub fn effective_timing(&self) -> EffectiveTiming {
+        EffectiveTiming::resolve(self.width, self.height, self.vrefresh, self.timing)
+    }
+}
+
+impl RandrOutput {
+    /// The timing of this output's *current* mode, real or synthesised.
+    #[must_use]
+    pub fn effective_timing(&self) -> EffectiveTiming {
+        EffectiveTiming::resolve(self.width, self.height, self.vrefresh, self.timing)
+    }
 }
 
 #[derive(Debug)]
@@ -320,52 +420,23 @@ impl RandrState {
             let name = format!("{}x{}", m.width, m.height).into_bytes();
             #[allow(clippy::cast_possible_truncation)]
             let name_len = name.len() as u16;
-            let info = if let Some(t) = m.timing {
-                // Real kernel timing (Xorg drmmode_ConvertFromKMode +
-                // xf86RandR12): dot_clock = Clock*1000, blanking verbatim.
-                // Clients compute refresh = dot_clock / (htotal*vtotal),
-                // reproducing the exact fractional rate (e.g. 59.95) the
-                // hardware mode carries and GNOME/MATE stored.
-                proto::ModeInfo {
-                    id: m.mode_id,
-                    width: m.width,
-                    height: m.height,
-                    dot_clock: t.clock_khz.saturating_mul(1000),
-                    hsync_start: t.hsync_start,
-                    hsync_end: t.hsync_end,
-                    htotal: t.htotal,
-                    hskew: 0,
-                    vsync_start: t.vsync_start,
-                    vsync_end: t.vsync_end,
-                    vtotal: t.vtotal,
-                    name_len,
-                    mode_flags: t.mode_flags,
-                }
-            } else {
-                // Fallback (nested/virtio: no real timing). Synthetic
-                // blanking kept consistent with dot_clock so the same
-                // formula back-computes to exactly the integer `vrefresh`.
-                // (Using width*height instead reported ≈ 51–53 Hz.)
-                let htotal = m.width.saturating_add(264);
-                let vtotal = m.height.saturating_add(28);
-                let dot_clock = u32::from(htotal) * u32::from(vtotal) * m.vrefresh;
-                proto::ModeInfo {
-                    id: m.mode_id,
-                    width: m.width,
-                    height: m.height,
-                    dot_clock,
-                    hsync_start: m.width + 40,
-                    hsync_end: m.width + 168,
-                    htotal,
-                    hskew: 0,
-                    vsync_start: m.height + 1,
-                    vsync_end: m.height + 4,
-                    vtotal,
-                    name_len,
-                    mode_flags: 0,
-                }
-            };
-            mode_infos.push(info);
+            // Shared with VidMode's GetModeLine — see `EffectiveTiming`.
+            let t = m.effective_timing();
+            mode_infos.push(proto::ModeInfo {
+                id: m.mode_id,
+                width: m.width,
+                height: m.height,
+                dot_clock: t.dot_clock_hz,
+                hsync_start: t.hsync_start,
+                hsync_end: t.hsync_end,
+                htotal: t.htotal,
+                hskew: t.hskew,
+                vsync_start: t.vsync_start,
+                vsync_end: t.vsync_end,
+                vtotal: t.vtotal,
+                name_len,
+                mode_flags: t.mode_flags,
+            });
             mode_names.extend_from_slice(&name);
         }
         proto::ScreenResources {
@@ -1176,6 +1247,14 @@ mod tests {
         let mi = res.modes.iter().find(|m| m.id == 7).expect("mode 7");
         let refresh = mi.dot_clock / (u32::from(mi.htotal) * u32::from(mi.vtotal));
         assert_eq!(refresh, 60, "xrandr-formula refresh must equal vrefresh");
+    }
+
+    #[test]
+    fn effective_timing_rounds_saturated_dot_clock_without_overflow() {
+        let timing = EffectiveTiming::resolve(u16::MAX, u16::MAX, u32::MAX, None);
+
+        assert_eq!(timing.dot_clock_hz, u32::MAX);
+        assert_eq!(timing.dot_clock_khz(), 4_294_967);
     }
 
     #[test]

--- a/crates/yserver-core/src/server.rs
+++ b/crates/yserver-core/src/server.rs
@@ -1068,6 +1068,10 @@ pub struct ServerState {
     /// GLX drawables (windows, pixmaps, pbuffers) — keyed by the GLX
     /// drawable XID the client chose at create-time.
     pub glx_drawables: HashMap<u32, GlxDrawable>,
+    /// Per-client XFree86-VidMode protocol version selected through
+    /// `SetClientVersion`. Missing means the legacy v0 reply layout, matching
+    /// Xorg's `ClientMajorVersion`.
+    pub vidmode_client_versions: HashMap<ClientId, (u16, u16)>,
     /// `GLX_EXT_texture_from_pixmap` is advertised only when the backend
     /// confirmed at init that it can allocate and export a BGRA8 dma-buf.
     /// Set once from `backend.supports_dmabuf_export()` during startup;
@@ -1312,6 +1316,7 @@ impl ServerState {
             glx_contexts: HashMap::new(),
             glx_next_context_tag: 1,
             glx_drawables: HashMap::new(),
+            vidmode_client_versions: HashMap::new(),
             glx_tfp_supported: false,
             sync_pending_awaits: Vec::new(),
             repeat_state: None,

--- a/crates/yserver-protocol/src/x11/mod.rs
+++ b/crates/yserver-protocol/src/x11/mod.rs
@@ -27,6 +27,7 @@ pub mod shape;
 pub mod sync;
 pub mod wire_swap;
 pub mod x_resource;
+pub mod xf86vidmode;
 pub mod xfixes;
 pub mod xinerama;
 pub mod xtest;

--- a/crates/yserver-protocol/src/x11/request_swap.rs
+++ b/crates/yserver-protocol/src/x11/request_swap.rs
@@ -161,8 +161,9 @@ const fn extension_request_swap_table(major: u8, minor: u8) -> Option<&'static [
         // XInput extension (major fixed at 137 in
         // `process_request::XI2_MAJOR_OPCODE`).
         137 => xi_request_swap_table(minor),
-        // XFree86-VidModeExtension (major fixed at 153): GetModeLine has
-        // screen(u16), SetClientVersion has major/minor(u16).
+        // XFree86-VidModeExtension (major fixed at 153). ValidateModeLine is
+        // intentionally decoded in the handler because its layout depends on
+        // per-client protocol-version state unavailable here.
         153 => xf86vidmode_request_swap_table(minor),
         _ => None,
     }
@@ -172,18 +173,28 @@ const fn xf86vidmode_request_swap_table(minor: u8) -> Option<&'static [FieldEntr
     use FieldEntry::Fixed;
     use FieldKind::U16;
 
-    // `screen(u16) + pad(u16)`, shared by GetModeLine, GetAllModeLines,
-    // GetGammaRampSize and GetPermissions.
+    // `screen(u16) + pad(u16)`, shared by the ordinary screen-scoped reads.
     const SCREEN: &[FieldEntry] = &[Fixed {
         offset: 0,
         kind: U16,
     }];
 
     Some(match minor {
-        // QueryVersion (0) has an empty body; every unimplemented minor is
-        // rejected before its body is read. Both are left to the `None`
-        // no-op arm.
-        1 | 6 | 19 | 20 => SCREEN,
+        // QueryVersion (0) has an empty body. ValidateModeLine (9) stays
+        // unswapped for its version-aware parser. Rejected write requests are
+        // not inspected.
+        1 | 4 | 6 | 11 | 13 | 16 | 19 | 20 => SCREEN,
+        // GetGammaRamp: screen(u16), size(u16).
+        17 => &[
+            Fixed {
+                offset: 0,
+                kind: U16,
+            },
+            Fixed {
+                offset: 2,
+                kind: U16,
+            },
+        ],
         14 => &[
             Fixed {
                 offset: 0,
@@ -1022,6 +1033,37 @@ mod tests {
         let mut body = vec![0xaa, 0xbb, 0xcc, 0xdd];
         let original = body.clone();
         swap_request_body(137, 255, ClientByteOrder::BigEndian, &mut body);
+        assert_eq!(body, original);
+    }
+
+    #[test]
+    fn xf86vidmode_read_requests_swap_screen_and_gamma_ramp_size() {
+        for minor in [1, 4, 6, 11, 13, 16, 19, 20] {
+            let mut body = vec![0x12, 0x34, 0, 0];
+            if minor == 16 {
+                body.resize(28, 0);
+            }
+            swap_request_body(153, minor, ClientByteOrder::BigEndian, &mut body);
+            assert_eq!(
+                u16::from_le_bytes(body[0..2].try_into().unwrap()),
+                0x1234,
+                "minor {minor}"
+            );
+        }
+
+        let mut ramp = vec![0x12, 0x34, 0x01, 0x00];
+        swap_request_body(153, 17, ClientByteOrder::BigEndian, &mut ramp);
+        assert_eq!(u16::from_le_bytes(ramp[0..2].try_into().unwrap()), 0x1234);
+        assert_eq!(u16::from_le_bytes(ramp[2..4].try_into().unwrap()), 0x0100);
+    }
+
+    #[test]
+    fn xf86vidmode_validate_body_stays_in_client_byte_order() {
+        let mut body = vec![0u8; 48];
+        body[0..4].copy_from_slice(&1u32.to_be_bytes());
+        body[44..48].copy_from_slice(&0u32.to_be_bytes());
+        let original = body.clone();
+        swap_request_body(153, 9, ClientByteOrder::BigEndian, &mut body);
         assert_eq!(body, original);
     }
 

--- a/crates/yserver-protocol/src/x11/request_swap.rs
+++ b/crates/yserver-protocol/src/x11/request_swap.rs
@@ -161,8 +161,35 @@ const fn extension_request_swap_table(major: u8, minor: u8) -> Option<&'static [
         // XInput extension (major fixed at 137 in
         // `process_request::XI2_MAJOR_OPCODE`).
         137 => xi_request_swap_table(minor),
+        // XFree86-VidModeExtension (major fixed at 153): GetModeLine has
+        // screen(u16), SetClientVersion has major/minor(u16).
+        153 => xf86vidmode_request_swap_table(minor),
         _ => None,
     }
+}
+
+const fn xf86vidmode_request_swap_table(minor: u8) -> Option<&'static [FieldEntry]> {
+    use FieldEntry::Fixed;
+    use FieldKind::U16;
+
+    Some(match minor {
+        0 => &[],
+        1 => &[Fixed {
+            offset: 0,
+            kind: U16,
+        }],
+        14 => &[
+            Fixed {
+                offset: 0,
+                kind: U16,
+            },
+            Fixed {
+                offset: 2,
+                kind: U16,
+            },
+        ],
+        _ => return None,
+    })
 }
 
 const fn randr_request_swap_table(minor: u8) -> Option<&'static [FieldEntry]> {
@@ -990,6 +1017,17 @@ mod tests {
         let original = body.clone();
         swap_request_body(137, 255, ClientByteOrder::BigEndian, &mut body);
         assert_eq!(body, original);
+    }
+
+    #[test]
+    fn xf86vidmode_get_mode_line_and_client_version_are_swapped() {
+        let mut screen = [0x12, 0x34, 0, 0];
+        swap_request_body(153, 1, ClientByteOrder::BigEndian, &mut screen);
+        assert_eq!(screen, [0x34, 0x12, 0, 0]);
+
+        let mut version = [0, 2, 0, 1];
+        swap_request_body(153, 14, ClientByteOrder::BigEndian, &mut version);
+        assert_eq!(version, [2, 0, 1, 0]);
     }
 
     #[test]

--- a/crates/yserver-protocol/src/x11/request_swap.rs
+++ b/crates/yserver-protocol/src/x11/request_swap.rs
@@ -172,12 +172,18 @@ const fn xf86vidmode_request_swap_table(minor: u8) -> Option<&'static [FieldEntr
     use FieldEntry::Fixed;
     use FieldKind::U16;
 
+    // `screen(u16) + pad(u16)`, shared by GetModeLine, GetAllModeLines,
+    // GetGammaRampSize and GetPermissions.
+    const SCREEN: &[FieldEntry] = &[Fixed {
+        offset: 0,
+        kind: U16,
+    }];
+
     Some(match minor {
-        0 => &[],
-        1 => &[Fixed {
-            offset: 0,
-            kind: U16,
-        }],
+        // QueryVersion (0) has an empty body; every unimplemented minor is
+        // rejected before its body is read. Both are left to the `None`
+        // no-op arm.
+        1 | 6 | 19 | 20 => SCREEN,
         14 => &[
             Fixed {
                 offset: 0,
@@ -1028,6 +1034,24 @@ mod tests {
         let mut version = [0, 2, 0, 1];
         swap_request_body(153, 14, ClientByteOrder::BigEndian, &mut version);
         assert_eq!(version, [2, 0, 1, 0]);
+    }
+
+    #[test]
+    fn every_screen_taking_xf86vidmode_request_swaps_its_screen_field() {
+        // GetAllModeLines, GetGammaRampSize, GetPermissions share
+        // GetModeLine's `screen(u16) + pad(u16)` body.
+        for minor in [1, 6, 19, 20] {
+            let mut body = [0x12, 0x34, 0, 0];
+            swap_request_body(153, minor, ClientByteOrder::BigEndian, &mut body);
+            assert_eq!(body, [0x34, 0x12, 0, 0], "minor {minor}");
+        }
+    }
+
+    #[test]
+    fn xf86vidmode_little_endian_client_body_is_untouched() {
+        let mut body = [0x12, 0x34, 0, 0];
+        swap_request_body(153, 1, ClientByteOrder::LittleEndian, &mut body);
+        assert_eq!(body, [0x12, 0x34, 0, 0]);
     }
 
     #[test]

--- a/crates/yserver-protocol/src/x11/xf86vidmode.rs
+++ b/crates/yserver-protocol/src/x11/xf86vidmode.rs
@@ -6,6 +6,18 @@
 //! `dotclock * 1000 / (htotal * vtotal)`. Yserver exposes those read-only
 //! requests plus `SetClientVersion`, which selects the legacy or v2 reply
 //! layout exactly as Xorg does.
+//!
+//! `GetAllModeLines`, `GetGammaRampSize` and `GetPermissions` round the
+//! surface out so that a client probing VidMode for something other than
+//! the MSC rate gets an honest read-only answer (one mode, no gamma ramp,
+//! no write permission) instead of a `BadRequest` it did not expect from an
+//! extension it just saw advertised. Every other request — mode setting,
+//! gamma, viewport and the remaining monitor/dot-clock queries — stays
+//! unimplemented.
+//!
+//! Request bodies reach the parsers here already in host byte order —
+//! `request_swap` has swapped them for a big-endian client — so the
+//! `parse_*` helpers read little-endian unconditionally.
 
 use super::{
     ClientByteOrder, SequenceNumber,
@@ -17,7 +29,14 @@ pub const MINOR_VERSION: u16 = 2;
 
 pub const QUERY_VERSION: u8 = 0;
 pub const GET_MODE_LINE: u8 = 1;
+pub const GET_ALL_MODE_LINES: u8 = 6;
 pub const SET_CLIENT_VERSION: u8 = 14;
+pub const GET_GAMMA_RAMP_SIZE: u8 = 19;
+pub const GET_PERMISSIONS: u8 = 20;
+
+/// `XF86VM_READ_PERMISSION`. Yserver never grants
+/// `XF86VM_WRITE_PERMISSION` (2): no VidMode mode-setting request exists.
+pub const PERMISSION_READ: u32 = 1;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ClientVersion {
@@ -55,11 +74,20 @@ pub fn parse_client_version(body: &[u8]) -> Option<ClientVersion> {
 }
 
 fn reply_prefix(byte_order: ClientByteOrder, sequence: SequenceNumber, length: u32) -> Vec<u8> {
-    let mut out = Vec::with_capacity(52);
+    let mut out = Vec::with_capacity(32 + 4 * length as usize);
     out.push(1);
     out.push(0);
     write_u16(byte_order, &mut out, sequence.0);
     write_u32(byte_order, &mut out, length);
+    out
+}
+
+/// Encode a 32-byte reply whose only payload is a single `CARD32` at the
+/// usual post-header offset (`GetPermissions`).
+fn encode_u32_reply(byte_order: ClientByteOrder, sequence: SequenceNumber, value: u32) -> Vec<u8> {
+    let mut out = reply_prefix(byte_order, sequence, 0);
+    write_u32(byte_order, &mut out, value);
+    out.resize(32, 0);
     out
 }
 
@@ -109,6 +137,78 @@ pub fn encode_get_mode_line_reply(
     write_u32(byte_order, &mut out, 0);
     debug_assert_eq!(out.len(), if version_2 { 52 } else { 36 });
     out
+}
+
+/// Encode `GetAllModeLines` reporting the single active mode.
+///
+/// Yserver has no VidMode mode list of its own: RANDR owns mode selection
+/// and none of VidMode's switching requests are implemented. Advertising
+/// exactly one mode is the honest answer and, unlike a longer list, does
+/// not invite a client to attempt a `SwitchToMode` that can only fail.
+///
+/// Note `xXF86VidModeModeInfo` widens `hskew` to a `CARD32` — it is a
+/// `CARD16` in the `GetModeLine` reply — and carries a `pad1` word plus
+/// three reserved words before `privsize`.
+#[must_use]
+pub fn encode_get_all_mode_lines_reply(
+    byte_order: ClientByteOrder,
+    sequence: SequenceNumber,
+    mode: ModeLine,
+    version_2: bool,
+) -> Vec<u8> {
+    let info_size = if version_2 { 48 } else { 28 };
+    let mut out = reply_prefix(byte_order, sequence, info_size / 4);
+    write_u32(byte_order, &mut out, 1); // modecount
+    out.resize(32, 0);
+
+    write_u32(byte_order, &mut out, mode.dot_clock);
+    write_u16(byte_order, &mut out, mode.hdisplay);
+    write_u16(byte_order, &mut out, mode.hsync_start);
+    write_u16(byte_order, &mut out, mode.hsync_end);
+    write_u16(byte_order, &mut out, mode.htotal);
+    if version_2 {
+        write_u32(byte_order, &mut out, u32::from(mode.hskew));
+    }
+    write_u16(byte_order, &mut out, mode.vdisplay);
+    write_u16(byte_order, &mut out, mode.vsync_start);
+    write_u16(byte_order, &mut out, mode.vsync_end);
+    write_u16(byte_order, &mut out, mode.vtotal);
+    if version_2 {
+        write_u32(byte_order, &mut out, 0); // pad1
+    }
+    write_u32(byte_order, &mut out, mode.flags);
+    if version_2 {
+        write_u32(byte_order, &mut out, 0); // reserved1
+        write_u32(byte_order, &mut out, 0); // reserved2
+        write_u32(byte_order, &mut out, 0); // reserved3
+    }
+    write_u32(byte_order, &mut out, 0); // privsize
+    debug_assert_eq!(out.len(), 32 + info_size as usize);
+    out
+}
+
+/// Encode `GetGammaRampSize`. Yserver implements no gamma ramp, and Xorg
+/// reports size 0 for a screen without one; `XF86VidModeGetGammaRampSize`
+/// hands that straight to the caller, which is the documented way for a
+/// client to learn the ramp is unavailable.
+#[must_use]
+pub fn encode_get_gamma_ramp_size_reply(
+    byte_order: ClientByteOrder,
+    sequence: SequenceNumber,
+) -> Vec<u8> {
+    let mut out = reply_prefix(byte_order, sequence, 0);
+    write_u16(byte_order, &mut out, 0); // size
+    out.resize(32, 0);
+    out
+}
+
+/// Encode `GetPermissions` — read-only, never `XF86VM_WRITE_PERMISSION`.
+#[must_use]
+pub fn encode_get_permissions_reply(
+    byte_order: ClientByteOrder,
+    sequence: SequenceNumber,
+) -> Vec<u8> {
+    encode_u32_reply(byte_order, sequence, PERMISSION_READ)
 }
 
 #[cfg(test)]
@@ -191,6 +291,92 @@ mod tests {
         assert_eq!(&reply[12..14], &2560_u16.to_be_bytes());
         assert_eq!(&reply[28..30], &1481_u16.to_be_bytes());
         assert_eq!(&reply[32..36], &5_u32.to_be_bytes());
+    }
+
+    #[test]
+    fn all_mode_lines_v2_reply_matches_xf86vidmodemodeinfo_layout() {
+        let reply = encode_get_all_mode_lines_reply(
+            ClientByteOrder::LittleEndian,
+            SequenceNumber(7),
+            fixture(),
+            true,
+        );
+        // 32-byte header + one 48-byte xXF86VidModeModeInfo.
+        assert_eq!(reply.len(), 80);
+        assert_eq!(u32::from_le_bytes(reply[4..8].try_into().unwrap()), 12);
+        assert_eq!(u32::from_le_bytes(reply[8..12].try_into().unwrap()), 1);
+        assert_eq!(&reply[12..32], &[0; 20]);
+        assert_eq!(
+            u32::from_le_bytes(reply[32..36].try_into().unwrap()),
+            241_500
+        );
+        assert_eq!(u16::from_le_bytes(reply[36..38].try_into().unwrap()), 2560);
+        assert_eq!(u16::from_le_bytes(reply[42..44].try_into().unwrap()), 2720);
+        // hskew is a CARD32 here, not the CARD16 of the GetModeLine reply.
+        assert_eq!(u32::from_le_bytes(reply[44..48].try_into().unwrap()), 0);
+        assert_eq!(u16::from_le_bytes(reply[48..50].try_into().unwrap()), 1440);
+        assert_eq!(u16::from_le_bytes(reply[54..56].try_into().unwrap()), 1481);
+        assert_eq!(u32::from_le_bytes(reply[56..60].try_into().unwrap()), 0);
+        assert_eq!(u32::from_le_bytes(reply[60..64].try_into().unwrap()), 5);
+        assert_eq!(&reply[64..80], &[0; 16]);
+    }
+
+    #[test]
+    fn legacy_all_mode_lines_reply_drops_the_hskew_word() {
+        let reply = encode_get_all_mode_lines_reply(
+            ClientByteOrder::LittleEndian,
+            SequenceNumber(7),
+            fixture(),
+            false,
+        );
+        // 32-byte header + one 28-byte xXF86OldVidModeModeInfo.
+        assert_eq!(reply.len(), 60);
+        assert_eq!(u32::from_le_bytes(reply[4..8].try_into().unwrap()), 7);
+        assert_eq!(u32::from_le_bytes(reply[8..12].try_into().unwrap()), 1);
+        assert_eq!(u16::from_le_bytes(reply[42..44].try_into().unwrap()), 2720);
+        // vdisplay follows htotal directly with no hskew in between.
+        assert_eq!(u16::from_le_bytes(reply[44..46].try_into().unwrap()), 1440);
+        assert_eq!(u16::from_le_bytes(reply[50..52].try_into().unwrap()), 1481);
+        assert_eq!(u32::from_le_bytes(reply[52..56].try_into().unwrap()), 5);
+        assert_eq!(u32::from_le_bytes(reply[56..60].try_into().unwrap()), 0);
+    }
+
+    #[test]
+    fn big_endian_all_mode_lines_reply_swaps_every_field() {
+        let reply = encode_get_all_mode_lines_reply(
+            ClientByteOrder::BigEndian,
+            SequenceNumber(0x1234),
+            fixture(),
+            true,
+        );
+        assert_eq!(&reply[2..4], &[0x12, 0x34]);
+        assert_eq!(&reply[4..8], &12_u32.to_be_bytes());
+        assert_eq!(&reply[8..12], &1_u32.to_be_bytes());
+        assert_eq!(&reply[32..36], &241_500_u32.to_be_bytes());
+        assert_eq!(&reply[36..38], &2560_u16.to_be_bytes());
+        assert_eq!(&reply[56..60], &0_u32.to_be_bytes());
+        assert_eq!(&reply[60..64], &5_u32.to_be_bytes());
+        assert_eq!(&reply[64..80], &[0; 16]);
+    }
+
+    #[test]
+    fn permissions_reply_is_read_only() {
+        let reply = encode_get_permissions_reply(ClientByteOrder::LittleEndian, SequenceNumber(3));
+        assert_eq!(reply.len(), 32);
+        assert_eq!(u32::from_le_bytes(reply[4..8].try_into().unwrap()), 0);
+        // READ without WRITE — mode setting is not implemented.
+        assert_eq!(u32::from_le_bytes(reply[8..12].try_into().unwrap()), 1);
+        assert_eq!(&reply[12..32], &[0; 20]);
+    }
+
+    #[test]
+    fn gamma_ramp_size_reply_reports_no_ramp() {
+        let reply =
+            encode_get_gamma_ramp_size_reply(ClientByteOrder::LittleEndian, SequenceNumber(3));
+        assert_eq!(reply.len(), 32);
+        assert_eq!(u32::from_le_bytes(reply[4..8].try_into().unwrap()), 0);
+        assert_eq!(u16::from_le_bytes(reply[8..10].try_into().unwrap()), 0);
+        assert_eq!(&reply[10..32], &[0; 22]);
     }
 
     #[test]

--- a/crates/yserver-protocol/src/x11/xf86vidmode.rs
+++ b/crates/yserver-protocol/src/x11/xf86vidmode.rs
@@ -55,6 +55,10 @@ pub const GET_PERMISSIONS: u8 = 20;
 pub const CLIENT_NOT_LOCAL: u8 = 5;
 /// Xorg `ModeStatus::MODE_OK`.
 pub const MODE_OK: u32 = 0;
+/// Xorg's `CLKFLAG_PROGRAMABLE` (historical spelling).
+pub const CLOCK_FLAG_PROGRAMMABLE: u32 = 1;
+/// Xorg's fixed upper bound for a legacy hardware clock table.
+pub const MAX_CLOCKS: u32 = 128;
 
 /// `XF86VM_READ_PERMISSION`. Yserver never grants
 /// `XF86VM_WRITE_PERMISSION` (2): no VidMode mode-setting request exists.
@@ -209,23 +213,21 @@ pub fn encode_get_view_port_reply(
     out
 }
 
-/// Encode one or more fixed clocks in kHz. Yserver reports only its selected
-/// output's active clock, so `maxclocks` truthfully equals the returned count.
+/// Encode Xorg's `GetDotClocks` reply for a programmable-clock driver.
+///
+/// Xorg's KMS modesetting driver sets `progClock`, so the reply advertises
+/// that capability and carries no legacy fixed-clock table. The active mode's
+/// actual dot clock is reported by `GetModeLine`.
 #[must_use]
 pub fn encode_get_dot_clocks_reply(
     byte_order: ClientByteOrder,
     sequence: SequenceNumber,
-    clocks: &[u32],
 ) -> Vec<u8> {
-    let count = u32::try_from(clocks.len()).unwrap_or(u32::MAX);
-    let mut out = reply_prefix(byte_order, sequence, count);
-    write_u32(byte_order, &mut out, 0); // flags: fixed, not programmable
-    write_u32(byte_order, &mut out, count);
-    write_u32(byte_order, &mut out, count); // maxclocks
+    let mut out = reply_prefix(byte_order, sequence, 0);
+    write_u32(byte_order, &mut out, CLOCK_FLAG_PROGRAMMABLE);
+    write_u32(byte_order, &mut out, 0); // no fixed clocks
+    write_u32(byte_order, &mut out, MAX_CLOCKS);
     out.resize(32, 0);
-    for &clock in clocks {
-        write_u32(byte_order, &mut out, clock);
-    }
     out
 }
 
@@ -579,19 +581,17 @@ mod tests {
         assert_eq!(viewport.len(), 32);
         assert_eq!(&viewport[8..16], &[0; 8]);
 
-        let clocks = encode_get_dot_clocks_reply(
-            ClientByteOrder::LittleEndian,
-            SequenceNumber(5),
-            &[241_500],
-        );
-        assert_eq!(clocks.len(), 36);
-        assert_eq!(u32::from_le_bytes(clocks[4..8].try_into().unwrap()), 1);
-        assert_eq!(u32::from_le_bytes(clocks[8..12].try_into().unwrap()), 0);
-        assert_eq!(u32::from_le_bytes(clocks[12..16].try_into().unwrap()), 1);
-        assert_eq!(u32::from_le_bytes(clocks[16..20].try_into().unwrap()), 1);
+        let clocks = encode_get_dot_clocks_reply(ClientByteOrder::LittleEndian, SequenceNumber(5));
+        assert_eq!(clocks.len(), 32);
+        assert_eq!(u32::from_le_bytes(clocks[4..8].try_into().unwrap()), 0);
         assert_eq!(
-            u32::from_le_bytes(clocks[32..36].try_into().unwrap()),
-            241_500
+            u32::from_le_bytes(clocks[8..12].try_into().unwrap()),
+            CLOCK_FLAG_PROGRAMMABLE
+        );
+        assert_eq!(u32::from_le_bytes(clocks[12..16].try_into().unwrap()), 0);
+        assert_eq!(
+            u32::from_le_bytes(clocks[16..20].try_into().unwrap()),
+            MAX_CLOCKS
         );
 
         let gamma = encode_get_gamma_reply(ClientByteOrder::LittleEndian, SequenceNumber(6));

--- a/crates/yserver-protocol/src/x11/xf86vidmode.rs
+++ b/crates/yserver-protocol/src/x11/xf86vidmode.rs
@@ -1,0 +1,206 @@
+//! Minimal read-only XFree86-VidModeExtension protocol surface.
+//!
+//! Mesa implements `glXGetMscRateOML` entirely client-side. It obtains the
+//! active mode timing through `XF86VidModeQueryVersion` followed by
+//! `XF86VidModeGetModeLine`, then derives the MSC rate from
+//! `dotclock * 1000 / (htotal * vtotal)`. Yserver exposes those read-only
+//! requests plus `SetClientVersion`, which selects the legacy or v2 reply
+//! layout exactly as Xorg does.
+
+use super::{
+    ClientByteOrder, SequenceNumber,
+    wire::{write_u16, write_u32},
+};
+
+pub const MAJOR_VERSION: u16 = 2;
+pub const MINOR_VERSION: u16 = 2;
+
+pub const QUERY_VERSION: u8 = 0;
+pub const GET_MODE_LINE: u8 = 1;
+pub const SET_CLIENT_VERSION: u8 = 14;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ClientVersion {
+    pub major: u16,
+    pub minor: u16,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ModeLine {
+    /// Pixel clock in kHz, matching `xXF86VidModeGetModeLineReply`.
+    pub dot_clock: u32,
+    pub hdisplay: u16,
+    pub hsync_start: u16,
+    pub hsync_end: u16,
+    pub htotal: u16,
+    pub hskew: u16,
+    pub vdisplay: u16,
+    pub vsync_start: u16,
+    pub vsync_end: u16,
+    pub vtotal: u16,
+    pub flags: u32,
+}
+
+#[must_use]
+pub fn parse_screen(body: &[u8]) -> Option<u16> {
+    (body.len() == 4).then(|| u16::from_le_bytes([body[0], body[1]]))
+}
+
+#[must_use]
+pub fn parse_client_version(body: &[u8]) -> Option<ClientVersion> {
+    (body.len() == 4).then(|| ClientVersion {
+        major: u16::from_le_bytes([body[0], body[1]]),
+        minor: u16::from_le_bytes([body[2], body[3]]),
+    })
+}
+
+fn reply_prefix(byte_order: ClientByteOrder, sequence: SequenceNumber, length: u32) -> Vec<u8> {
+    let mut out = Vec::with_capacity(52);
+    out.push(1);
+    out.push(0);
+    write_u16(byte_order, &mut out, sequence.0);
+    write_u32(byte_order, &mut out, length);
+    out
+}
+
+#[must_use]
+pub fn encode_query_version_reply(
+    byte_order: ClientByteOrder,
+    sequence: SequenceNumber,
+) -> Vec<u8> {
+    let mut out = reply_prefix(byte_order, sequence, 0);
+    write_u16(byte_order, &mut out, MAJOR_VERSION);
+    write_u16(byte_order, &mut out, MINOR_VERSION);
+    out.resize(32, 0);
+    out
+}
+
+/// Encode Xorg's v2 (52-byte) or legacy v0/v1 (36-byte) GetModeLine reply.
+#[must_use]
+pub fn encode_get_mode_line_reply(
+    byte_order: ClientByteOrder,
+    sequence: SequenceNumber,
+    mode: ModeLine,
+    version_2: bool,
+) -> Vec<u8> {
+    let mut out = reply_prefix(byte_order, sequence, if version_2 { 5 } else { 1 });
+    write_u32(byte_order, &mut out, mode.dot_clock);
+    write_u16(byte_order, &mut out, mode.hdisplay);
+    write_u16(byte_order, &mut out, mode.hsync_start);
+    write_u16(byte_order, &mut out, mode.hsync_end);
+    write_u16(byte_order, &mut out, mode.htotal);
+    if version_2 {
+        write_u16(byte_order, &mut out, mode.hskew);
+    }
+    write_u16(byte_order, &mut out, mode.vdisplay);
+    write_u16(byte_order, &mut out, mode.vsync_start);
+    write_u16(byte_order, &mut out, mode.vsync_end);
+    write_u16(byte_order, &mut out, mode.vtotal);
+    if version_2 {
+        write_u16(byte_order, &mut out, 0);
+    }
+    write_u32(byte_order, &mut out, mode.flags);
+    if version_2 {
+        write_u32(byte_order, &mut out, 0);
+        write_u32(byte_order, &mut out, 0);
+        write_u32(byte_order, &mut out, 0);
+    }
+    // Xorg pretends that no server-private mode data exists.
+    write_u32(byte_order, &mut out, 0);
+    debug_assert_eq!(out.len(), if version_2 { 52 } else { 36 });
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> ModeLine {
+        ModeLine {
+            dot_clock: 241_500,
+            hdisplay: 2560,
+            hsync_start: 2608,
+            hsync_end: 2640,
+            htotal: 2720,
+            hskew: 0,
+            vdisplay: 1440,
+            vsync_start: 1443,
+            vsync_end: 1448,
+            vtotal: 1481,
+            flags: 5,
+        }
+    }
+
+    #[test]
+    fn query_version_reply_matches_v2_2_wire_layout() {
+        let reply =
+            encode_query_version_reply(ClientByteOrder::LittleEndian, SequenceNumber(0x1234));
+        assert_eq!(reply.len(), 32);
+        assert_eq!(&reply[0..8], &[1, 0, 0x34, 0x12, 0, 0, 0, 0]);
+        assert_eq!(&reply[8..12], &[2, 0, 2, 0]);
+    }
+
+    #[test]
+    fn mode_line_v2_reply_matches_xf86vmproto_layout() {
+        let reply = encode_get_mode_line_reply(
+            ClientByteOrder::LittleEndian,
+            SequenceNumber(9),
+            fixture(),
+            true,
+        );
+        assert_eq!(reply.len(), 52);
+        assert_eq!(u32::from_le_bytes(reply[4..8].try_into().unwrap()), 5);
+        assert_eq!(
+            u32::from_le_bytes(reply[8..12].try_into().unwrap()),
+            241_500
+        );
+        assert_eq!(u16::from_le_bytes(reply[12..14].try_into().unwrap()), 2560);
+        assert_eq!(u16::from_le_bytes(reply[18..20].try_into().unwrap()), 2720);
+        assert_eq!(u16::from_le_bytes(reply[22..24].try_into().unwrap()), 1440);
+        assert_eq!(u16::from_le_bytes(reply[28..30].try_into().unwrap()), 1481);
+        assert_eq!(u32::from_le_bytes(reply[32..36].try_into().unwrap()), 5);
+        assert_eq!(&reply[36..52], &[0; 16]);
+    }
+
+    #[test]
+    fn legacy_mode_line_reply_omits_hskew_and_reserved_fields() {
+        let reply = encode_get_mode_line_reply(
+            ClientByteOrder::LittleEndian,
+            SequenceNumber(9),
+            fixture(),
+            false,
+        );
+        assert_eq!(reply.len(), 36);
+        assert_eq!(u32::from_le_bytes(reply[4..8].try_into().unwrap()), 1);
+        assert_eq!(u16::from_le_bytes(reply[20..22].try_into().unwrap()), 1440);
+        assert_eq!(u32::from_le_bytes(reply[28..32].try_into().unwrap()), 5);
+        assert_eq!(&reply[32..36], &[0; 4]);
+    }
+
+    #[test]
+    fn big_endian_reply_swaps_every_multibyte_field() {
+        let reply = encode_get_mode_line_reply(
+            ClientByteOrder::BigEndian,
+            SequenceNumber(0x1234),
+            fixture(),
+            true,
+        );
+        assert_eq!(&reply[2..4], &[0x12, 0x34]);
+        assert_eq!(&reply[4..8], &[0, 0, 0, 5]);
+        assert_eq!(&reply[8..12], &241_500_u32.to_be_bytes());
+        assert_eq!(&reply[12..14], &2560_u16.to_be_bytes());
+        assert_eq!(&reply[28..30], &1481_u16.to_be_bytes());
+        assert_eq!(&reply[32..36], &5_u32.to_be_bytes());
+    }
+
+    #[test]
+    fn request_parsers_require_exact_bodies() {
+        assert_eq!(parse_screen(&[0, 0, 0, 0]), Some(0));
+        assert_eq!(
+            parse_client_version(&[2, 0, 1, 0]),
+            Some(ClientVersion { major: 2, minor: 1 })
+        );
+        assert_eq!(parse_screen(&[0, 0]), None);
+        assert_eq!(parse_client_version(&[2, 0, 1, 0, 0]), None);
+    }
+}

--- a/crates/yserver-protocol/src/x11/xf86vidmode.rs
+++ b/crates/yserver-protocol/src/x11/xf86vidmode.rs
@@ -23,7 +23,7 @@
 
 use super::{
     ClientByteOrder, SequenceNumber,
-    wire::{pad_vec4, read_u32, write_u16, write_u32},
+    wire::{pad_vec4, read_u16, read_u32, write_u16, write_u32},
 };
 
 pub const MAJOR_VERSION: u16 = 2;
@@ -55,6 +55,8 @@ pub const GET_PERMISSIONS: u8 = 20;
 pub const CLIENT_NOT_LOCAL: u8 = 5;
 /// Xorg `ModeStatus::MODE_OK`.
 pub const MODE_OK: u32 = 0;
+/// Xorg `ModeStatus::MODE_BAD` (`-2` on the CARD32 wire).
+pub const MODE_BAD: u32 = 0xffff_fffe;
 /// Xorg's `CLKFLAG_PROGRAMABLE` (historical spelling).
 pub const CLOCK_FLAG_PROGRAMMABLE: u32 = 1;
 /// Xorg's fixed upper bound for a legacy hardware clock table.
@@ -74,6 +76,12 @@ pub struct ClientVersion {
 pub struct GammaRampRequest {
     pub screen: u16,
     pub size: u16,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ValidateModeLineRequest {
+    pub screen: u32,
+    pub mode: ModeLine,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -119,19 +127,18 @@ pub fn parse_gamma_ramp_request(body: &[u8]) -> Option<GammaRampRequest> {
     })
 }
 
-/// Validate the version-dependent `ValidateModeLine` size and return its
-/// screen number.
+/// Parse the version-dependent `ValidateModeLine` request.
 ///
 /// The fixed request is 52 bytes for protocol v2 and 36 bytes for the legacy
 /// layout, including the 4-byte X request header. `privsize` counts trailing
 /// `CARD32`s. Unlike other parsers, `body` has deliberately not passed through
 /// the generic byte-swap table; see the module-level note.
 #[must_use]
-pub fn parse_validate_mode_line_screen(
+pub fn parse_validate_mode_line_request(
     byte_order: ClientByteOrder,
     body: &[u8],
     version_2: bool,
-) -> Option<u32> {
+) -> Option<ValidateModeLineRequest> {
     let (fixed_body_len, privsize_offset) = if version_2 { (48, 44) } else { (32, 28) };
     if body.len() < fixed_body_len {
         return None;
@@ -142,7 +149,31 @@ pub fn parse_validate_mode_line_screen(
     ))
     .ok()?;
     let expected_len = fixed_body_len.checked_add(privsize.checked_mul(4)?)?;
-    (body.len() == expected_len).then(|| read_u32(byte_order, body))
+    if body.len() != expected_len {
+        return None;
+    }
+
+    let mode = ModeLine {
+        dot_clock: read_u32(byte_order, &body[4..8]),
+        hdisplay: read_u16(byte_order, &body[8..10]),
+        hsync_start: read_u16(byte_order, &body[10..12]),
+        hsync_end: read_u16(byte_order, &body[12..14]),
+        htotal: read_u16(byte_order, &body[14..16]),
+        hskew: if version_2 {
+            read_u16(byte_order, &body[16..18])
+        } else {
+            0
+        },
+        vdisplay: read_u16(byte_order, &body[if version_2 { 18..20 } else { 16..18 }]),
+        vsync_start: read_u16(byte_order, &body[if version_2 { 20..22 } else { 18..20 }]),
+        vsync_end: read_u16(byte_order, &body[if version_2 { 22..24 } else { 20..22 }]),
+        vtotal: read_u16(byte_order, &body[if version_2 { 24..26 } else { 22..24 }]),
+        flags: read_u32(byte_order, &body[if version_2 { 28..32 } else { 24..28 }]),
+    };
+    Some(ValidateModeLineRequest {
+        screen: read_u32(byte_order, body),
+        mode,
+    })
 }
 
 fn reply_prefix(byte_order: ClientByteOrder, sequence: SequenceNumber, length: u32) -> Vec<u8> {
@@ -650,11 +681,26 @@ mod tests {
         legacy_validate[0..4].copy_from_slice(&1u32.to_be_bytes());
         legacy_validate[28..32].copy_from_slice(&1u32.to_be_bytes());
         assert_eq!(
-            parse_validate_mode_line_screen(ClientByteOrder::BigEndian, &legacy_validate, false),
-            Some(1)
+            parse_validate_mode_line_request(ClientByteOrder::BigEndian, &legacy_validate, false),
+            Some(ValidateModeLineRequest {
+                screen: 1,
+                mode: ModeLine {
+                    dot_clock: 0,
+                    hdisplay: 0,
+                    hsync_start: 0,
+                    hsync_end: 0,
+                    htotal: 0,
+                    hskew: 0,
+                    vdisplay: 0,
+                    vsync_start: 0,
+                    vsync_end: 0,
+                    vtotal: 0,
+                    flags: 0,
+                },
+            })
         );
         assert_eq!(
-            parse_validate_mode_line_screen(
+            parse_validate_mode_line_request(
                 ClientByteOrder::BigEndian,
                 &legacy_validate[..32],
                 false
@@ -666,8 +712,23 @@ mod tests {
         let mut v2_validate = [0u8; 48];
         v2_validate[0..4].copy_from_slice(&0u32.to_le_bytes());
         assert_eq!(
-            parse_validate_mode_line_screen(ClientByteOrder::LittleEndian, &v2_validate, true),
-            Some(0)
+            parse_validate_mode_line_request(ClientByteOrder::LittleEndian, &v2_validate, true),
+            Some(ValidateModeLineRequest {
+                screen: 0,
+                mode: ModeLine {
+                    dot_clock: 0,
+                    hdisplay: 0,
+                    hsync_start: 0,
+                    hsync_end: 0,
+                    htotal: 0,
+                    hskew: 0,
+                    vdisplay: 0,
+                    vsync_start: 0,
+                    vsync_end: 0,
+                    vtotal: 0,
+                    flags: 0,
+                },
+            })
         );
     }
 }

--- a/crates/yserver-protocol/src/x11/xf86vidmode.rs
+++ b/crates/yserver-protocol/src/x11/xf86vidmode.rs
@@ -1,4 +1,4 @@
-//! Minimal read-only XFree86-VidModeExtension protocol surface.
+//! Read-only XFree86-VidModeExtension protocol surface.
 //!
 //! Mesa implements `glXGetMscRateOML` entirely client-side. It obtains the
 //! active mode timing through `XF86VidModeQueryVersion` followed by
@@ -7,21 +7,23 @@
 //! requests plus `SetClientVersion`, which selects the legacy or v2 reply
 //! layout exactly as Xorg does.
 //!
-//! `GetAllModeLines`, `GetGammaRampSize` and `GetPermissions` round the
-//! surface out so that a client probing VidMode for something other than
-//! the MSC rate gets an honest read-only answer (one mode, no gamma ramp,
-//! no write permission) instead of a `BadRequest` it did not expect from an
-//! extension it just saw advertised. Every other request — mode setting,
-//! gamma, viewport and the remaining monitor/dot-clock queries — stays
-//! unimplemented.
+//! Xorg serves VidMode's read requests even to clients without mode-setting
+//! permission. Yserver mirrors that read surface from the selected RANDR
+//! output: one active mode, monitor/timing information, viewport `(0, 0)`,
+//! and the same gamma ramp exposed through RANDR. Mode-setting and gamma
+//! writes remain disabled; the core dispatcher rejects them with VidMode's
+//! `ClientNotLocal` error, matching the read-only permission model.
 //!
 //! Request bodies reach the parsers here already in host byte order —
 //! `request_swap` has swapped them for a big-endian client — so the
-//! `parse_*` helpers read little-endian unconditionally.
+//! ordinary `parse_*` helpers read little-endian unconditionally.
+//! `ValidateModeLine` is the exception: its legacy/v2 layout depends on
+//! per-client state unavailable to the generic swap table, so its parser
+//! reads the original client byte order explicitly.
 
 use super::{
     ClientByteOrder, SequenceNumber,
-    wire::{write_u16, write_u32},
+    wire::{pad_vec4, read_u32, write_u16, write_u32},
 };
 
 pub const MAJOR_VERSION: u16 = 2;
@@ -29,10 +31,30 @@ pub const MINOR_VERSION: u16 = 2;
 
 pub const QUERY_VERSION: u8 = 0;
 pub const GET_MODE_LINE: u8 = 1;
+pub const MOD_MODE_LINE: u8 = 2;
+pub const SWITCH_MODE: u8 = 3;
+pub const GET_MONITOR: u8 = 4;
+pub const LOCK_MODE_SWITCH: u8 = 5;
 pub const GET_ALL_MODE_LINES: u8 = 6;
+pub const ADD_MODE_LINE: u8 = 7;
+pub const DELETE_MODE_LINE: u8 = 8;
+pub const VALIDATE_MODE_LINE: u8 = 9;
+pub const SWITCH_TO_MODE: u8 = 10;
+pub const GET_VIEW_PORT: u8 = 11;
+pub const SET_VIEW_PORT: u8 = 12;
+pub const GET_DOT_CLOCKS: u8 = 13;
 pub const SET_CLIENT_VERSION: u8 = 14;
+pub const SET_GAMMA: u8 = 15;
+pub const GET_GAMMA: u8 = 16;
+pub const GET_GAMMA_RAMP: u8 = 17;
+pub const SET_GAMMA_RAMP: u8 = 18;
 pub const GET_GAMMA_RAMP_SIZE: u8 = 19;
 pub const GET_PERMISSIONS: u8 = 20;
+
+/// Relative extension error used by Xorg's non-local write gate.
+pub const CLIENT_NOT_LOCAL: u8 = 5;
+/// Xorg `ModeStatus::MODE_OK`.
+pub const MODE_OK: u32 = 0;
 
 /// `XF86VM_READ_PERMISSION`. Yserver never grants
 /// `XF86VM_WRITE_PERMISSION` (2): no VidMode mode-setting request exists.
@@ -42,6 +64,12 @@ pub const PERMISSION_READ: u32 = 1;
 pub struct ClientVersion {
     pub major: u16,
     pub minor: u16,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GammaRampRequest {
+    pub screen: u16,
+    pub size: u16,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -73,12 +101,143 @@ pub fn parse_client_version(body: &[u8]) -> Option<ClientVersion> {
     })
 }
 
+/// Parse `GetGamma`, whose historical request is padded to 32 bytes.
+#[must_use]
+pub fn parse_gamma_screen(body: &[u8]) -> Option<u16> {
+    (body.len() == 28).then(|| u16::from_le_bytes([body[0], body[1]]))
+}
+
+#[must_use]
+pub fn parse_gamma_ramp_request(body: &[u8]) -> Option<GammaRampRequest> {
+    (body.len() == 4).then(|| GammaRampRequest {
+        screen: u16::from_le_bytes([body[0], body[1]]),
+        size: u16::from_le_bytes([body[2], body[3]]),
+    })
+}
+
+/// Validate the version-dependent `ValidateModeLine` size and return its
+/// screen number.
+///
+/// The fixed request is 52 bytes for protocol v2 and 36 bytes for the legacy
+/// layout, including the 4-byte X request header. `privsize` counts trailing
+/// `CARD32`s. Unlike other parsers, `body` has deliberately not passed through
+/// the generic byte-swap table; see the module-level note.
+#[must_use]
+pub fn parse_validate_mode_line_screen(
+    byte_order: ClientByteOrder,
+    body: &[u8],
+    version_2: bool,
+) -> Option<u32> {
+    let (fixed_body_len, privsize_offset) = if version_2 { (48, 44) } else { (32, 28) };
+    if body.len() < fixed_body_len {
+        return None;
+    }
+    let privsize = usize::try_from(read_u32(
+        byte_order,
+        body.get(privsize_offset..privsize_offset + 4)?,
+    ))
+    .ok()?;
+    let expected_len = fixed_body_len.checked_add(privsize.checked_mul(4)?)?;
+    (body.len() == expected_len).then(|| read_u32(byte_order, body))
+}
+
 fn reply_prefix(byte_order: ClientByteOrder, sequence: SequenceNumber, length: u32) -> Vec<u8> {
     let mut out = Vec::with_capacity(32 + 4 * length as usize);
     out.push(1);
     out.push(0);
     write_u16(byte_order, &mut out, sequence.0);
     write_u32(byte_order, &mut out, length);
+    out
+}
+
+#[must_use]
+pub fn encode_validate_mode_line_reply(
+    byte_order: ClientByteOrder,
+    sequence: SequenceNumber,
+    status: u32,
+) -> Vec<u8> {
+    encode_u32_reply(byte_order, sequence, status)
+}
+
+/// Encode `GetMonitor`: sync ranges precede individually padded vendor and
+/// model strings, as consumed by libXxf86vm's `_XReadPad` calls.
+#[must_use]
+pub fn encode_get_monitor_reply(
+    byte_order: ClientByteOrder,
+    sequence: SequenceNumber,
+    vendor: &[u8],
+    model: &[u8],
+    hsync_ranges: &[u32],
+    vsync_ranges: &[u32],
+) -> Vec<u8> {
+    let vendor = &vendor[..vendor.len().min(usize::from(u8::MAX))];
+    let model = &model[..model.len().min(usize::from(u8::MAX))];
+    let hsync_ranges = &hsync_ranges[..hsync_ranges.len().min(usize::from(u8::MAX))];
+    let vsync_ranges = &vsync_ranges[..vsync_ranges.len().min(usize::from(u8::MAX))];
+    let payload_len = (hsync_ranges.len() + vsync_ranges.len()) * 4
+        + vendor.len().next_multiple_of(4)
+        + model.len().next_multiple_of(4);
+    let length = u32::try_from(payload_len / 4).unwrap_or(u32::MAX);
+    let mut out = reply_prefix(byte_order, sequence, length);
+    out.push(u8::try_from(vendor.len()).unwrap_or(u8::MAX));
+    out.push(u8::try_from(model.len()).unwrap_or(u8::MAX));
+    out.push(u8::try_from(hsync_ranges.len()).unwrap_or(u8::MAX));
+    out.push(u8::try_from(vsync_ranges.len()).unwrap_or(u8::MAX));
+    out.resize(32, 0);
+    for &range in hsync_ranges.iter().chain(vsync_ranges) {
+        write_u32(byte_order, &mut out, range);
+    }
+    out.extend_from_slice(vendor);
+    pad_vec4(&mut out);
+    out.extend_from_slice(model);
+    pad_vec4(&mut out);
+    debug_assert_eq!(out.len(), 32 + payload_len);
+    out
+}
+
+#[must_use]
+pub fn encode_get_view_port_reply(
+    byte_order: ClientByteOrder,
+    sequence: SequenceNumber,
+    x: u32,
+    y: u32,
+) -> Vec<u8> {
+    let mut out = reply_prefix(byte_order, sequence, 0);
+    write_u32(byte_order, &mut out, x);
+    write_u32(byte_order, &mut out, y);
+    out.resize(32, 0);
+    out
+}
+
+/// Encode one or more fixed clocks in kHz. Yserver reports only its selected
+/// output's active clock, so `maxclocks` truthfully equals the returned count.
+#[must_use]
+pub fn encode_get_dot_clocks_reply(
+    byte_order: ClientByteOrder,
+    sequence: SequenceNumber,
+    clocks: &[u32],
+) -> Vec<u8> {
+    let count = u32::try_from(clocks.len()).unwrap_or(u32::MAX);
+    let mut out = reply_prefix(byte_order, sequence, count);
+    write_u32(byte_order, &mut out, 0); // flags: fixed, not programmable
+    write_u32(byte_order, &mut out, count);
+    write_u32(byte_order, &mut out, count); // maxclocks
+    out.resize(32, 0);
+    for &clock in clocks {
+        write_u32(byte_order, &mut out, clock);
+    }
+    out
+}
+
+/// `GetGamma` reports per-screen scalar values, not the CRTC LUT. Because
+/// yserver rejects `SetGamma`, the state remains Xorg's identity default.
+#[must_use]
+pub fn encode_get_gamma_reply(byte_order: ClientByteOrder, sequence: SequenceNumber) -> Vec<u8> {
+    let mut out = reply_prefix(byte_order, sequence, 0);
+    for _ in 0..3 {
+        write_u32(byte_order, &mut out, 10_000); // 1.0 * 10000
+    }
+    out.resize(32, 0);
     out
 }
 
@@ -187,18 +346,46 @@ pub fn encode_get_all_mode_lines_reply(
     out
 }
 
-/// Encode `GetGammaRampSize`. Yserver implements no gamma ramp, and Xorg
-/// reports size 0 for a screen without one; `XF86VidModeGetGammaRampSize`
-/// hands that straight to the caller, which is the documented way for a
-/// client to learn the ramp is unavailable.
+/// Encode the selected output's real RANDR/CRTC gamma-ramp size.
 #[must_use]
 pub fn encode_get_gamma_ramp_size_reply(
     byte_order: ClientByteOrder,
     sequence: SequenceNumber,
+    size: u16,
 ) -> Vec<u8> {
     let mut out = reply_prefix(byte_order, sequence, 0);
-    write_u16(byte_order, &mut out, 0); // size
+    write_u16(byte_order, &mut out, size);
     out.resize(32, 0);
+    out
+}
+
+/// Encode `GetGammaRamp` using Xorg's per-channel even-`CARD16` stride.
+#[must_use]
+pub fn encode_get_gamma_ramp_reply(
+    byte_order: ClientByteOrder,
+    sequence: SequenceNumber,
+    red: &[u16],
+    green: &[u16],
+    blue: &[u16],
+) -> Vec<u8> {
+    debug_assert_eq!(red.len(), green.len());
+    debug_assert_eq!(red.len(), blue.len());
+    let size = u16::try_from(red.len()).unwrap_or(u16::MAX);
+    let padded_entries = red.len().next_multiple_of(2);
+    let payload_len = padded_entries.saturating_mul(3).saturating_mul(2);
+    let length = u32::try_from(payload_len / 4).unwrap_or(u32::MAX);
+    let mut out = reply_prefix(byte_order, sequence, length);
+    write_u16(byte_order, &mut out, size);
+    out.resize(32, 0);
+    for channel in [red, green, blue] {
+        for &entry in channel {
+            write_u16(byte_order, &mut out, entry);
+        }
+        if channel.len() != padded_entries {
+            write_u16(byte_order, &mut out, 0);
+        }
+    }
+    debug_assert_eq!(out.len(), 32 + payload_len);
     out
 }
 
@@ -370,13 +557,71 @@ mod tests {
     }
 
     #[test]
-    fn gamma_ramp_size_reply_reports_no_ramp() {
+    fn monitor_viewport_dotclock_and_gamma_replies_match_wire_layouts() {
+        let monitor = encode_get_monitor_reply(
+            ClientByteOrder::LittleEndian,
+            SequenceNumber(3),
+            b"DEL",
+            b"U2723QE",
+            &[0x1234_1234],
+            &[0x5678_5678],
+        );
+        assert_eq!(monitor.len(), 52);
+        assert_eq!(u32::from_le_bytes(monitor[4..8].try_into().unwrap()), 5);
+        assert_eq!(&monitor[8..12], &[3, 7, 1, 1]);
+        assert_eq!(&monitor[32..36], &0x1234_1234_u32.to_le_bytes());
+        assert_eq!(&monitor[36..40], &0x5678_5678_u32.to_le_bytes());
+        assert_eq!(&monitor[40..44], b"DEL\0");
+        assert_eq!(&monitor[44..52], b"U2723QE\0");
+
+        let viewport =
+            encode_get_view_port_reply(ClientByteOrder::LittleEndian, SequenceNumber(4), 0, 0);
+        assert_eq!(viewport.len(), 32);
+        assert_eq!(&viewport[8..16], &[0; 8]);
+
+        let clocks = encode_get_dot_clocks_reply(
+            ClientByteOrder::LittleEndian,
+            SequenceNumber(5),
+            &[241_500],
+        );
+        assert_eq!(clocks.len(), 36);
+        assert_eq!(u32::from_le_bytes(clocks[4..8].try_into().unwrap()), 1);
+        assert_eq!(u32::from_le_bytes(clocks[8..12].try_into().unwrap()), 0);
+        assert_eq!(u32::from_le_bytes(clocks[12..16].try_into().unwrap()), 1);
+        assert_eq!(u32::from_le_bytes(clocks[16..20].try_into().unwrap()), 1);
+        assert_eq!(
+            u32::from_le_bytes(clocks[32..36].try_into().unwrap()),
+            241_500
+        );
+
+        let gamma = encode_get_gamma_reply(ClientByteOrder::LittleEndian, SequenceNumber(6));
+        assert_eq!(gamma.len(), 32);
+        assert_eq!(&gamma[8..20], &[0x10, 0x27, 0, 0].repeat(3));
+    }
+
+    #[test]
+    fn gamma_ramp_replies_report_real_size_and_xorg_channel_padding() {
         let reply =
-            encode_get_gamma_ramp_size_reply(ClientByteOrder::LittleEndian, SequenceNumber(3));
+            encode_get_gamma_ramp_size_reply(ClientByteOrder::LittleEndian, SequenceNumber(3), 256);
         assert_eq!(reply.len(), 32);
         assert_eq!(u32::from_le_bytes(reply[4..8].try_into().unwrap()), 0);
-        assert_eq!(u16::from_le_bytes(reply[8..10].try_into().unwrap()), 0);
+        assert_eq!(u16::from_le_bytes(reply[8..10].try_into().unwrap()), 256);
         assert_eq!(&reply[10..32], &[0; 22]);
+
+        let ramp = encode_get_gamma_ramp_reply(
+            ClientByteOrder::LittleEndian,
+            SequenceNumber(4),
+            &[1, 2, 3],
+            &[4, 5, 6],
+            &[7, 8, 9],
+        );
+        // Each odd-sized channel has one CARD16 of padding: 4 * 2 * 3 bytes.
+        assert_eq!(ramp.len(), 56);
+        assert_eq!(u32::from_le_bytes(ramp[4..8].try_into().unwrap()), 6);
+        assert_eq!(u16::from_le_bytes(ramp[8..10].try_into().unwrap()), 3);
+        assert_eq!(&ramp[32..40], &[1, 0, 2, 0, 3, 0, 0, 0]);
+        assert_eq!(&ramp[40..48], &[4, 0, 5, 0, 6, 0, 0, 0]);
+        assert_eq!(&ramp[48..56], &[7, 0, 8, 0, 9, 0, 0, 0]);
     }
 
     #[test]
@@ -388,5 +633,41 @@ mod tests {
         );
         assert_eq!(parse_screen(&[0, 0]), None);
         assert_eq!(parse_client_version(&[2, 0, 1, 0, 0]), None);
+
+        let mut gamma = [0u8; 28];
+        gamma[0..2].copy_from_slice(&1u16.to_le_bytes());
+        assert_eq!(parse_gamma_screen(&gamma), Some(1));
+        assert_eq!(parse_gamma_screen(&gamma[..4]), None);
+        assert_eq!(
+            parse_gamma_ramp_request(&[0, 0, 0, 1]),
+            Some(GammaRampRequest {
+                screen: 0,
+                size: 256
+            })
+        );
+
+        let mut legacy_validate = [0u8; 36];
+        legacy_validate[0..4].copy_from_slice(&1u32.to_be_bytes());
+        legacy_validate[28..32].copy_from_slice(&1u32.to_be_bytes());
+        assert_eq!(
+            parse_validate_mode_line_screen(ClientByteOrder::BigEndian, &legacy_validate, false),
+            Some(1)
+        );
+        assert_eq!(
+            parse_validate_mode_line_screen(
+                ClientByteOrder::BigEndian,
+                &legacy_validate[..32],
+                false
+            ),
+            None,
+            "privsize=1 requires one trailing CARD32"
+        );
+
+        let mut v2_validate = [0u8; 48];
+        v2_validate[0..4].copy_from_slice(&0u32.to_le_bytes());
+        assert_eq!(
+            parse_validate_mode_line_screen(ClientByteOrder::LittleEndian, &v2_validate, true),
+            Some(0)
+        );
     }
 }

--- a/docs/status.md
+++ b/docs/status.md
@@ -87,9 +87,11 @@ lives in [`code-quality-audit-2026-07-26.md`](code-quality-audit-2026-07-26.md).
   same selected active output and effective DRM/RANDR timing; `GetMonitor`
   also uses its EDID identity when available. `GetDotClocks` mirrors Xorg's
   KMS modesetting driver by advertising a programmable clock rather than a
-  legacy fixed-clock table. VidMode gamma-ramp reads resolve the same
-  connector and backend LUT as RANDR, while the independent per-screen
-  `GetGamma` scalar stays at the unmodified Xorg default of 1.0.
+  legacy fixed-clock table. `ValidateModeLine` returns `MODE_OK` only for that
+  advertised active timing and `MODE_BAD` for invalid or other modes. VidMode
+  gamma-ramp reads resolve the same connector and backend LUT as RANDR, while
+  the independent per-screen `GetGamma` scalar stays at the unmodified Xorg
+  default of 1.0.
   RANDR remains the only display-configuration interface:
   `GetPermissions` reports `XF86VM_READ_PERMISSION` without WRITE, and every
   known mode/gamma write returns VidMode `ClientNotLocal`, matching Xorg's

--- a/docs/status.md
+++ b/docs/status.md
@@ -73,6 +73,22 @@ lives in [`code-quality-audit-2026-07-26.md`](code-quality-audit-2026-07-26.md).
   rather than completion-clock provenance, as the playback cause on
   bee/Plasma. Design:
   [`2026-07-28-present-completion-clock-provenance-design.md`](superpowers/specs/2026-07-28-present-completion-clock-provenance-design.md).
+- **2026-07-28 Flatpak/ANGLE `GLX_OML_sync_control`:** session logs showed
+  `eglGetMscRateANGLE` failing specifically because Mesa's
+  `glXGetMscRateOML()` could not query the missing
+  `XFree86-VidModeExtension`. Mesa performs this operation client-side rather
+  than through a GLX vendor-private request. Yserver now advertises a
+  read-only, Xorg-compatible VidMode 2.2 surface: `QueryVersion`,
+  `GetModeLine`, and `SetClientVersion`, including legacy/v2 reply layouts,
+  swapped-client request handling, screen validation, and per-client version
+  lifetime. `GetModeLine` returns the selected active output's real DRM/RANDR
+  pixel clock, totals, sync ranges, and flags, with the existing nested-mode
+  synthesis as fallback. Protocol encoders and end-to-end dispatcher
+  regressions cover both reply layouts and errors; legacy mode-setting
+  requests remain unsupported and return `BadRequest`.
+  Live validation against a freshly built ynest confirmed the advertised
+  opcode/error base, a valid `xvidtune -show` modeline, and a successful Mesa
+  `glXGetMscRateOML()` call returning the derived refresh fraction.
 - **2026-07-26 protocol silent-success audit:** the first two phases and the
   core-request classification portion of Phase 3 are complete on
   `quality/protocol-stub-audit`. Reserved/unknown major opcodes and unknown

--- a/docs/status.md
+++ b/docs/status.md
@@ -79,24 +79,30 @@ lives in [`code-quality-audit-2026-07-26.md`](code-quality-audit-2026-07-26.md).
   `XFree86-VidModeExtension`. Mesa performs this operation client-side rather
   than through a GLX vendor-private request. Yserver now advertises a
   read-only, Xorg-compatible VidMode 2.2 surface: `QueryVersion`,
-  `GetModeLine`, and `SetClientVersion`, including legacy/v2 reply layouts,
-  swapped-client request handling, screen validation, and per-client version
-  lifetime. `GetModeLine` returns the selected active output's real DRM/RANDR
-  pixel clock, totals, sync ranges, and flags, with the existing nested-mode
-  synthesis as fallback. Because advertising the extension makes non-Mesa
-  clients take the VidMode path, the read-only stubs `GetAllModeLines` (the
-  single active mode), `GetGammaRampSize` (0) and `GetPermissions`
-  (`XF86VM_READ_PERMISSION` only) are answered as well, so such a client gets
-  an honest "no" instead of a `BadRequest` it never expected. Every other
-  minor — mode setting, gamma, viewport and the remaining monitor/dot-clock
-  queries — stays unimplemented and returns `BadRequest`, which a regression
-  asserts opcode by opcode.
+  `SetClientVersion`, `GetModeLine`, `GetMonitor`, `GetAllModeLines`,
+  `ValidateModeLine`, `GetViewPort`, `GetDotClocks`, `GetGamma`,
+  `GetGammaRamp`, `GetGammaRampSize` and `GetPermissions`, including
+  legacy/v2 reply layouts, swapped-client request handling, screen validation,
+  and per-client version lifetime. The mode, monitor ranges and dot clock all
+  come from the same selected active output and effective DRM/RANDR timing;
+  `GetMonitor` also uses its EDID identity when available. VidMode gamma-ramp
+  reads resolve the same connector and backend LUT as RANDR, while the
+  independent per-screen `GetGamma` scalar stays at the unmodified Xorg
+  default of 1.0.
+  RANDR remains the only display-configuration interface:
+  `GetPermissions` reports `XF86VM_READ_PERMISSION` without WRITE, and every
+  known mode/gamma write returns VidMode `ClientNotLocal`, matching Xorg's
+  coherent non-local/read-only branch instead of returning `BadRequest`.
+  Yserver is Unix-socket-only, so this deliberately applies a read-only product
+  policy to physically local clients rather than fully emulating Xorg's local
+  WRITE permission.
   RANDR's `ModeInfo` and VidMode's mode line now resolve their blanking
   through one shared `EffectiveTiming` helper, so the two extensions cannot
   drift into describing the same hardware mode differently. Protocol encoders
-  and end-to-end dispatcher regressions cover both reply layouts, the
-  `BadLength`/`BadValue`/`BadRequest` paths, big-endian clients, and
-  per-client version cleanup on disconnect.
+  and end-to-end dispatcher regressions cover both mode layouts, every read
+  family, real gamma data, `ClientNotLocal`, the
+  `BadLength`/`BadValue`/`BadRequest` paths, big-endian clients, and per-client
+  version cleanup on disconnect.
   Live validation against a freshly built ynest confirmed the advertised
   opcode/error base, a valid `xvidtune -show` modeline, and a successful Mesa
   `glXGetMscRateOML()` call returning the derived refresh fraction.

--- a/docs/status.md
+++ b/docs/status.md
@@ -83,9 +83,20 @@ lives in [`code-quality-audit-2026-07-26.md`](code-quality-audit-2026-07-26.md).
   swapped-client request handling, screen validation, and per-client version
   lifetime. `GetModeLine` returns the selected active output's real DRM/RANDR
   pixel clock, totals, sync ranges, and flags, with the existing nested-mode
-  synthesis as fallback. Protocol encoders and end-to-end dispatcher
-  regressions cover both reply layouts and errors; legacy mode-setting
-  requests remain unsupported and return `BadRequest`.
+  synthesis as fallback. Because advertising the extension makes non-Mesa
+  clients take the VidMode path, the read-only stubs `GetAllModeLines` (the
+  single active mode), `GetGammaRampSize` (0) and `GetPermissions`
+  (`XF86VM_READ_PERMISSION` only) are answered as well, so such a client gets
+  an honest "no" instead of a `BadRequest` it never expected. Every other
+  minor — mode setting, gamma, viewport and the remaining monitor/dot-clock
+  queries — stays unimplemented and returns `BadRequest`, which a regression
+  asserts opcode by opcode.
+  RANDR's `ModeInfo` and VidMode's mode line now resolve their blanking
+  through one shared `EffectiveTiming` helper, so the two extensions cannot
+  drift into describing the same hardware mode differently. Protocol encoders
+  and end-to-end dispatcher regressions cover both reply layouts, the
+  `BadLength`/`BadValue`/`BadRequest` paths, big-endian clients, and
+  per-client version cleanup on disconnect.
   Live validation against a freshly built ynest confirmed the advertised
   opcode/error base, a valid `xvidtune -show` modeline, and a successful Mesa
   `glXGetMscRateOML()` call returning the derived refresh fraction.

--- a/docs/status.md
+++ b/docs/status.md
@@ -83,12 +83,13 @@ lives in [`code-quality-audit-2026-07-26.md`](code-quality-audit-2026-07-26.md).
   `ValidateModeLine`, `GetViewPort`, `GetDotClocks`, `GetGamma`,
   `GetGammaRamp`, `GetGammaRampSize` and `GetPermissions`, including
   legacy/v2 reply layouts, swapped-client request handling, screen validation,
-  and per-client version lifetime. The mode, monitor ranges and dot clock all
-  come from the same selected active output and effective DRM/RANDR timing;
-  `GetMonitor` also uses its EDID identity when available. VidMode gamma-ramp
-  reads resolve the same connector and backend LUT as RANDR, while the
-  independent per-screen `GetGamma` scalar stays at the unmodified Xorg
-  default of 1.0.
+  and per-client version lifetime. The mode and monitor ranges come from the
+  same selected active output and effective DRM/RANDR timing; `GetMonitor`
+  also uses its EDID identity when available. `GetDotClocks` mirrors Xorg's
+  KMS modesetting driver by advertising a programmable clock rather than a
+  legacy fixed-clock table. VidMode gamma-ramp reads resolve the same
+  connector and backend LUT as RANDR, while the independent per-screen
+  `GetGamma` scalar stays at the unmodified Xorg default of 1.0.
   RANDR remains the only display-configuration interface:
   `GetPermissions` reports `XF86VM_READ_PERMISSION` without WRITE, and every
   known mode/gamma write returns VidMode `ClientNotLocal`, matching Xorg's


### PR DESCRIPTION
## Why this is needed

A Flatpak application using ANGLE on yserver repeatedly logged:

```text
Xlib: extension "XFree86-VidModeExtension" missing on display ":7".
EGL Driver message (Error) eglGetMscRateANGLE: glXGetMscRateOML failed.
```

Mesa implements `glXGetMscRateOML()` entirely client-side. It calls
`XF86VidModeQueryVersion()` and `XF86VidModeGetModeLine()` to obtain the
current pixel clock and horizontal/vertical totals, then derives the
refresh-rate numerator and denominator required by `GLX_OML_sync_control`.
With VidMode absent, this path fails even though GLX and direct rendering
otherwise work.

Therefore this is not a new GLX wire request, and merely advertising an extra
GLX extension string would not fix the failure. Yserver must provide the
read-only VidMode protocol surface used by Mesa and other established clients.

## What changes

- advertise XFree86-VidMode 2.2 and implement its Xorg read surface:
  `QueryVersion`, `SetClientVersion`, `GetModeLine`, `GetMonitor`,
  `GetAllModeLines`, `ValidateModeLine`, `GetViewPort`, `GetDotClocks`,
  `GetGamma`, `GetGammaRamp`, `GetGammaRampSize`, and `GetPermissions`
- return the selected output's real DRM/RANDR pixel clock, totals, sync ranges,
  flags, monitor identity, and gamma LUT, using the same output/timing resolver
  as RANDR
- report `GetDotClocks` like Xorg's KMS modesetting driver: programmable-clock
  flag set, no legacy fixed-clock table, and `maxclocks = MAXCLOCKS` (128);
  the current mode's actual dot clock remains in `GetModeLine`
- parse the complete legacy/v2 `ValidateModeLine` request and return `MODE_OK`
  only for the active advertised timing, with `MODE_BAD` for invalid or other
  modes
- match Xorg's legacy/v2 wire layouts, errors, per-client version state,
  swapped-client handling, gamma channel padding, and reply-stream alignment
- keep VidMode read-only because RANDR owns display configuration:
  `GetPermissions` advertises READ only, known write minors return
  `ClientNotLocal`, and only unknown minors return `BadRequest`

## Testing

- `cargo +nightly fmt -- --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- protocol and core tests cover both legacy and v2 layouts, byte order,
  real RANDR timing/gamma data, the Xorg programmable-clock reply (including
  headless operation), read/write dispatch, and error behavior
- live ynest: `xdpyinfo` advertises VidMode and `xvidtune -show` returns the
  modeline
- direct Mesa probe: `glXGetMscRateOML()` succeeds and returns the derived
  refresh fraction
- live v2 stream probe: `GetAllModeLines` returns exactly a 32-byte reply plus
  one 48-byte `xXF86VidModeModeInfo` (`length = 12`), followed by a successful
  `GetInputFocus` round-trip on the same connection
