### PR TITLE
fix(shape): clip descendants to ancestor Bounding regions

### DIFF
--- a/crates/yserver-core/src/nested.rs
+++ b/crates/yserver-core/src/nested.rs
@@ -511,9 +511,12 @@ where
     Some(out)
 }
 
-pub(crate) fn normalize_region_rects(
-    mut rects: Vec<x11xfixes::RegionRect>,
-) -> Vec<x11xfixes::RegionRect> {
+/// Return the exact union of `rects` as sorted, non-overlapping YX bands.
+///
+/// Backends may call this at their storage boundary rather than relying on
+/// every `Backend` caller to preserve the core's region representation.
+#[must_use]
+pub fn normalize_region_rects(mut rects: Vec<x11xfixes::RegionRect>) -> Vec<x11xfixes::RegionRect> {
     rects.retain(|rect| !rect.is_empty());
     if rects.is_empty() {
         return rects;

--- a/crates/yserver/src/kms/render/backend.rs
+++ b/crates/yserver/src/kms/render/backend.rs
@@ -25247,10 +25247,17 @@ impl Backend for KmsBackend {
         // projection of the core resource tree. The `Option` preserves
         // the empty-vs-absent distinction (DRIFT 1): `None` removes the
         // entry (unset → full window / live geometry); `Some(rects)`
-        // stores the region verbatim, INCLUDING `Some([])` (explicit
-        // empty → click-through for input, drawn-as-nothing for bounding).
+        // stores the exact region, INCLUDING `Some([])` (explicit empty →
+        // click-through for input, drawn-as-nothing for bounding).
         // `cursor_inside_shape` and the scene's bounding clip already read
         // `Some([])` correctly; the old API deleted on empty and lost it.
+        //
+        // Canonicalize once at this backend boundary. Core protocol paths
+        // already provide normalized regions, but the Backend contract does
+        // not require that; keeping the KMS maps YX-banded lets scene
+        // intersection skip vertically-disjoint bands and guarantees that
+        // overlapping client rectangles never become overlapping SrcOver
+        // draws in a COW subtree.
         let dst = match kind {
             0 => &mut self.core.shape_bounding,
             1 => &mut self.core.shape_clip,
@@ -25265,7 +25272,10 @@ impl Backend for KmsBackend {
                 dst.remove(&host_xid);
             }
             Some(rects) => {
-                dst.insert(host_xid, rects.to_vec());
+                dst.insert(
+                    host_xid,
+                    yserver_core::nested::normalize_region_rects(rects.to_vec()),
+                );
             }
         }
         // Bounding (0) and clip (1) shapes change what the scene draws,
@@ -26087,6 +26097,7 @@ mod tests {
         core_loop::{CoreSender, Message},
         server::ServerState,
     };
+    use yserver_protocol::x11::xfixes::RegionRect;
 
     fn test_device_key(minor: u32) -> DrmDeviceKey {
         DrmDeviceKey { major: 226, minor }
@@ -26780,6 +26791,70 @@ mod tests {
             &mut state.randr,
         ));
         assert_eq!(state.randr.primary_output, output);
+    }
+
+    #[test]
+    fn set_shape_rectangles_canonicalizes_and_preserves_empty_presence() {
+        let mut backend = KmsBackend::for_tests();
+        let overlapping = [
+            RegionRect {
+                x: 0,
+                y: 0,
+                width: 10,
+                height: 10,
+            },
+            RegionRect {
+                x: 5,
+                y: 0,
+                width: 10,
+                height: 10,
+            },
+            RegionRect {
+                x: 0,
+                y: 0,
+                width: 10,
+                height: 10,
+            },
+        ];
+
+        backend
+            .set_shape_rectangles(None, 0x100, 0, Some(&overlapping))
+            .expect("store bounding shape");
+        let stored = backend
+            .core
+            .shape_bounding
+            .get(&0x100)
+            .expect("shape entry");
+        assert_eq!(
+            stored.as_slice(),
+            &[RegionRect {
+                x: 0,
+                y: 0,
+                width: 15,
+                height: 10,
+            }],
+            "the KMS storage boundary must merge overlaps and duplicates",
+        );
+
+        backend
+            .set_shape_rectangles(None, 0x100, 0, Some(&[]))
+            .expect("store explicit empty shape");
+        assert!(
+            backend
+                .core
+                .shape_bounding
+                .get(&0x100)
+                .is_some_and(Vec::is_empty),
+            "an explicit empty shape remains present and distinct from unset",
+        );
+
+        backend
+            .set_shape_rectangles(None, 0x100, 0, None)
+            .expect("unset shape");
+        assert!(
+            !backend.core.shape_bounding.contains_key(&0x100),
+            "None removes the shape entry",
+        );
     }
 
     #[test]

--- a/crates/yserver/src/kms/render/composite_pool_ring.rs
+++ b/crates/yserver/src/kms/render/composite_pool_ring.rs
@@ -62,6 +62,7 @@ impl SlotTracker {
 
 pub struct CompositePoolRing {
     pools: [vk::DescriptorPool; RING_LEN],
+    capacities: [u32; RING_LEN],
     tracker: SlotTracker,
     vk: Arc<VkContext>,
 }
@@ -78,16 +79,9 @@ impl CompositePoolRing {
     /// Create a new ring with `RING_LEN` descriptor pools, each
     /// sized for `max_sets_per_pool` COMBINED_IMAGE_SAMPLER sets.
     pub fn new(vk: Arc<VkContext>, max_sets_per_pool: u32) -> Result<Self, vk::Result> {
-        let pool_sizes = [vk::DescriptorPoolSize::default()
-            .ty(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
-            .descriptor_count(max_sets_per_pool)];
-        let pool_info = vk::DescriptorPoolCreateInfo::default()
-            .max_sets(max_sets_per_pool)
-            .pool_sizes(&pool_sizes);
-
         let mut pools = [vk::DescriptorPool::null(); RING_LEN];
         for i in 0..RING_LEN {
-            pools[i] = match unsafe { vk.device.create_descriptor_pool(&pool_info, None) } {
+            pools[i] = match create_pool(&vk, max_sets_per_pool.max(1)) {
                 Ok(p) => p,
                 Err(e) => {
                     // Roll back previously created pools.
@@ -101,28 +95,73 @@ impl CompositePoolRing {
 
         Ok(Self {
             pools,
+            capacities: [max_sets_per_pool.max(1); RING_LEN],
             tracker: SlotTracker::default(),
             vk,
         })
     }
 
-    /// Borrow a free pool slot. Returns its index, or `None` if all
-    /// `RING_LEN` slots are in use (backpressure). Caller is
-    /// responsible for calling `release(slot)` when the slot's
-    /// frame fully retires.
-    pub fn acquire(&mut self) -> Option<usize> {
-        self.tracker.acquire()
+    /// Borrow an empty slot with capacity for the complete frame. Only a
+    /// free slot can grow; pools held by other frames are never touched.
+    /// A failed growth leaves the old pool available for a later retry.
+    pub fn acquire(&mut self, required_sets: usize) -> Result<Option<usize>, vk::Result> {
+        let vk = Arc::clone(&self.vk);
+        self.acquire_with(required_sets, |capacity| create_pool(&vk, capacity))
+    }
+
+    fn acquire_with(
+        &mut self,
+        required_sets: usize,
+        create: impl FnOnce(u32) -> Result<vk::DescriptorPool, vk::Result>,
+    ) -> Result<Option<usize>, vk::Result> {
+        let required =
+            u32::try_from(required_sets).map_err(|_| vk::Result::ERROR_OUT_OF_POOL_MEMORY)?;
+        let Some(slot) = self.tracker.acquire() else {
+            return Ok(None);
+        };
+        if required.max(1) > self.capacities[slot] {
+            let capacity = required
+                .max(1)
+                .checked_next_power_of_two()
+                .unwrap_or(required);
+            let replacement = match create(capacity) {
+                Ok(pool) => pool,
+                Err(error) => {
+                    self.tracker.release(slot);
+                    return Err(error);
+                }
+            };
+            // Acquire selected a free slot: its preceding frame has retired.
+            // Create first so allocation failure preserves the usable pool.
+            unsafe {
+                self.vk
+                    .device
+                    .destroy_descriptor_pool(self.pools[slot], None)
+            };
+            self.pools[slot] = replacement;
+            self.capacities[slot] = capacity;
+        }
+        Ok(Some(slot))
     }
 
     /// Return a pool slot to the ring. Resets the pool (invalidates
     /// any descriptor sets allocated from it) and marks the slot
     /// available for the next `acquire`.
     pub fn release(&mut self, slot: usize) {
-        unsafe {
-            let _ = self
-                .vk
+        assert!(
+            self.tracker.in_use[slot],
+            "releasing an unused composite pool"
+        );
+        let reset = unsafe {
+            self.vk
                 .device
-                .reset_descriptor_pool(self.pools[slot], vk::DescriptorPoolResetFlags::empty());
+                .reset_descriptor_pool(self.pools[slot], vk::DescriptorPoolResetFlags::empty())
+        };
+        if let Err(error) = reset {
+            // The sets may still occupy the pool. Never advertise its old
+            // capacity as empty; acquire will replace it before recording.
+            log::warn!("render compose: descriptor pool reset failed: {error:?}");
+            self.capacities[slot] = 0;
         }
         self.tracker.release(slot);
     }
@@ -135,10 +174,20 @@ impl CompositePoolRing {
     }
 }
 
+fn create_pool(vk: &VkContext, capacity: u32) -> Result<vk::DescriptorPool, vk::Result> {
+    let sizes = [vk::DescriptorPoolSize::default()
+        .ty(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
+        .descriptor_count(capacity)];
+    let info = vk::DescriptorPoolCreateInfo::default()
+        .max_sets(capacity)
+        .pool_sizes(&sizes);
+    unsafe { vk.device.create_descriptor_pool(&info, None) }
+}
+
 impl Drop for CompositePoolRing {
     fn drop(&mut self) {
         // The frames that owned these pools are gone; destroy them.
-        // Drop runs only when the parent ActiveOutput is itself
+        // Drop runs only when the parent OutputLayout is itself
         // being torn down (hotplug-remove or server shutdown).
         unsafe {
             let _ = self.vk.device.device_wait_idle();
@@ -160,6 +209,196 @@ unsafe impl Send for CompositePoolRing {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Diagnostic for PR #112. Run explicitly with Lavapipe selected:
+    /// VK_DRIVER_FILES=/usr/share/vulkan/icd.d/lvp_icd.json cargo test -p yserver \
+    /// pr112_software_pool_pressure -- --ignored --nocapture
+    ///
+    /// This exercises real Vulkan allocation and ring ownership, without
+    /// KMS or queue submission. It does not qualify GPU fence retirement.
+    #[test]
+    #[ignore = "requires an explicitly selected CPU Vulkan ICD"]
+    fn pr112_software_pool_pressure() {
+        use crate::kms::vk::pipeline::INITIAL_DESCRIPTOR_SETS_PER_FRAME;
+        use std::collections::HashSet;
+
+        let vk = VkContext::new().expect("software Vulkan must initialize; do not silently skip");
+        let properties = unsafe {
+            vk.instance
+                .get_physical_device_properties(vk.physical_device)
+        };
+        assert_eq!(properties.device_type, vk::PhysicalDeviceType::CPU);
+        let bindings = [vk::DescriptorSetLayoutBinding::default()
+            .binding(0)
+            .descriptor_type(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
+            .descriptor_count(1)
+            .stage_flags(vk::ShaderStageFlags::FRAGMENT)];
+        let layout = unsafe {
+            vk.device.create_descriptor_set_layout(
+                &vk::DescriptorSetLayoutCreateInfo::default().bindings(&bindings),
+                None,
+            )
+        }
+        .expect("descriptor layout");
+        let mut rings: Vec<_> = (0..2)
+            .map(|_| {
+                CompositePoolRing::new(Arc::clone(&vk), INITIAL_DESCRIPTOR_SETS_PER_FRAME).unwrap()
+            })
+            .collect();
+
+        for cycle in 0..4 {
+            let mut live_sets = HashSet::new();
+            for (output, ring) in rings.iter_mut().enumerate() {
+                for expected_slot in 0..RING_LEN {
+                    let slot = ring.acquire(4225).unwrap().expect("unused slot");
+                    assert_eq!(slot, expected_slot);
+                    assert!(ring.capacities[slot] >= 4225);
+                    let layouts = [layout];
+                    let allocation = vk::DescriptorSetAllocateInfo::default()
+                        .descriptor_pool(ring.pool_at(slot))
+                        .set_layouts(&layouts);
+                    let mut allocated = 0;
+                    let mut failure = None;
+                    for _ in 0..(65 * 65) {
+                        match unsafe { vk.device.allocate_descriptor_sets(&allocation) } {
+                            Ok(sets) => {
+                                assert!(live_sets.insert(sets[0]), "live set handle reused");
+                                allocated += 1;
+                            }
+                            Err(error) => {
+                                assert!(matches!(
+                                    error,
+                                    vk::Result::ERROR_OUT_OF_POOL_MEMORY
+                                        | vk::Result::ERROR_FRAGMENTED_POOL
+                                ));
+                                failure = Some(error);
+                                break;
+                            }
+                        }
+                    }
+                    // Vulkan permits overallocation on some implementations;
+                    // the configured capacity is guaranteed, not a mandated
+                    // failure index. Report the observed index instead.
+                    assert!(allocated >= INITIAL_DESCRIPTOR_SETS_PER_FRAME);
+                    assert_eq!(ring.tracker.slots_in_use(), slot + 1);
+                    eprintln!(
+                        "PR112 cycle={cycle} output={output} slot={slot} requested=4225 \
+                         allocated={allocated} failure={failure:?}"
+                    );
+                }
+                assert_eq!(
+                    ring.acquire(4225).unwrap(),
+                    None,
+                    "pressure must not recycle a held slot"
+                );
+            }
+            // No work was submitted; releasing every held slot is safe.
+            for ring in &mut rings {
+                for slot in 0..RING_LEN {
+                    ring.release(slot);
+                }
+            }
+        }
+        drop(rings);
+        unsafe { vk.device.destroy_descriptor_set_layout(layout, None) };
+    }
+
+    #[test]
+    #[ignore = "requires an explicitly selected CPU Vulkan ICD"]
+    fn software_growth_failure_preserves_held_pools_and_retry_capacity() {
+        let vk = VkContext::new().expect("CPU Vulkan required");
+        let properties = unsafe {
+            vk.instance
+                .get_physical_device_properties(vk.physical_device)
+        };
+        assert_eq!(properties.device_type, vk::PhysicalDeviceType::CPU);
+        let mut ring = CompositePoolRing::new(Arc::clone(&vk), 1024).unwrap();
+        let first = ring.acquire(1024).unwrap().unwrap();
+        let second = ring.acquire(4225).unwrap().unwrap();
+        let before = ring.pools;
+        let capacities = ring.capacities;
+        assert_eq!(
+            ring.acquire_with(8193, |capacity| {
+                assert_eq!(capacity, 16384);
+                Err(vk::Result::ERROR_OUT_OF_DEVICE_MEMORY)
+            }),
+            Err(vk::Result::ERROR_OUT_OF_DEVICE_MEMORY)
+        );
+        assert_eq!(ring.pools, before);
+        assert_eq!(ring.capacities, capacities);
+        assert_eq!(ring.tracker.slots_in_use(), 2);
+        let third = ring
+            .acquire_with(1024, |_| panic!("old pool is still usable"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            ring.acquire_with(65536, |_| panic!("must not grow a held pool"))
+                .unwrap(),
+            None
+        );
+        ring.release(second);
+        let again = ring
+            .acquire_with(4225, |_| panic!("reuse enlarged pool"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(again, second);
+        assert_eq!(ring.pools, before);
+        ring.release(again);
+        ring.release(first);
+        ring.release(third);
+        if let Some(overflow) = (u32::MAX as usize).checked_add(1) {
+            assert_eq!(
+                ring.acquire(overflow),
+                Err(vk::Result::ERROR_OUT_OF_POOL_MEMORY)
+            );
+            assert_eq!(ring.tracker.slots_in_use(), 0);
+        }
+        let empty = ring.acquire(0).unwrap().unwrap();
+        ring.release(empty);
+    }
+
+    #[test]
+    #[ignore = "requires an explicitly selected CPU Vulkan ICD"]
+    fn software_failed_reset_replaces_pool_before_reuse() {
+        unsafe extern "system" fn fail_reset(
+            _: vk::Device,
+            _: vk::DescriptorPool,
+            _: vk::DescriptorPoolResetFlags,
+        ) -> vk::Result {
+            vk::Result::ERROR_OUT_OF_DEVICE_MEMORY
+        }
+
+        let mut vk = VkContext::new().expect("CPU Vulkan required");
+        let properties = unsafe {
+            vk.instance
+                .get_physical_device_properties(vk.physical_device)
+        };
+        assert_eq!(properties.device_type, vk::PhysicalDeviceType::CPU);
+        let context = Arc::get_mut(&mut vk).unwrap();
+        let mut functions = context.device.fp_v1_0().clone();
+        functions.reset_descriptor_pool = fail_reset;
+        context.device = ash::Device::from_parts_1_3(
+            context.device.handle(),
+            functions,
+            context.device.fp_v1_1().clone(),
+            context.device.fp_v1_2().clone(),
+            context.device.fp_v1_3().clone(),
+        );
+        let mut ring = CompositePoolRing::new(vk, 1024).unwrap();
+        let slot = ring.acquire(1).unwrap().unwrap();
+        let old = ring.pool_at(slot);
+        ring.release(slot);
+        assert_eq!(ring.capacities[slot], 0);
+        let reused = ring.acquire(1).unwrap().unwrap();
+        assert_eq!(reused, slot);
+        assert_ne!(
+            ring.pool_at(slot),
+            old,
+            "replacement is created before destroying old pool"
+        );
+        assert_eq!(ring.capacities[slot], 1);
+        ring.release(slot);
+    }
 
     // `SlotTracker` is exercised here; the full `CompositePoolRing`
     // needs a real `VkContext` (for both `new` and `Drop`) and is

--- a/crates/yserver/src/kms/render/scene.rs
+++ b/crates/yserver/src/kms/render/scene.rs
@@ -89,7 +89,7 @@ use crate::kms::{
     vk::{
         compositor::{CompositeDraw, CompositeScene, PresentError},
         damage_audit_compare::{DamageAuditComparePipeline, DamageAuditTileSummary},
-        pipeline::{CompositePushConsts, CompositorPipeline, MAX_DESCRIPTOR_SETS_PER_FRAME},
+        pipeline::{CompositePushConsts, CompositorPipeline, INITIAL_DESCRIPTOR_SETS_PER_FRAME},
         scanout::{
             BoPhase, BoState, CopiedRenderSource, CopiedTransportPreparation, OutputScanout,
             ScanoutBo,
@@ -1302,7 +1302,7 @@ impl SceneCompositor {
         i: usize,
     ) -> Result<OutputSceneState, SceneError> {
         let layout = &platform.outputs[i];
-        let ring = CompositePoolRing::new(Arc::clone(vk), MAX_DESCRIPTOR_SETS_PER_FRAME)
+        let ring = CompositePoolRing::new(Arc::clone(vk), INITIAL_DESCRIPTOR_SETS_PER_FRAME)
             .map_err(SceneError::Vk)?;
         let bo_depth = platform
             .scanout_pools
@@ -4530,7 +4530,11 @@ fn tick_one_output(
 
     // 6. Acquire descriptor-pool slot.
     let state = inner.outputs.get_mut(output_idx).expect("range");
-    let slot = match state.pool_ring.acquire() {
+    let slot = match state
+        .pool_ring
+        .acquire(render_scene.draws.len())
+        .map_err(|e| SceneError::Present(PresentError::Vk(e)))?
+    {
         Some(s) => s,
         None => {
             log::debug!(
@@ -4591,11 +4595,9 @@ fn tick_one_output(
         (pl, inner.overlay_xor_cache.pipeline_layout())
     };
     let mut gpu_submitted = false;
-    // Step 1 — whether every draw of `render_scene` was actually recorded.
-    // Descriptor allocation `break`s on pool exhaustion and the recorder draws
-    // only the allocated prefix; on the clipped path a frame that painted less
-    // than it claims must not be staged as `painted`. The copied route renders
-    // Full and re-clears every frame, so only the shared path reports it.
+    // Successful allocation/recording covers every draw; failed batches
+    // return before queue submission. Retain the completion check as a
+    // defensive damage-staging invariant.
     let mut compose_complete = true;
     let record_start = std::time::Instant::now();
     let (render_result, previous_gpu_ns, copied_prepare_failed) = match pool {
@@ -4733,14 +4735,8 @@ fn tick_one_output(
                     let bit = 1u32 << (output_idx % 32);
                     if WARNED.fetch_or(bit, std::sync::atomic::Ordering::Relaxed) & bit == 0 {
                         log::warn!(
-                            "render scene: output {output_idx} composed {} of {} draws \
-                             (descriptor pool exhausted); BO state invalidated, next \
-                             frame repaints in full",
-                            render_scene
-                                .draws
-                                .len()
-                                .min(MAX_DESCRIPTOR_SETS_PER_FRAME as usize),
-                            render_scene.draws.len(),
+                            "render scene: output {output_idx} failed composite coverage \
+                             check; BO state invalidated, next frame repaints in full",
                         );
                     }
                 }
@@ -5536,6 +5532,7 @@ fn build_scene_with(
             i32::MIN / 2,
             i32::MAX / 2,
             i32::MAX / 2,
+            None,
         );
     }
     // The root is the last node in computation order — the bottom of the
@@ -6225,6 +6222,149 @@ struct NodeDecision {
     child_under_redirected_ancestor: bool,
 }
 
+/// Return the exclusive end of the YX band starting at `start`.
+///
+/// KMS canonicalizes SHAPE regions when it stores them, and intersections
+/// produced below preserve that representation: rectangles are ordered by
+/// `(y0, y1, x0)`, rectangles in one band share their Y interval, and their
+/// X spans neither overlap nor touch.
+fn abs_region_band_end(region: &[[i32; 4]], start: usize) -> usize {
+    let y0 = region[start][1];
+    let y1 = region[start][3];
+    let mut end = start + 1;
+    while end < region.len() && region[end][1] == y0 && region[end][3] == y1 {
+        end += 1;
+    }
+    end
+}
+
+/// Coalesce a newly appended band vertically with the previous band when
+/// their X spans are identical and their Y intervals touch.
+fn coalesce_abs_band(
+    out: &mut Vec<[i32; 4]>,
+    band_start: usize,
+    previous_band_start: &mut Option<usize>,
+) {
+    if band_start == out.len() {
+        return;
+    }
+    if let Some(previous_start) = *previous_band_start {
+        let previous_len = band_start - previous_start;
+        let current_len = out.len() - band_start;
+        let bands_touch = out[previous_start][3] == out[band_start][1];
+        let same_x_spans = previous_len == current_len
+            && (0..previous_len).all(|offset| {
+                out[previous_start + offset][0] == out[band_start + offset][0]
+                    && out[previous_start + offset][2] == out[band_start + offset][2]
+            });
+        if bands_touch && same_x_spans {
+            let new_y1 = out[band_start][3];
+            for rect in &mut out[previous_start..band_start] {
+                rect[3] = new_y1;
+            }
+            out.truncate(band_start);
+            return;
+        }
+    }
+    *previous_band_start = Some(band_start);
+}
+
+/// Exact intersection of two canonical YX-banded regions, each a list of
+/// absolute half-open `[x0, y0, x1, y1]` rectangles.
+///
+/// The sweep only compares horizontally within vertically-overlapping bands
+/// and preserves canonical ordering/coalescing in the output. It deliberately
+/// has no rectangle cap or bounding-box fallback: a legitimate exact region
+/// can contain the Cartesian product of the input rectangle counts (vertical
+/// stripes intersecting horizontal stripes), and replacing that output with
+/// its extents violates SHAPE by painting holes.
+fn intersect_abs_regions(a: &[[i32; 4]], b: &[[i32; 4]]) -> Vec<[i32; 4]> {
+    if a.is_empty() || b.is_empty() {
+        return Vec::new();
+    }
+
+    let mut out = Vec::new();
+    let mut previous_band_start = None;
+    let mut a_start = 0;
+    let mut b_start = 0;
+    let mut a_end = abs_region_band_end(a, a_start);
+    let mut b_end = abs_region_band_end(b, b_start);
+
+    while a_start < a.len() && b_start < b.len() {
+        let ay0 = a[a_start][1];
+        let ay1 = a[a_start][3];
+        let by0 = b[b_start][1];
+        let by1 = b[b_start][3];
+        let y0 = ay0.max(by0);
+        let y1 = ay1.min(by1);
+
+        if y1 > y0 {
+            let band_start = out.len();
+            let mut ai = a_start;
+            let mut bi = b_start;
+            while ai < a_end && bi < b_end {
+                let [ax0, _, ax1, _] = a[ai];
+                let [bx0, _, bx1, _] = b[bi];
+                let x0 = ax0.max(bx0);
+                let x1 = ax1.min(bx1);
+                if x1 > x0 {
+                    out.push([x0, y0, x1, y1]);
+                }
+                if ax1 <= bx1 {
+                    ai += 1;
+                }
+                if bx1 <= ax1 {
+                    bi += 1;
+                }
+            }
+            coalesce_abs_band(&mut out, band_start, &mut previous_band_start);
+        }
+
+        if ay1 <= by1 {
+            a_start = a_end;
+            if a_start < a.len() {
+                a_end = abs_region_band_end(a, a_start);
+            }
+        }
+        if by1 <= ay1 {
+            b_start = b_end;
+            if b_start < b.len() {
+                b_end = abs_region_band_end(b, b_start);
+            }
+        }
+    }
+    out
+}
+
+/// Exact SHAPE clipping, independent of the capped occlusion/damage Region.
+fn clip_shape_place(place: &[vk::Rect2D], ancestor: &[[i32; 4]]) -> Vec<vk::Rect2D> {
+    let own = shape_place_boxes(place);
+    intersect_abs_regions(&own, ancestor)
+        .into_iter()
+        .map(|[x0, y0, x1, y1]| vk::Rect2D {
+            offset: vk::Offset2D { x: x0, y: y0 },
+            extent: vk::Extent2D {
+                width: (x1 - x0) as u32,
+                height: (y1 - y0) as u32,
+            },
+        })
+        .collect()
+}
+
+fn shape_place_boxes(place: &[vk::Rect2D]) -> Vec<[i32; 4]> {
+    place
+        .iter()
+        .map(|r| {
+            [
+                r.offset.x,
+                r.offset.y,
+                r.offset.x.saturating_add_unsigned(r.extent.width),
+                r.offset.y.saturating_add_unsigned(r.extent.height),
+            ]
+        })
+        .collect()
+}
+
 /// #133 step 5 (5.2 / 5.3) — a node's INNER region as output-local rects:
 /// Xorg's `winSize` (`SetWinSize`, `dix/window.c:1713`).
 ///
@@ -6259,37 +6399,30 @@ fn inner_place_rects(
     // The content box in storage-local coords, clamped to the ancestor
     // visible box. At `co == 0` this is the window rect — the same box
     // `place` starts from.
-    let mut boxes: Vec<(i32, i32, i32, i32)> = Vec::new();
+    let mut boxes: Vec<[i32; 4]> = Vec::new();
     let bx0 = co.max(vis_lx0);
     let by0 = co.max(vis_ly0);
     let bx1 = (co + own_w).min(vis_lx1);
     let by1 = (co + own_h).min(vis_ly1);
     if bx1 > bx0 && by1 > by0 {
-        boxes.push((bx0, by0, bx1, by1));
+        boxes.push([bx0, by0, bx1, by1]);
     }
     for list in [bounding, clip].into_iter().flatten() {
-        let mut next: Vec<(i32, i32, i32, i32)> = Vec::new();
-        for &(ax0, ay0, ax1, ay1) in &boxes {
-            for r in list {
-                let sx0 = i32::from(r.x) + co;
-                let sy0 = i32::from(r.y) + co;
-                let sx1 = sx0 + i32::from(r.width);
-                let sy1 = sy0 + i32::from(r.height);
-                let ix0 = ax0.max(sx0);
-                let iy0 = ay0.max(sy0);
-                let ix1 = ax1.min(sx1);
-                let iy1 = ay1.min(sy1);
-                if ix1 > ix0 && iy1 > iy0 {
-                    next.push((ix0, iy0, ix1, iy1));
-                }
-            }
-        }
-        boxes = next;
+        let shape: Vec<_> = list
+            .iter()
+            .filter(|r| r.width != 0 && r.height != 0)
+            .map(|r| {
+                let x = i32::from(r.x) + co;
+                let y = i32::from(r.y) + co;
+                [x, y, x + i32::from(r.width), y + i32::from(r.height)]
+            })
+            .collect();
+        boxes = intersect_abs_regions(&boxes, &shape);
         if boxes.is_empty() {
             break;
         }
     }
-    let out = boxes.into_iter().map(|(x0, y0, x1, y1)| vk::Rect2D {
+    let out = boxes.into_iter().map(|[x0, y0, x1, y1]| vk::Rect2D {
         offset: vk::Offset2D {
             x: dx + x0,
             y: dy + y0,
@@ -6733,8 +6866,8 @@ fn visit_window_subtree(
     // Per-window SHAPE bounding regions (`KmsCore::shape_bounding`).
     // When a host xid has an entry the window's scene draw is
     // clipped to those rects — marco's rounded-corner frame masks
-    // depend on this. Empty / missing entry → unshaped, single
-    // full-window draw.
+    // depend on this. A missing entry is unshaped; an explicit empty
+    // entry produces no visible pixels.
     shape_bounding: &HashMap<u32, Vec<xfixes::RegionRect>>,
     // Per-window SHAPE CLIP regions (`KmsCore::shape_clip`). #133 step 5
     // (5.3): the clip shape narrows `winSize` — the region DESCENDANTS are
@@ -6785,6 +6918,9 @@ fn visit_window_subtree(
     clip_y0: i32,
     clip_x1: i32,
     clip_y1: i32,
+    // Exact accumulated ancestor winSize, output-local. None means no shaped
+    // ancestor; Some([]) suppresses the subtree. Never use capped Region here.
+    ancestor_shape: Option<&[[i32; 4]]>,
 ) {
     let debug_focus = scene_walk_debug_enabled_for(host_xid);
     // Stage 4 diagnostic: trace-level scene-walk decision per window.
@@ -6827,7 +6963,7 @@ fn visit_window_subtree(
         return;
     }
 
-    let node = decide_node(
+    let mut node = decide_node(
         host_xid,
         geom,
         parent_content_abs_x,
@@ -6847,6 +6983,13 @@ fn visit_window_subtree(
         clip_x1,
         clip_y1,
     );
+    if let Some(ancestor) = ancestor_shape {
+        node.place = clip_shape_place(&node.place, ancestor);
+        if let Some(inner) = &mut node.child_place {
+            *inner = clip_shape_place(inner, ancestor);
+        }
+    }
+
     sink.stats.nodes_visited += 1;
     // OUTER absolute — what the node samples and occludes with.
     let abs_x = node.abs_x;
@@ -7017,8 +7160,9 @@ fn visit_window_subtree(
     // children to the parent's PLACE (rect ∩ ancestors ∩ shape), not its
     // bounding box, is the parent-bounding-shape fix: Xorg's child universe is
     // `∩ borderSize`, and `borderSize` is shape-clipped. This is the one union
-    // in the walk; a collapse degrades to "children clipped to the parent's
-    // bbox", which is exactly the pre-step-1 behaviour.
+    // in the walk; it may conservatively collapse for occlusion, while the
+    // independent ancestor_shape constraint still clips every child's place
+    // exactly before emission.
     //
     // Leaf fast path: a node with no children needs no `mine` at all. Its
     // pieces are `universe ∩ r` per place rect (which is exactly `mine ∩ r`,
@@ -7037,6 +7181,16 @@ fn visit_window_subtree(
     // ARE the same rect list — the `bw == 0` path reads exactly the vector it
     // read before, through the same code below.
     let child_region_rects: &[vk::Rect2D] = node.child_place.as_deref().unwrap_or(&node.place);
+    let child_shape = if !is_leaf
+        && (ancestor_shape.is_some()
+            || shape_bounding.contains_key(&host_xid)
+            || shape_clip.contains_key(&host_xid))
+    {
+        Some(shape_place_boxes(child_region_rects))
+    } else {
+        None
+    };
+
     let mut mine = Region::new();
     // #133 step 5 (5.2) — this node's OWN region that lies outside its inner
     // region: the border ring. Xorg keeps the same two things apart —
@@ -7116,6 +7270,7 @@ fn visit_window_subtree(
                 node.child_clip_y0,
                 node.child_clip_x1,
                 node.child_clip_y1,
+                child_shape.as_deref(),
             );
         }
     }
@@ -7768,6 +7923,58 @@ fn submit_copied_scanout_render(
         .map_err(|error| CopiedRenderSubmitError::Present(PresentError::Vk(error)))
 }
 
+/// Allocate the complete draw list before any recording/submission. The
+/// callback is the Vulkan batch allocator in production; tests inject its
+/// failures without depending on an ICD enforcing pool capacity.
+fn allocate_composite_descriptors(
+    scene: &CompositeScene,
+    allocate: impl FnOnce(usize) -> Result<Vec<vk::DescriptorSet>, vk::Result>,
+) -> Result<Vec<vk::DescriptorSet>, PresentError> {
+    if scene.draws.is_empty() {
+        return Ok(Vec::new());
+    }
+    u32::try_from(scene.draws.len()).map_err(|_| vk::Result::ERROR_OUT_OF_POOL_MEMORY)?;
+    let descriptors = allocate(scene.draws.len())?;
+    // A successful Vulkan batch has exactly the requested size. Keep this
+    // guard at the recorder boundary so no caller can submit a prefix.
+    if descriptors.len() != scene.draws.len() {
+        return Err(PresentError::Vk(vk::Result::ERROR_OUT_OF_POOL_MEMORY));
+    }
+    Ok(descriptors)
+}
+
+fn prepare_composite_descriptors(
+    vk: &crate::kms::vk::device::VkContext,
+    pipeline: &CompositorPipeline,
+    descriptor_pool: vk::DescriptorPool,
+    scene: &CompositeScene,
+) -> Result<Vec<vk::DescriptorSet>, PresentError> {
+    // All-or-nothing allocation: never record or acknowledge a partial
+    // frame. Vulkan rolls back a failed batch; the caller releases the slot
+    // and retains damage through the existing unsubmitted-error path.
+    let descriptors = allocate_composite_descriptors(scene, |count| {
+        let layouts = vec![pipeline.descriptor_set_layout; count];
+        let alloc_info = vk::DescriptorSetAllocateInfo::default()
+            .descriptor_pool(descriptor_pool)
+            .set_layouts(&layouts);
+        unsafe { vk.device.allocate_descriptor_sets(&alloc_info) }
+    })?;
+    for (draw, &set) in scene.draws.iter().zip(&descriptors) {
+        let image_info = [vk::DescriptorImageInfo::default()
+            .image_view(draw.image_view)
+            .sampler(pipeline.sampler)
+            .image_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL)];
+        let writes = [vk::WriteDescriptorSet::default()
+            .dst_set(set)
+            .dst_binding(0)
+            .descriptor_type(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
+            .image_info(&image_info)];
+        unsafe { vk.device.update_descriptor_sets(&writes, &[]) };
+    }
+
+    Ok(descriptors)
+}
+
 #[allow(clippy::too_many_arguments)]
 fn record_and_submit_render(
     vk: &crate::kms::vk::device::VkContext,
@@ -7815,36 +8022,7 @@ fn record_and_submit_render(
     };
     target.set_last_gpu_render_ns(last_gpu_render_ns);
 
-    // Allocate descriptor sets — same shape as v1.
-    let mut descriptors: Vec<vk::DescriptorSet> = Vec::with_capacity(scene.draws.len());
-    for draw in &scene.draws {
-        let layouts = [pipeline.descriptor_set_layout];
-        let alloc_info = vk::DescriptorSetAllocateInfo::default()
-            .descriptor_pool(descriptor_pool)
-            .set_layouts(&layouts);
-        let set = match unsafe { vk.device.allocate_descriptor_sets(&alloc_info) } {
-            Ok(sets) => sets[0],
-            Err(e) => {
-                log::warn!(
-                    "render compose: descriptor allocation failed ({e:?}) at draw {} of {}",
-                    descriptors.len(),
-                    scene.draws.len(),
-                );
-                break;
-            }
-        };
-        let image_info = [vk::DescriptorImageInfo::default()
-            .image_view(draw.image_view)
-            .sampler(pipeline.sampler)
-            .image_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL)];
-        let writes = [vk::WriteDescriptorSet::default()
-            .dst_set(set)
-            .dst_binding(0)
-            .descriptor_type(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
-            .image_info(&image_info)];
-        unsafe { vk.device.update_descriptor_sets(&writes, &[]) };
-        descriptors.push(set);
-    }
+    let descriptors = prepare_composite_descriptors(vk, pipeline, descriptor_pool, scene)?;
 
     // Record.
     record_command_buffer(
@@ -7905,6 +8083,9 @@ fn record_command_buffer<T: ComposeRenderTarget + ?Sized>(
     xor_pipeline: vk::Pipeline,
     xor_layout: vk::PipelineLayout,
 ) -> Result<(), PresentError> {
+    if descriptors.len() != scene.draws.len() {
+        return Err(PresentError::Vk(vk::Result::ERROR_OUT_OF_POOL_MEMORY));
+    }
     let device = &vk.device;
     let cb = bo.command_buffer();
     // Mirror the timestamp gate `record_and_submit_render` uses so we can bracket the
@@ -8055,7 +8236,7 @@ fn record_command_buffer<T: ComposeRenderTarget + ?Sized>(
         for scissor in scissors {
             crate::vk_count!(cmd_set_scissor);
             device.cmd_set_scissor(cb, 0, std::slice::from_ref(scissor));
-            for (i, draw) in scene.draws.iter().enumerate().take(descriptors.len()) {
+            for (draw, &descriptor) in scene.draws.iter().zip(descriptors) {
                 if scissors.len() > 1
                     && draw_dst_rect_inward(draw).is_some_and(|dst| !rects_intersect(dst, *scissor))
                 {
@@ -8067,7 +8248,7 @@ fn record_command_buffer<T: ComposeRenderTarget + ?Sized>(
                     device.cmd_bind_pipeline(cb, vk::PipelineBindPoint::GRAPHICS, pl);
                     last_pipeline = Some(pl);
                 }
-                let sets = [descriptors[i]];
+                let sets = [descriptor];
                 crate::vk_count!(cmd_bind_descriptor_sets);
                 device.cmd_bind_descriptor_sets(
                     cb,
@@ -9943,6 +10124,793 @@ mod tests {
         );
     }
 
+    #[test]
+    fn intersect_abs_regions_preserves_large_exact_stripe_product() {
+        // Both inputs are canonical, non-overlapping YX-banded regions.
+        // Their exact intersection contains 65×65 disjoint pixels, well
+        // beyond the removed 64-rect fallback. Collapsing to extents would
+        // incorrectly fill every one-pixel gap.
+        let vertical: Vec<[i32; 4]> = (0..65)
+            .map(|i| {
+                let x = i * 2;
+                [x, 0, x + 1, 129]
+            })
+            .collect();
+        let horizontal: Vec<[i32; 4]> = (0..65)
+            .map(|i| {
+                let y = i * 2;
+                [0, y, 129, y + 1]
+            })
+            .collect();
+
+        let intersection = intersect_abs_regions(&vertical, &horizontal);
+        assert_eq!(
+            intersection.len(),
+            65 * 65,
+            "every vertical/horizontal stripe crossing is a real output rect",
+        );
+        assert!(
+            intersection
+                .iter()
+                .all(|[x0, y0, x1, y1]| x1 - x0 == 1 && y1 - y0 == 1),
+            "the exact result must retain the one-pixel crossings: {intersection:?}",
+        );
+        assert!(
+            !intersection
+                .iter()
+                .any(|[x0, y0, x1, y1]| *x0 <= 1 && 1 < *x1 && *y0 <= 1 && 1 < *y1),
+            "the hole at (1,1) must not be painted by a bounding-box fallback",
+        );
+    }
+
+    #[test]
+    fn pr112_full_frame_cow_shape_does_not_amplify_draws_on_either_output() {
+        pr112_full_frame_cow_shape_does_not_amplify_draws_on_either_output_with_mode(
+            Visibility::Off,
+        );
+        pr112_full_frame_cow_shape_does_not_amplify_draws_on_either_output_with_mode(
+            Visibility::On,
+        );
+    }
+
+    fn pr112_full_frame_cow_shape_does_not_amplify_draws_on_either_output_with_mode(
+        mode: Visibility,
+    ) {
+        let mut core = KmsCore::for_tests();
+        let mut store = DrawableStore::new();
+        let mut platform = PlatformBackend::for_tests();
+        let mut windows = super::super::backend::WindowsMap::new();
+        let cow = yserver_core::resources::COMPOSITE_OVERLAY_WINDOW.0;
+        alloc_stub_window(&mut store, &mut windows, cow, 0, 0, 5120, 1440, None, true);
+        core.top_level_order.push(cow);
+        alloc_stub_window(
+            &mut store,
+            &mut windows,
+            0xB1,
+            0,
+            0,
+            5120,
+            1440,
+            Some(cow),
+            true,
+        );
+        // Many restored descendants across the virtual desktop. This tests
+        // the reported full-frame COW rectangle, not a complex synthetic mask.
+        for i in 0..100u32 {
+            let xid = 0x1000 + i;
+            alloc_stub_window(
+                &mut store,
+                &mut windows,
+                xid,
+                i16::try_from((i % 20) * 250).unwrap(),
+                i16::try_from((i / 20) * 250).unwrap(),
+                200,
+                200,
+                Some(0xB1),
+                true,
+            );
+            windows.get_mut(&xid).unwrap().stack_rank = u64::from(i);
+        }
+        for output_x in [0, 2560] {
+            platform.outputs[0].x = output_x;
+            platform.outputs[0].width = 2560;
+            platform.outputs[0].height = 1440;
+            core.shape_bounding.remove(&cow);
+            let plain = build_scene(
+                &core,
+                &mut store,
+                &windows,
+                0,
+                &platform,
+                None,
+                None,
+                Some(cow),
+                false,
+                mode,
+            );
+            core.shape_bounding.insert(
+                cow,
+                vec![xfixes::RegionRect {
+                    x: 0,
+                    y: 0,
+                    width: 5120,
+                    height: 1440,
+                }],
+            );
+            let shaped = build_scene(
+                &core,
+                &mut store,
+                &windows,
+                0,
+                &platform,
+                None,
+                None,
+                Some(cow),
+                false,
+                mode,
+            );
+            assert!(!plain.scene.draws.is_empty());
+            assert_eq!(plain.scene.draws.len(), shaped.scene.draws.len());
+            assert_eq!(plain.sampled_ids, shaped.sampled_ids);
+            assert_eq!(plain.snapshots.len(), shaped.snapshots.len());
+            for (a, b) in plain.scene.draws.iter().zip(&shaped.scene.draws) {
+                assert_eq!(a.image_view, b.image_view);
+                assert_eq!(a.dst_origin, b.dst_origin);
+                assert_eq!(a.dst_size, b.dst_size);
+                assert_eq!(a.src_origin, b.src_origin);
+                assert_eq!(a.src_size, b.src_size);
+                assert_eq!(a.alpha_passthrough, b.alpha_passthrough);
+            }
+            eprintln!(
+                "PR112 output_x={output_x} plain={} shaped={}",
+                plain.scene.draws.len(),
+                shaped.scene.draws.len()
+            );
+        }
+    }
+
+    #[test]
+    fn pr112_nested_stripes_exceed_pool_budget_in_real_scene_walk() {
+        pr112_nested_stripes_exceed_pool_budget_in_real_scene_walk_with_mode(Visibility::Off);
+        pr112_nested_stripes_exceed_pool_budget_in_real_scene_walk_with_mode(Visibility::On);
+    }
+
+    fn pr112_nested_stripes_exceed_pool_budget_in_real_scene_walk_with_mode(mode: Visibility) {
+        let mut core = KmsCore::for_tests();
+        let mut store = DrawableStore::new();
+        let platform = PlatformBackend::for_tests();
+        let mut windows = super::super::backend::WindowsMap::new();
+        let cow = yserver_core::resources::COMPOSITE_OVERLAY_WINDOW.0;
+        alloc_stub_window(&mut store, &mut windows, cow, 0, 0, 129, 129, None, true);
+        core.top_level_order.push(cow);
+        alloc_stub_window(
+            &mut store,
+            &mut windows,
+            0xB1,
+            0,
+            0,
+            129,
+            129,
+            Some(cow),
+            true,
+        );
+        core.shape_bounding.insert(
+            cow,
+            (0..65)
+                .map(|i| xfixes::RegionRect {
+                    x: i * 2,
+                    y: 0,
+                    width: 1,
+                    height: 129,
+                })
+                .collect(),
+        );
+        core.shape_bounding.insert(
+            0xB1,
+            (0..65)
+                .map(|i| xfixes::RegionRect {
+                    x: 0,
+                    y: i * 2,
+                    width: 129,
+                    height: 1,
+                })
+                .collect(),
+        );
+        let id = store.lookup(0xB1).unwrap();
+        let view = store.get(id).unwrap().storage.sample_view;
+        let built = build_scene(
+            &core,
+            &mut store,
+            &windows,
+            0,
+            &platform,
+            None,
+            None,
+            Some(cow),
+            false,
+            mode,
+        );
+        let pieces: Vec<_> = built
+            .scene
+            .draws
+            .iter()
+            .filter(|draw| draw.image_view == view)
+            .collect();
+        assert_eq!(pieces.len(), 4225);
+        assert!(built.scene.draws.len() > INITIAL_DESCRIPTOR_SETS_PER_FRAME as usize);
+        // Raster oracle: no missing pixels, painted holes, or repeated
+        // SrcOver blends. Check the scene output, not just region arithmetic.
+        let mut coverage = vec![0u8; 129 * 129];
+        for draw in pieces {
+            assert!(draw.alpha_passthrough);
+            assert_eq!(draw.dst_size, [1.0, 1.0]);
+            let x = draw.dst_origin[0] as usize;
+            let y = draw.dst_origin[1] as usize;
+            assert!(x < 129 && y < 129);
+            coverage[y * 129 + x] += 1;
+        }
+        for (offset, count) in coverage.into_iter().enumerate() {
+            let (x, y) = (offset % 129, offset / 129);
+            assert_eq!(count, u8::from(x % 2 == 0 && y % 2 == 0), "pixel ({x},{y})");
+        }
+        assert_eq!(
+            built
+                .sampled_ids
+                .iter()
+                .filter(|&&sample| sample == id)
+                .count(),
+            1
+        );
+        assert_eq!(
+            built
+                .snapshots
+                .iter()
+                .filter(|snapshot| snapshot.id == id)
+                .count(),
+            1
+        );
+        eprintln!(
+            "PR112 nested stripes total_draws={} child_draws=4225 capacity={}",
+            built.scene.draws.len(),
+            INITIAL_DESCRIPTOR_SETS_PER_FRAME
+        );
+    }
+
+    #[test]
+    fn intersect_abs_regions_coalesces_identical_output_bands() {
+        let a = [[0, 0, 10, 10]];
+        // B cannot coalesce its two Y bands because only the first has the
+        // disjoint 20..30 span. Intersecting with A removes that difference,
+        // so the two resulting 0..10 spans must coalesce vertically.
+        let b = [[0, 0, 10, 5], [20, 0, 30, 5], [0, 5, 10, 10]];
+
+        assert_eq!(intersect_abs_regions(&a, &b), vec![[0, 0, 10, 10]]);
+    }
+
+    /// SHAPE bounding region clips DESCENDANTS too, not just the
+    /// shaped window itself — "the window's border and contents ...
+    /// and those of its inferiors are clipped to the bounding region".
+    ///
+    /// Regression: KWin reparents a Plasma panel into
+    /// frame → wrapper → client and puts the floating panel's shape on
+    /// the FRAME (3440x24+0+16 inside a 3440x40 frame) so the margin it
+    /// slides through shows the wallpaper when nothing composites. The
+    /// wrapper in between is unshaped and full-height; the scene folded
+    /// only ancestor *geometry* into the child clip, so the wrapper was
+    /// emitted whole and its opaque background painted a white band
+    /// across the margin — Strix Halo / amdgpu, non-composited Plasma
+    /// 6.6, 2026-07-28. Enabling a compositor masked it (KWin then
+    /// samples the window as a texture and the alpha carries the
+    /// cut-out), which is why it only showed with compositing off.
+    #[test]
+    fn build_scene_clips_descendants_to_ancestor_shape_bounding() {
+        use yserver_protocol::x11::xfixes::RegionRect;
+        let mut core = KmsCore::for_tests();
+        let mut store = DrawableStore::new();
+        let platform = PlatformBackend::for_tests();
+        let mut windows = super::super::backend::WindowsMap::new();
+
+        // Frame @ (0, 100), 400×40 — the shaped ancestor.
+        alloc_stub_window(&mut store, &mut windows, 0x100, 0, 100, 400, 40, None, true);
+        core.top_level_order.push(0x100);
+        // Panel band: only rows 16..40 of the frame are in the region.
+        core.shape_bounding.insert(
+            0x100,
+            vec![RegionRect {
+                x: 0,
+                y: 16,
+                width: 400,
+                height: 24,
+            }],
+        );
+
+        // Wrapper: fills the frame, NO shape of its own.
+        alloc_stub_window(
+            &mut store,
+            &mut windows,
+            0x101,
+            0,
+            0,
+            400,
+            40,
+            Some(0x100),
+            true,
+        );
+
+        let built = build_scene(
+            &core,
+            &mut store,
+            &windows,
+            0,
+            &platform,
+            None,
+            None,
+            None,
+            false,
+            Visibility::Off,
+        );
+        let scene = built.scene;
+
+        // Nothing may be painted above the band's top edge (abs y 116).
+        assert!(
+            !scene.draws.iter().any(|d| d.dst_origin[1] < 116.0),
+            "no draw may land above the ancestor's bounding band at y=116 \
+             (the margin must stay clear); got {:?}",
+            scene.draws,
+        );
+        // The unshaped wrapper inherits the band: y 116, height 24.
+        let wrapper = scene
+            .draws
+            .iter()
+            .find(|d| (d.dst_origin[1] - 116.0).abs() < 1e-5 && d.dst_size[1] == 24.0)
+            .unwrap_or_else(|| {
+                panic!(
+                    "wrapper must be clipped to the ancestor band, got {:?}",
+                    scene.draws
+                )
+            });
+        assert_eq!(
+            wrapper.dst_size,
+            [400.0, 24.0],
+            "wrapper must be clipped to 400×24, not drawn at its full 400×40",
+        );
+        // It must sample the matching sub-region of its own storage,
+        // otherwise the band shows the wrong 24 rows of the wrapper.
+        assert!(
+            (wrapper.src_origin[1] - 16.0 / 40.0).abs() < 1e-5
+                && (wrapper.src_size[1] - 24.0 / 40.0).abs() < 1e-5,
+            "wrapper must sample rows 16..40 of its storage, got origin {:?} size {:?}",
+            wrapper.src_origin,
+            wrapper.src_size,
+        );
+    }
+
+    /// A multi-rect ancestor region must clip descendants to the region
+    /// itself, not to its bounding box. Plasma's panel frame carries a
+    /// rounded mask — three rects, a 1px cap inset one pixel further
+    /// than the body — and clipping the unshaped wrapper to the extents
+    /// instead left one lit pixel in each of the four corners
+    /// (measured on Strix Halo: `(8,8)`, `(8,3431)`, `(31,8)`,
+    /// `(31,3431)` still `#FFFFFF` over the wallpaper).
+    #[test]
+    fn build_scene_clips_descendants_to_multi_rect_ancestor_shape() {
+        use yserver_protocol::x11::xfixes::RegionRect;
+        let mut core = KmsCore::for_tests();
+        let mut store = DrawableStore::new();
+        let platform = PlatformBackend::for_tests();
+        let mut windows = super::super::backend::WindowsMap::new();
+
+        // Frame @ (0, 0), 100×40.
+        alloc_stub_window(&mut store, &mut windows, 0x100, 0, 0, 100, 40, None, true);
+        core.top_level_order.push(0x100);
+        // Rounded band: 1px caps inset one further than the body, so
+        // the four corner pixels are inside the bounding box (8..32 ×
+        // 8..92) but outside the region.
+        core.shape_bounding.insert(
+            0x100,
+            vec![
+                RegionRect {
+                    x: 9,
+                    y: 8,
+                    width: 82,
+                    height: 1,
+                },
+                RegionRect {
+                    x: 8,
+                    y: 9,
+                    width: 84,
+                    height: 22,
+                },
+                RegionRect {
+                    x: 9,
+                    y: 31,
+                    width: 82,
+                    height: 1,
+                },
+            ],
+        );
+
+        // Unshaped wrapper filling the frame.
+        alloc_stub_window(
+            &mut store,
+            &mut windows,
+            0x101,
+            0,
+            0,
+            100,
+            40,
+            Some(0x100),
+            true,
+        );
+
+        let built = build_scene(
+            &core,
+            &mut store,
+            &windows,
+            0,
+            &platform,
+            None,
+            None,
+            None,
+            false,
+            Visibility::Off,
+        );
+        let scene = built.scene;
+
+        // Every corner pixel of the bounding box lies outside the true
+        // region and must be covered by no draw at all.
+        for (px, py) in [(8.0_f32, 8.0_f32), (91.0, 8.0), (8.0, 31.0), (91.0, 31.0)] {
+            let covering: Vec<_> = scene
+                .draws
+                .iter()
+                .filter(|d| {
+                    px >= d.dst_origin[0]
+                        && px < d.dst_origin[0] + d.dst_size[0]
+                        && py >= d.dst_origin[1]
+                        && py < d.dst_origin[1] + d.dst_size[1]
+                })
+                .collect();
+            assert!(
+                covering.is_empty(),
+                "corner pixel ({px}, {py}) is outside the rounded region but \
+                 {} draw(s) cover it — the ancestor region was flattened to \
+                 its bounding box: {:?}",
+                covering.len(),
+                covering,
+            );
+        }
+
+        // The body interior must still be painted, twice over: once by
+        // the shaped frame and once by the wrapper it clips.
+        let mid = scene
+            .draws
+            .iter()
+            .filter(|d| {
+                50.0 >= d.dst_origin[0]
+                    && 50.0 < d.dst_origin[0] + d.dst_size[0]
+                    && 20.0 >= d.dst_origin[1]
+                    && 20.0 < d.dst_origin[1] + d.dst_size[1]
+            })
+            .count();
+        assert_eq!(
+            mid, 2,
+            "the band interior must still be drawn by both frame and wrapper, \
+             got {mid} draw(s): {:?}",
+            scene.draws,
+        );
+    }
+
+    #[test]
+    fn build_scene_intersects_shaped_ancestor_and_offset_shaped_child() {
+        use yserver_protocol::x11::xfixes::RegionRect;
+
+        let mut core = KmsCore::for_tests();
+        let mut store = DrawableStore::new();
+        let platform = PlatformBackend::for_tests();
+        let mut windows = super::super::backend::WindowsMap::new();
+
+        // Parent absolute box (50,50)-(150,150), with an inset shape
+        // (60,60)-(140,140).
+        alloc_stub_window(
+            &mut store,
+            &mut windows,
+            0x100,
+            50,
+            50,
+            100,
+            100,
+            None,
+            true,
+        );
+        core.top_level_order.push(0x100);
+        core.shape_bounding.insert(
+            0x100,
+            vec![RegionRect {
+                x: 10,
+                y: 10,
+                width: 80,
+                height: 80,
+            }],
+        );
+
+        // Child origin is (40,70): negative X relative to its parent.
+        // Its own shape also starts above the child. Own shape absolute
+        // (70,65)-(130,115), ancestor shape (60,60)-(140,140), and
+        // parent geometry together leave (70,70)-(130,115).
+        alloc_stub_window(
+            &mut store,
+            &mut windows,
+            0x101,
+            -10,
+            20,
+            100,
+            100,
+            Some(0x100),
+            true,
+        );
+        core.shape_bounding.insert(
+            0x101,
+            vec![RegionRect {
+                x: 30,
+                y: -5,
+                width: 60,
+                height: 50,
+            }],
+        );
+        let child_id = store.lookup(0x101).expect("child id");
+        let child_view = store.get(child_id).expect("child").storage.sample_view;
+
+        let built = build_scene(
+            &core,
+            &mut store,
+            &windows,
+            0,
+            &platform,
+            None,
+            None,
+            None,
+            false,
+            Visibility::Off,
+        );
+        let child_draws: Vec<_> = built
+            .scene
+            .draws
+            .iter()
+            .filter(|draw| draw.image_view == child_view)
+            .collect();
+        assert_eq!(
+            child_draws.len(),
+            1,
+            "the shaped child intersection must emit exactly one piece: {:?}",
+            built.scene.draws,
+        );
+        let child = child_draws[0];
+        assert_eq!(child.dst_origin, [70.0, 70.0]);
+        assert_eq!(child.dst_size, [60.0, 45.0]);
+        assert!(
+            (child.src_origin[0] - 0.3).abs() < 1e-5 && child.src_origin[1].abs() < 1e-5,
+            "negative/local offsets must map to the matching child texture area: {:?}",
+            child.src_origin,
+        );
+    }
+
+    #[test]
+    fn build_scene_intersects_two_shaped_ancestors_for_grandchild() {
+        use yserver_protocol::x11::xfixes::RegionRect;
+
+        let mut core = KmsCore::for_tests();
+        let mut store = DrawableStore::new();
+        let platform = PlatformBackend::for_tests();
+        let mut windows = super::super::backend::WindowsMap::new();
+
+        alloc_stub_window(
+            &mut store,
+            &mut windows,
+            0x100,
+            100,
+            100,
+            100,
+            100,
+            None,
+            true,
+        );
+        core.top_level_order.push(0x100);
+        core.shape_bounding.insert(
+            0x100,
+            vec![RegionRect {
+                x: 20,
+                y: 0,
+                width: 60,
+                height: 100,
+            }],
+        );
+
+        alloc_stub_window(
+            &mut store,
+            &mut windows,
+            0x101,
+            10,
+            10,
+            100,
+            100,
+            Some(0x100),
+            true,
+        );
+        core.shape_bounding.insert(
+            0x101,
+            vec![RegionRect {
+                x: 0,
+                y: 20,
+                width: 100,
+                height: 40,
+            }],
+        );
+
+        alloc_stub_window(
+            &mut store,
+            &mut windows,
+            0x102,
+            5,
+            5,
+            90,
+            80,
+            Some(0x101),
+            true,
+        );
+        let grandchild_id = store.lookup(0x102).expect("grandchild id");
+        let grandchild_view = store
+            .get(grandchild_id)
+            .expect("grandchild")
+            .storage
+            .sample_view;
+
+        let built = build_scene(
+            &core,
+            &mut store,
+            &windows,
+            0,
+            &platform,
+            None,
+            None,
+            None,
+            false,
+            Visibility::Off,
+        );
+        let grandchild_draws: Vec<_> = built
+            .scene
+            .draws
+            .iter()
+            .filter(|draw| draw.image_view == grandchild_view)
+            .collect();
+        assert_eq!(
+            grandchild_draws.len(),
+            1,
+            "the grandchild must inherit the exact intersection of both shapes",
+        );
+        assert_eq!(grandchild_draws[0].dst_origin, [120.0, 130.0]);
+        assert_eq!(grandchild_draws[0].dst_size, [60.0, 40.0]);
+    }
+
+    #[test]
+    fn build_scene_propagates_empty_nested_shape_intersection() {
+        use yserver_protocol::x11::xfixes::RegionRect;
+
+        let mut core = KmsCore::for_tests();
+        let mut store = DrawableStore::new();
+        let platform = PlatformBackend::for_tests();
+        let mut windows = super::super::backend::WindowsMap::new();
+
+        alloc_stub_window(&mut store, &mut windows, 0x100, 0, 0, 100, 100, None, true);
+        core.top_level_order.push(0x100);
+        core.shape_bounding.insert(
+            0x100,
+            vec![RegionRect {
+                x: 0,
+                y: 0,
+                width: 10,
+                height: 100,
+            }],
+        );
+
+        alloc_stub_window(
+            &mut store,
+            &mut windows,
+            0x101,
+            0,
+            0,
+            100,
+            100,
+            Some(0x100),
+            true,
+        );
+        core.shape_bounding.insert(
+            0x101,
+            vec![RegionRect {
+                x: 20,
+                y: 0,
+                width: 10,
+                height: 100,
+            }],
+        );
+        alloc_stub_window(
+            &mut store,
+            &mut windows,
+            0x102,
+            0,
+            0,
+            100,
+            100,
+            Some(0x101),
+            true,
+        );
+        let child_id = store.lookup(0x101).expect("child id");
+        let grandchild_id = store.lookup(0x102).expect("grandchild id");
+
+        let built = build_scene(
+            &core,
+            &mut store,
+            &windows,
+            0,
+            &platform,
+            None,
+            None,
+            None,
+            false,
+            Visibility::Off,
+        );
+        assert!(
+            !built.pieces_ids.contains(&child_id) && !built.pieces_ids.contains(&grandchild_id),
+            "Some([]) from the empty nested intersection must suppress the \
+             child and its entire subtree: {:?}",
+            built.scene.draws,
+        );
+        assert_eq!(
+            built.scene.draws.len(),
+            1,
+            "only the shaped parent remains visible after the empty intersection",
+        );
+    }
+
+    #[test]
+    fn build_scene_explicit_empty_ancestor_shape_suppresses_child() {
+        let mut core = KmsCore::for_tests();
+        let mut store = DrawableStore::new();
+        let platform = PlatformBackend::for_tests();
+        let mut windows = super::super::backend::WindowsMap::new();
+
+        alloc_stub_window(&mut store, &mut windows, 0x100, 0, 0, 100, 100, None, true);
+        core.top_level_order.push(0x100);
+        core.shape_bounding.insert(0x100, Vec::new());
+        alloc_stub_window(
+            &mut store,
+            &mut windows,
+            0x101,
+            0,
+            0,
+            100,
+            100,
+            Some(0x100),
+            true,
+        );
+
+        let built = build_scene(
+            &core,
+            &mut store,
+            &windows,
+            0,
+            &platform,
+            None,
+            None,
+            None,
+            false,
+            Visibility::Off,
+        );
+        assert!(
+            built.scene.draws.is_empty() && built.pieces_ids.is_empty(),
+            "an explicit empty Bounding shape must clip the window and inferiors",
+        );
+    }
+
     /// SHAPE bounding region clips the window's scene draw. Marco
     /// uses `SHAPE-Request: Rectangles destination=Bounding` to set
     /// a rounded-corner mask on frame windows; without honouring it
@@ -11037,6 +12005,103 @@ mod tests {
                 d,
             );
         }
+    }
+
+    #[test]
+    fn cow_multi_piece_shape_samples_and_snapshots_each_window_once() {
+        use yserver_protocol::x11::xfixes::RegionRect;
+
+        let mut core = KmsCore::for_tests();
+        let mut store = DrawableStore::new();
+        let platform = PlatformBackend::for_tests();
+        let mut windows = super::super::backend::WindowsMap::new();
+
+        let cow_xid: u32 = yserver_core::resources::COMPOSITE_OVERLAY_WINDOW.0;
+        alloc_stub_window(&mut store, &mut windows, cow_xid, 0, 0, 100, 40, None, true);
+        core.top_level_order.push(cow_xid);
+        core.shape_bounding.insert(
+            cow_xid,
+            vec![
+                RegionRect {
+                    x: 0,
+                    y: 0,
+                    width: 100,
+                    height: 10,
+                },
+                RegionRect {
+                    x: 0,
+                    y: 20,
+                    width: 100,
+                    height: 10,
+                },
+                RegionRect {
+                    x: 0,
+                    y: 35,
+                    width: 100,
+                    height: 5,
+                },
+            ],
+        );
+
+        alloc_stub_window(
+            &mut store,
+            &mut windows,
+            0xB1,
+            0,
+            0,
+            100,
+            40,
+            Some(cow_xid),
+            true,
+        );
+        let stage_id = store.lookup(0xB1).expect("stage id");
+        let stage_view = store.get(stage_id).expect("stage").storage.sample_view;
+
+        let built = build_scene(
+            &core,
+            &mut store,
+            &windows,
+            0,
+            &platform,
+            None,
+            None,
+            Some(cow_xid),
+            false,
+            Visibility::Off,
+        );
+        let stage_draws: Vec<_> = built
+            .scene
+            .draws
+            .iter()
+            .filter(|draw| draw.image_view == stage_view)
+            .collect();
+        assert_eq!(
+            stage_draws.len(),
+            3,
+            "the unshaped COW child must inherit all three ancestor pieces",
+        );
+        assert!(
+            stage_draws.iter().all(|draw| draw.alpha_passthrough),
+            "every inherited piece in the COW subtree must retain SrcOver blending",
+        );
+        assert_eq!(
+            built
+                .sampled_ids
+                .iter()
+                .filter(|&&id| id == stage_id)
+                .count(),
+            1,
+            "multi-piece emission must sample-key the drawable once",
+        );
+        assert_eq!(
+            built
+                .snapshots
+                .iter()
+                .filter(|snapshot| snapshot.id == stage_id)
+                .count(),
+            1,
+            "multi-piece emission must capture presentation damage once",
+        );
     }
 
     /// Phase 2.7 — the COW must emit via the normal `top_level_order`
@@ -15660,3 +16725,7 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+#[path = "scene_software_tests.rs"]
+mod software_tests;

--- a/crates/yserver/src/kms/render/scene_diff.rs
+++ b/crates/yserver/src/kms/render/scene_diff.rs
@@ -50,14 +50,6 @@
 //! - **The empty-projection force-compose**, which exists so a paint whose
 //!   projection landed empty can retire at all.
 
-#![cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "the signature accessors land ahead of their consumers"
-    )
-)]
-
 use std::collections::HashMap;
 
 use ash::vk;

--- a/crates/yserver/src/kms/render/scene_software_tests.rs
+++ b/crates/yserver/src/kms/render/scene_software_tests.rs
@@ -1,0 +1,478 @@
+//! Headless tests of the production composite recorder. Never select a GPU.
+use super::*;
+use crate::kms::vk::{device::VkContext, target::DrawableImage};
+
+fn scene_with_draws(count: usize) -> CompositeScene {
+    CompositeScene {
+        bg_color: [0.0, 0.0, 1.0, 1.0],
+        draws: vec![
+            CompositeDraw {
+                image_view: vk::ImageView::null(),
+                dst_origin: [0.0; 2],
+                dst_size: [1.0; 2],
+                src_origin: [0.0; 2],
+                src_size: [1.0; 2],
+                alpha_passthrough: true,
+            };
+            count
+        ],
+    }
+}
+
+#[test]
+fn allocation_failures_never_return_a_recordable_prefix() {
+    for count in [1, 1023, 1024, 1025, 4225, 4290] {
+        for error in [
+            vk::Result::ERROR_OUT_OF_POOL_MEMORY,
+            vk::Result::ERROR_OUT_OF_HOST_MEMORY,
+            vk::Result::ERROR_OUT_OF_DEVICE_MEMORY,
+        ] {
+            let result = allocate_composite_descriptors(&scene_with_draws(count), |requested| {
+                assert_eq!(requested, count);
+                Err(error)
+            });
+            assert!(matches!(result, Err(PresentError::Vk(e)) if e == error));
+        }
+        // Also reject a misbehaving allocator returning a partial success.
+        let result = allocate_composite_descriptors(&scene_with_draws(count), |_| {
+            Ok(vec![vk::DescriptorSet::null(); count - 1])
+        });
+        assert!(matches!(result, Err(PresentError::Vk(_))));
+    }
+    let empty = allocate_composite_descriptors(&scene_with_draws(0), |_| {
+        panic!("Vulkan forbids a zero-count allocation")
+    })
+    .unwrap();
+    assert!(empty.is_empty());
+}
+
+fn cpu_vk() -> Arc<VkContext> {
+    let _ = env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .is_test(true)
+        .try_init();
+    let vk = VkContext::new().expect("CPU Vulkan required; never silently skip");
+    let properties = unsafe {
+        vk.instance
+            .get_physical_device_properties(vk.physical_device)
+    };
+    assert_eq!(
+        properties.device_type,
+        vk::PhysicalDeviceType::CPU,
+        "select Lavapipe explicitly with VK_DRIVER_FILES"
+    );
+    vk
+}
+
+struct Offscreen {
+    vk: Arc<VkContext>,
+    image: DrawableImage,
+    pool: vk::CommandPool,
+    cb: vk::CommandBuffer,
+    readback: vk::Buffer,
+    memory: vk::DeviceMemory,
+}
+impl Offscreen {
+    fn new(vk: Arc<VkContext>) -> Self {
+        let image = DrawableImage::new_server_owned_window(Arc::clone(&vk), 129, 129).unwrap();
+        unsafe {
+            let pool = vk
+                .device
+                .create_command_pool(
+                    &vk::CommandPoolCreateInfo::default()
+                        .queue_family_index(vk.graphics_queue_family)
+                        .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER),
+                    None,
+                )
+                .unwrap();
+            let cb = vk
+                .device
+                .allocate_command_buffers(
+                    &vk::CommandBufferAllocateInfo::default()
+                        .command_pool(pool)
+                        .level(vk::CommandBufferLevel::PRIMARY)
+                        .command_buffer_count(1),
+                )
+                .unwrap()[0];
+            let readback = vk
+                .device
+                .create_buffer(
+                    &vk::BufferCreateInfo::default()
+                        .size(129 * 129 * 4)
+                        .usage(vk::BufferUsageFlags::TRANSFER_DST)
+                        .sharing_mode(vk::SharingMode::EXCLUSIVE),
+                    None,
+                )
+                .unwrap();
+            let req = vk.device.get_buffer_memory_requirements(readback);
+            let props = vk
+                .instance
+                .get_physical_device_memory_properties(vk.physical_device);
+            let index = (0..props.memory_type_count)
+                .find(|i| {
+                    req.memory_type_bits & (1 << i) != 0
+                        && props.memory_types[*i as usize].property_flags.contains(
+                            vk::MemoryPropertyFlags::HOST_VISIBLE
+                                | vk::MemoryPropertyFlags::HOST_COHERENT,
+                        )
+                })
+                .expect("host coherent readback memory");
+            let memory = vk
+                .device
+                .allocate_memory(
+                    &vk::MemoryAllocateInfo::default()
+                        .allocation_size(req.size)
+                        .memory_type_index(index),
+                    None,
+                )
+                .unwrap();
+            vk.device.bind_buffer_memory(readback, memory, 0).unwrap();
+            Self {
+                vk,
+                image,
+                pool,
+                cb,
+                readback,
+                memory,
+            }
+        }
+    }
+    fn begin(&self) {
+        unsafe {
+            self.vk
+                .device
+                .reset_command_buffer(self.cb, vk::CommandBufferResetFlags::empty())
+                .unwrap();
+            self.vk
+                .device
+                .begin_command_buffer(self.cb, &vk::CommandBufferBeginInfo::default())
+                .unwrap();
+        }
+    }
+    fn submit(&self) {
+        unsafe {
+            let cb = [vk::CommandBufferSubmitInfo::default().command_buffer(self.cb)];
+            self.vk
+                .device
+                .queue_submit2(
+                    self.vk.graphics_queue,
+                    &[vk::SubmitInfo2::default().command_buffer_infos(&cb)],
+                    vk::Fence::null(),
+                )
+                .unwrap();
+            self.vk
+                .device
+                .queue_wait_idle(self.vk.graphics_queue)
+                .unwrap();
+        }
+    }
+    fn barrier(
+        &self,
+        image: vk::Image,
+        old: vk::ImageLayout,
+        new: vk::ImageLayout,
+        src: vk::AccessFlags2,
+        dst: vk::AccessFlags2,
+    ) {
+        let barriers = [vk::ImageMemoryBarrier2::default()
+            .image(image)
+            .old_layout(old)
+            .new_layout(new)
+            .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+            .dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+            .src_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+            .dst_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+            .src_access_mask(src)
+            .dst_access_mask(dst)
+            .subresource_range(
+                vk::ImageSubresourceRange::default()
+                    .aspect_mask(vk::ImageAspectFlags::COLOR)
+                    .level_count(1)
+                    .layer_count(1),
+            )];
+        unsafe {
+            self.vk.device.cmd_pipeline_barrier2(
+                self.cb,
+                &vk::DependencyInfo::default().image_memory_barriers(&barriers),
+            );
+        }
+    }
+    fn initialize_source(&self, source: &DrawableImage) {
+        self.begin();
+        self.barrier(
+            source.vk_image,
+            vk::ImageLayout::UNDEFINED,
+            vk::ImageLayout::TRANSFER_DST_OPTIMAL,
+            vk::AccessFlags2::empty(),
+            vk::AccessFlags2::TRANSFER_WRITE,
+        );
+        unsafe {
+            self.vk.device.cmd_clear_color_image(
+                self.cb,
+                source.vk_image,
+                vk::ImageLayout::TRANSFER_DST_OPTIMAL,
+                &vk::ClearColorValue {
+                    float32: [0.5, 0.0, 0.0, 0.5],
+                },
+                &[vk::ImageSubresourceRange::default()
+                    .aspect_mask(vk::ImageAspectFlags::COLOR)
+                    .level_count(1)
+                    .layer_count(1)],
+            );
+        }
+        self.barrier(
+            source.vk_image,
+            vk::ImageLayout::TRANSFER_DST_OPTIMAL,
+            vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+            vk::AccessFlags2::TRANSFER_WRITE,
+            vk::AccessFlags2::SHADER_SAMPLED_READ,
+        );
+        unsafe {
+            self.vk.device.end_command_buffer(self.cb).unwrap();
+        }
+        self.submit();
+    }
+    fn pixels(&self) -> Vec<u8> {
+        self.begin();
+        self.barrier(
+            self.image.vk_image,
+            vk::ImageLayout::GENERAL,
+            vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
+            vk::AccessFlags2::COLOR_ATTACHMENT_WRITE,
+            vk::AccessFlags2::TRANSFER_READ,
+        );
+        unsafe {
+            self.vk.device.cmd_copy_image_to_buffer(
+                self.cb,
+                self.image.vk_image,
+                vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
+                self.readback,
+                &[vk::BufferImageCopy::default()
+                    .image_subresource(
+                        vk::ImageSubresourceLayers::default()
+                            .aspect_mask(vk::ImageAspectFlags::COLOR)
+                            .layer_count(1),
+                    )
+                    .image_extent(vk::Extent3D {
+                        width: 129,
+                        height: 129,
+                        depth: 1,
+                    })],
+            );
+            let barrier = [vk::MemoryBarrier2::default()
+                .src_stage_mask(vk::PipelineStageFlags2::TRANSFER)
+                .src_access_mask(vk::AccessFlags2::TRANSFER_WRITE)
+                .dst_stage_mask(vk::PipelineStageFlags2::HOST)
+                .dst_access_mask(vk::AccessFlags2::HOST_READ)];
+            self.vk.device.cmd_pipeline_barrier2(
+                self.cb,
+                &vk::DependencyInfo::default().memory_barriers(&barrier),
+            );
+            self.vk.device.end_command_buffer(self.cb).unwrap();
+        }
+        self.submit();
+        unsafe {
+            let ptr = self
+                .vk
+                .device
+                .map_memory(self.memory, 0, 129 * 129 * 4, vk::MemoryMapFlags::empty())
+                .unwrap();
+            let pixels = std::slice::from_raw_parts(ptr.cast::<u8>(), 129 * 129 * 4).to_vec();
+            self.vk.device.unmap_memory(self.memory);
+            pixels
+        }
+    }
+}
+impl ComposeRenderTarget for Offscreen {
+    fn image(&self) -> vk::Image {
+        self.image.vk_image
+    }
+    fn image_view(&self) -> vk::ImageView {
+        self.image.vk_image_view
+    }
+    fn command_buffer(&self) -> vk::CommandBuffer {
+        self.cb
+    }
+    fn completion_semaphore(&self) -> vk::Semaphore {
+        vk::Semaphore::null()
+    }
+    fn width(&self) -> u32 {
+        129
+    }
+    fn height(&self) -> u32 {
+        129
+    }
+    fn timestamp_pool(&self) -> vk::QueryPool {
+        vk::QueryPool::null()
+    }
+    fn set_last_gpu_render_ns(&mut self, _: Option<u64>) {}
+    fn post_compose_preparation(&self) -> Result<PostComposePreparation, PresentError> {
+        Ok(PostComposePreparation::Shared)
+    }
+    fn record_post_compose(&self, _: &VkContext, _: vk::CommandBuffer, _: PostComposePreparation) {
+        self.barrier(
+            self.image.vk_image,
+            vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
+            vk::ImageLayout::GENERAL,
+            vk::AccessFlags2::COLOR_ATTACHMENT_WRITE,
+            vk::AccessFlags2::MEMORY_READ,
+        );
+    }
+}
+
+impl Drop for Offscreen {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = self.vk.device.queue_wait_idle(self.vk.graphics_queue);
+            self.vk.device.destroy_command_pool(self.pool, None);
+            self.vk.device.destroy_buffer(self.readback, None);
+            self.vk.device.free_memory(self.memory, None);
+        }
+    }
+}
+
+#[test]
+#[ignore = "requires VK_DRIVER_FILES pointing to a CPU Vulkan ICD"]
+fn software_composite_renders_every_shape_piece_and_preserves_holes() {
+    let vk = cpu_vk();
+    let pipeline = CompositorPipeline::new(Arc::clone(&vk), vk::Format::B8G8R8A8_UNORM).unwrap();
+    let source = DrawableImage::new_server_owned_window(Arc::clone(&vk), 1, 1).unwrap();
+    let mut rings = [
+        CompositePoolRing::new(Arc::clone(&vk), 1024).unwrap(),
+        CompositePoolRing::new(Arc::clone(&vk), 1024).unwrap(),
+    ];
+    let outputs = [
+        Offscreen::new(Arc::clone(&vk)),
+        Offscreen::new(Arc::clone(&vk)),
+    ];
+    outputs[0].initialize_source(&source);
+    let mut scene = scene_with_draws(4225);
+    for (i, draw) in scene.draws.iter_mut().enumerate() {
+        draw.image_view = source.vk_image_view;
+        draw.dst_origin = [((i % 65) * 2) as f32, ((i / 65) * 2) as f32];
+    }
+    for round in 0..3 {
+        for (output, ring) in outputs.iter().zip(&mut rings) {
+            let slot = ring.acquire(scene.draws.len()).unwrap().unwrap();
+            let descriptors =
+                prepare_composite_descriptors(&vk, &pipeline, ring.pool_at(slot), &scene).unwrap();
+            assert_eq!(descriptors.len(), 4225);
+            // The guard must reject a prefix before touching command state.
+            assert!(
+                record_command_buffer(
+                    &vk,
+                    output,
+                    &pipeline,
+                    &scene,
+                    &descriptors[..1024],
+                    Repaint::Full(output.image.extent),
+                    &[vk::Rect2D {
+                        offset: vk::Offset2D::default(),
+                        extent: output.image.extent
+                    }],
+                    &[],
+                    vk::Pipeline::null(),
+                    vk::PipelineLayout::null()
+                )
+                .is_err()
+            );
+            record_command_buffer(
+                &vk,
+                output,
+                &pipeline,
+                &scene,
+                &descriptors,
+                Repaint::Full(output.image.extent),
+                &[vk::Rect2D {
+                    offset: vk::Offset2D::default(),
+                    extent: output.image.extent,
+                }],
+                &[],
+                vk::Pipeline::null(),
+                vk::PipelineLayout::null(),
+            )
+            .unwrap();
+            output.submit();
+            let pixels = output.pixels();
+            for (i, pixel) in pixels.chunks_exact(4).enumerate() {
+                if i % 129 % 2 == 0 && i / 129 % 2 == 0 {
+                    assert!(
+                        (127..=128).contains(&pixel[0])
+                            && pixel[1] == 0
+                            && (127..=128).contains(&pixel[2])
+                            && pixel[3] == 255,
+                        "round={round} pixel={i} expected one SrcOver blend, got {pixel:?}"
+                    );
+                } else {
+                    assert_eq!(pixel, [255, 0, 0, 255], "hole {i} painted");
+                }
+            }
+            ring.release(slot);
+        }
+    }
+}
+
+/// Replace only vkAllocateDescriptorSets in this test device's dispatch table.
+/// Every other Vulkan call uses Lavapipe. No production fault-injection hooks.
+unsafe extern "system" fn fail_descriptor_batch(
+    _: vk::Device,
+    info: *const vk::DescriptorSetAllocateInfo<'_>,
+    sets: *mut vk::DescriptorSet,
+) -> vk::Result {
+    // Match Vulkan's all-or-nothing failure contract.
+    unsafe {
+        for i in 0..(*info).descriptor_set_count as usize {
+            sets.add(i).write(vk::DescriptorSet::null());
+        }
+    }
+    vk::Result::ERROR_OUT_OF_POOL_MEMORY
+}
+
+#[test]
+#[ignore = "requires VK_DRIVER_FILES pointing to a CPU Vulkan ICD"]
+fn software_allocation_failure_prevents_recording_and_submission() {
+    let mut vk = cpu_vk();
+    let context = Arc::get_mut(&mut vk).unwrap();
+    let mut functions = context.device.fp_v1_0().clone();
+    functions.allocate_descriptor_sets = fail_descriptor_batch;
+    context.device = ash::Device::from_parts_1_3(
+        context.device.handle(),
+        functions,
+        context.device.fp_v1_1().clone(),
+        context.device.fp_v1_2().clone(),
+        context.device.fp_v1_3().clone(),
+    );
+    let pipeline = CompositorPipeline::new(Arc::clone(&vk), vk::Format::B8G8R8A8_UNORM).unwrap();
+    let mut output = Offscreen::new(Arc::clone(&vk));
+    let mut ring = CompositePoolRing::new(Arc::clone(&vk), 1024).unwrap();
+    for count in [1, 1023, 1024, 1025, 4225, 4290] {
+        let slot = ring.acquire(count).unwrap().unwrap();
+        let mut submitted = false;
+        let extent = output.image.extent;
+        let result = record_and_submit_render(
+            &vk,
+            &mut output,
+            &pipeline,
+            ring.pool_at(slot),
+            &scene_with_draws(count),
+            Repaint::Full(extent),
+            &[vk::Rect2D {
+                offset: vk::Offset2D::default(),
+                extent,
+            }],
+            vk::Fence::null(),
+            &mut submitted,
+            &[],
+            vk::Pipeline::null(),
+            vk::PipelineLayout::null(),
+        );
+        assert!(matches!(
+            result,
+            Err(PresentError::Vk(vk::Result::ERROR_OUT_OF_POOL_MEMORY))
+        ));
+        assert!(
+            !submitted,
+            "failed frame must not enter the submitted/ack path"
+        );
+        ring.release(slot);
+    }
+}

--- a/crates/yserver/src/kms/vk/pipeline.rs
+++ b/crates/yserver/src/kms/vk/pipeline.rs
@@ -112,11 +112,9 @@ pub struct CompositorPipeline {
     pub color_format: vk::Format,
 }
 
-/// Soft cap on per-frame draws per output. Used by `CompositePoolRing`
-/// to size each per-output descriptor pool. Resized only if real
-/// sessions show it's not enough — e.g. a complex WM with hundreds of
-/// subwindows + decorations. Most fvwm/wmaker sessions stay well under 256.
-pub const MAX_DESCRIPTOR_SETS_PER_FRAME: u32 = 1024;
+/// Initial per-slot descriptor capacity. Complex SHAPE regions are unbounded;
+/// `CompositePoolRing` grows a free slot to the complete frame's demand.
+pub const INITIAL_DESCRIPTOR_SETS_PER_FRAME: u32 = 1024;
 
 #[derive(Debug, thiserror::Error)]
 pub enum PipelineError {

--- a/docs/pr112-descriptor-fix.md
+++ b/docs/pr112-descriptor-fix.md
@@ -1,0 +1,94 @@
+# PR #112: exact SHAPE clipping and composite descriptor capacity
+
+This branch is rebased on upstream `master` at
+`64d4b6e400f99ac51eb94f5705df2a3b449ec7bc`. It fixes the demonstrated capacity
+and partial-frame failure paths. The RX580 crash reported on the original
+July PR has not been reproduced; this change is not hardware qualification.
+
+## Implementation
+
+- Preserve exact SHAPE Bounding regions for descendants. The current upstream
+  visibility walker uses capped regions for conservative occlusion/damage;
+  those can become bounding boxes. A separate exact ancestor constraint clips
+  each node's placement before emission, in both optimized and reference
+  visibility modes. It derives from the parent's inner region (`winSize`),
+  retaining upstream's border and Clip-shape semantics. No rectangle-count
+  fallback paints mask holes.
+- Normalize shapes once at the backend boundary. Nested intersections use the
+  original PR's canonical YX-band sweep; inner Bounding/Clip intersections now
+  preserve the same representation.
+- Treat 1024 descriptor sets as initial capacity. A free pool slot grows to
+  the next power of two covering the frame's draw count. Held slots are never
+  resized/reset. Replacement is created before destroying the retired pool;
+  growth failure preserves its old handle/capacity and releases the reservation.
+  A failed reset marks the slot for replacement instead of reusing occupied
+  capacity. Per-frame ownership and retirement remain unchanged.
+- Allocate every descriptor for a frame in a single Vulkan batch. Any error
+  propagates before recording or queue submission. The recorder also rejects
+  mismatched draw/descriptor lengths instead of rendering a prefix. Existing
+  submit-error handling retains damage and releases unsubmitted resources.
+- Remove an already-unfulfilled `dead_code` expectation in `scene_diff.rs` so
+  the rebased code passes the repository's exact Clippy gate. No lint is disabled.
+
+## Software evidence
+
+The focused tests explicitly select CPU Vulkan (Lavapipe) and fail rather than
+silently skip if initialization fails or the selected device is not a CPU.
+
+- Full-frame 5120x1440 COW mask: same draw list with/without the single rectangle
+  on two simulated output positions, under both visibility modes.
+- Nested 65x65 stripes: 4225 child pieces, checked pixel by pixel, exceeding both
+  the 32-rectangle occlusion cap and the old 1024-descriptor capacity. The test
+  fails when exact ancestor clipping is temporarily removed (negative control).
+- Production Vulkan descriptor preparation and command recording: offscreen
+  readback of two outputs over three pool-reuse rounds checks every pixel,
+  including the final pieces after descriptor 1024. Holes retain background;
+  covered pixels receive exactly one premultiplied SrcOver blend.
+- Allocation fault injection replaces only `vkAllocateDescriptorSets` in a
+  test device's Ash dispatch table. The actual `record_and_submit_render`
+  path returns `ERROR_OUT_OF_POOL_MEMORY` with `gpu_submitted == false` at
+  draw counts 1, 1023, 1024, 1025, 4225 and 4290. There are no production
+  fault-injection switches. Pure tests also cover host/device-memory errors,
+  invalid partial-success vectors, and the zero-draw case.
+- Pool tests check two independent rings, all three held slots, failed growth,
+  successful retry, retained grown capacity, and count-conversion overflow.
+- Khronos validation layers were loaded from a package extracted under `/tmp`;
+  no system installation was required. Offscreen recorder and allocation-error
+  tests produced no Vulkan validation errors. Lavapipe reports missing external
+  semaphore FD/DRM modifier support, which those headless tests do not use.
+
+## Completed checks (2026-09-09)
+
+- `cargo +nightly fmt` and the format check passed.
+- `cargo clippy --all-targets -- -D warnings` passed with Rust/Clippy 1.98.0,
+  selected using `RUSTUP_TOOLCHAIN=1.98.0`. The default toolchain was unchanged.
+- `cargo test --all-targets --locked`: 2871 passed, zero failures (Rust 1.98.0).
+  The earlier `cargo test --workspace` run also passed on Rust 1.96.1.
+- Seven focused `software` tests passed with Rust 1.98.0, Lavapipe and the
+  Khronos validation layer. The logged pool-reset failures are deliberate
+  fault injection; no Vulkan validation errors were reported.
+- Pool-reset failure is also injected through the test device dispatch table;
+  the following acquisition replaces the pool before any reuse.
+- Default tests requiring Unix sockets ran outside the filesystem/network
+  sandbox after its `bind` restriction was identified. Vulkan stayed on CPU.
+
+Local evidence logs are `/tmp/yserver-pr112-tests-1.98.log`,
+`/tmp/yserver-pr112-clippy-1.98.log`, `/tmp/yserver-pr112-validation-1.98.log`,
+and `/tmp/yserver-pr112-negative-control.log`.
+
+## Reproduction
+
+With a CPU ICD and, optionally, the Khronos validation layer installed:
+
+```sh
+export VK_DRIVER_FILES=/usr/share/vulkan/icd.d/lvp_icd.json
+cargo test -p yserver --lib software -- --include-ignored --nocapture
+cargo test -p yserver --lib pr112_ -- --include-ignored --nocapture
+cargo +nightly fmt
+cargo clippy --all-targets -- -D warnings
+cargo test --workspace
+```
+
+Hardware-dependent ignored tests remain excluded. These runs do not exercise
+DRI3 external-memory import, kernel pageflip/fence handoff, or the reporter's
+restored Plasma session on RADV/Polaris.

--- a/docs/status.md
+++ b/docs/status.md
@@ -590,6 +590,22 @@ lives in [`code-quality-audit-2026-07-26.md`](code-quality-audit-2026-07-26.md).
 
 ## Where we are
 
+- **2026-09-09 PR #112, exact descendant SHAPE clipping and descriptor capacity:**
+  rebased onto `origin/master` at `64d4b6e`. The current visibility walker
+  carries exact ancestor `winSize` separately from capped occlusion/damage
+  regions, preserving Bounding/Clip masks and border/content coordinates.
+  Empty intersections remain empty even when the occlusion region collapses.
+  Composite descriptor pools grow only on free slots to cover the complete
+  frame; descriptor sets allocate in one batch and allocation failure returns
+  before recording/submission, preserving the existing retry/damage path.
+  Software tests cover both visibility modes, two outputs, 4225-piece masks,
+  pixel readback including alpha/holes, pool-growth/reset failure and retry,
+  and injected Vulkan allocation errors at the real submit boundary. Exact
+  CI Clippy passes on Rust 1.98.0; 2871 default tests and seven focused software
+  tests pass, with no Vulkan validation errors in the latter. The RX580
+  crash is not claimed reproduced or fixed; no hardware/KMS tests were run.
+  See [`pr112-descriptor-fix.md`](pr112-descriptor-fix.md) for validation.
+
 - **2026-08-24 direct-scanout fallback-target fix:** a `CowDescendant` root
   Present's pinned redirected paint target need not be the Composite Overlay
   Window itself. Lazy fallback now copies into that exact pinned paint target


### PR DESCRIPTION
## Why

The SHAPE Bounding region applies to a window **and its inferiors**. The KMS
scene walk already accumulated ancestor geometry for parent clipping, but it
did not accumulate ancestor Bounding regions. A shaped parent therefore
clipped its own draw while an unshaped descendant could still paint outside
that shape.

This was visible on non-composited Plasma 6.6 on amdgpu/Strix Halo. KWin
shapes the panel frame into a rounded three-rectangle band inside a
`3440x40` frame, but the unshaped full-height wrapper child was emitted in
full. Its background painted an opaque white band over the panel margin.
Enabling compositing hid the bug because KWin then sampled the shaped window
as a texture and the cut-out was carried by alpha.

The first extents-based attempt also demonstrated why preserving the exact
region matters: it left the four bounding-box corner pixels painted even
though they were outside the rounded mask.

## What changed

- Thread the accumulated ancestor Bounding region through
  `emit_window_subtree` as absolute half-open rectangles.
- Preserve the `None` versus `Some([])` distinction: no shaped ancestor is
  different from an explicitly empty intersection that suppresses the
  subtree.
- Canonicalize SHAPE regions once at the KMS backend boundary so stored
  regions are sorted, non-overlapping YX bands. This also prevents
  overlapping client rectangles from becoming overlapping SrcOver draws in
  a COW subtree.
- Intersect nested regions exactly with a YX-band sweep and consume the
  canonical result once per emitted window.
- Remove the 64-rectangle/bounding-box fallback. Legitimate bitmap masks can
  exceed 64 rectangles, and vertical stripes intersecting horizontal stripes
  can inherently produce the Cartesian product as disjoint output. Replacing
  that exact result with its extents violates SHAPE by painting holes.
- Keep the common draw path lean: an unshaped window emits directly without
  a candidate `Vec`, and a shaped leaf with no shaped ancestor does not build
  an unused absolute-region copy.
- Keep `sampled_ids` and presentation-damage snapshots once per window even
  when one shape produces multiple draws.

## Validation

The original panel case was verified on hardware, including the four
bounding-box corner pixels of the rounded mask. The review follow-ups add
regressions for:

- shaped ancestor + shaped descendant with negative/local offsets;
- two nested shaped ancestors and an unshaped grandchild;
- explicit-empty and empty-intersection propagation;
- a 65 by 65 vertical/horizontal stripe intersection;
- COW multi-piece alpha, sampling, and damage-snapshot bookkeeping;
- backend canonicalization of overlapping and duplicate rectangles.

All repository gates pass:

- `cargo +nightly fmt`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --workspace`
