### PR TITLE
feat(dri3): serve DRI3 1.4 syncobjs through DRM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Build
 target/
 
+# Local DRM/DRI3 protocol reference docs gathered for plan research —
+# not part of the repo (see docs/superpowers/plans/2026-08-08-dri3-syncobj-drm-signal.md).
+/dri3_1.4/
+
 # Runtime logs (reference traces live under docs/assets/)
 *.log
 !docs/assets/*.log

--- a/crates/yserver-core/src/backend/recording.rs
+++ b/crates/yserver-core/src/backend/recording.rs
@@ -591,14 +591,19 @@ impl Backend for RecordingBackend {
         client_id: yserver_protocol::x11::ClientId,
         syncobj_xid: u32,
     ) -> std::io::Result<()> {
-        // One code on the wire — BadValue — for both unknown and not-owner.
-        // Deliberately not Xorg's BadValue/BadAccess split (spec § "Divergence
-        // from Xorg"): the ownership ENFORCEMENT is what matters, the code is
-        // cosmetic and no client branches on it.
-        if self.dri3_syncobj_owners.get(&syncobj_xid) != Some(&client_id) {
+        // Mirror the wire split Xorg gets from dixLookupResourceByType:
+        // unknown -> BadValue (io::Error::other), not the owner -> BadAccess
+        // (PermissionDenied). The handler maps the error kind to the code.
+        let Some(owner) = self.dri3_syncobj_owners.get(&syncobj_xid) else {
             return Err(std::io::Error::other(format!(
-                "DRI3 FreeSyncobj: unknown or not the owning client (0x{syncobj_xid:x})"
+                "DRI3 FreeSyncobj: unknown syncobj 0x{syncobj_xid:x}"
             )));
+        };
+        if *owner != client_id {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                format!("DRI3 FreeSyncobj: 0x{syncobj_xid:x} owned by another client"),
+            ));
         }
         self.dri3_syncobj_owners.remove(&syncobj_xid);
         Ok(())

--- a/crates/yserver-core/src/backend/recording.rs
+++ b/crates/yserver-core/src/backend/recording.rs
@@ -276,6 +276,18 @@ pub struct RecordingBackend {
     /// trait default for `dri3_signal_syncobj` returns `Err` (no real
     /// syncobj backing here), so this override also returns `Ok(())`.
     pub signalled_dri3_syncobjs: Vec<(u32, u64)>,
+    /// Minimal DRI3 syncobj registry for wire-level tests: xid -> owning
+    /// client. Backed by a dummy `SyncobjHandle` so `dri3_syncobj_handle` has
+    /// something to return.
+    pub(crate) dri3_syncobj_owners: std::collections::HashMap<u32, yserver_protocol::x11::ClientId>,
+    /// DRI3 capability surface. Defaults to `Dri3Caps::unsupported()` and is
+    /// a FIELD, not a hardcoded override: the existing
+    /// `dri3_hidden_when_caps_unsupported` test (process_request.rs:37076)
+    /// requires the DEFAULT RecordingBackend to stay unsupported (DRI3 absent
+    /// from QueryExtension/ListExtensions). The syncobj conformance tests
+    /// flip this to a (1, 4)/`syncobj: true` surface so the `IMPORT_SYNCOBJ` /
+    /// `FREE_SYNCOBJ` handlers pass their `caps.syncobj` gate.
+    pub(crate) dri3_caps: crate::backend::Dri3Caps,
     /// `present_id`s passed to `signal_present_wake`, in call order, so
     /// vblank-pacing tests can assert the deferred wake fired.
     pub signalled_present_wakes: Vec<u64>,
@@ -398,6 +410,8 @@ impl RecordingBackend {
             finished_present_source_waits: Vec::new(),
             triggered_dri3_fences: Vec::new(),
             signalled_dri3_syncobjs: Vec::new(),
+            dri3_syncobj_owners: std::collections::HashMap::new(),
+            dri3_caps: crate::backend::Dri3Caps::unsupported(),
             signalled_present_wakes: Vec::new(),
             completed_present_events_to_drain: Vec::new(),
             next_present_source_pin: 1,
@@ -477,6 +491,15 @@ impl RecordingBackend {
     }
 }
 
+#[derive(Debug)]
+struct DummySyncobjHandle;
+
+impl crate::backend::SyncobjHandle for DummySyncobjHandle {
+    fn signal(&self, _value: u64) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
 impl Backend for RecordingBackend {
     // State accessors — return fixed sentinels so the call sites that
     // need a real number get a real number; record nothing.
@@ -542,6 +565,50 @@ impl Backend for RecordingBackend {
     fn dri3_signal_syncobj(&mut self, syncobj_xid: u32, value: u64) -> std::io::Result<()> {
         self.signalled_dri3_syncobjs.push((syncobj_xid, value));
         Ok(())
+    }
+
+    fn dri3_capabilities(&self) -> crate::backend::Dri3Caps {
+        self.dri3_caps
+    }
+
+    fn dri3_import_syncobj(
+        &mut self,
+        client_id: yserver_protocol::x11::ClientId,
+        syncobj_xid: u32,
+        _fd: std::os::fd::OwnedFd,
+    ) -> std::io::Result<()> {
+        self.dri3_syncobj_owners.insert(syncobj_xid, client_id);
+        Ok(())
+    }
+
+    fn dri3_free_syncobj(
+        &mut self,
+        client_id: yserver_protocol::x11::ClientId,
+        syncobj_xid: u32,
+    ) -> std::io::Result<()> {
+        // One code on the wire — BadValue — for both unknown and not-owner.
+        // Deliberately not Xorg's BadValue/BadAccess split (spec § "Divergence
+        // from Xorg"): the ownership ENFORCEMENT is what matters, the code is
+        // cosmetic and no client branches on it.
+        if self.dri3_syncobj_owners.get(&syncobj_xid) != Some(&client_id) {
+            return Err(std::io::Error::other(format!(
+                "DRI3 FreeSyncobj: unknown or not the owning client (0x{syncobj_xid:x})"
+            )));
+        }
+        self.dri3_syncobj_owners.remove(&syncobj_xid);
+        Ok(())
+    }
+
+    fn dri3_syncobj_handle(
+        &self,
+        syncobj_xid: u32,
+    ) -> Option<std::sync::Arc<dyn crate::backend::SyncobjHandle>> {
+        self.dri3_syncobj_owners
+            .contains_key(&syncobj_xid)
+            .then(|| {
+                std::sync::Arc::new(DummySyncobjHandle)
+                    as std::sync::Arc<dyn crate::backend::SyncobjHandle>
+            })
     }
 
     fn apply_device_config(

--- a/crates/yserver-core/src/backend/recording.rs
+++ b/crates/yserver-core/src/backend/recording.rs
@@ -577,6 +577,11 @@ impl Backend for RecordingBackend {
         syncobj_xid: u32,
         _fd: std::os::fd::OwnedFd,
     ) -> std::io::Result<()> {
+        if self.dri3_syncobj_owners.contains_key(&syncobj_xid) {
+            return Err(std::io::Error::other(format!(
+                "DRI3 ImportSyncobj: syncobj 0x{syncobj_xid:x} already imported"
+            )));
+        }
         self.dri3_syncobj_owners.insert(syncobj_xid, client_id);
         Ok(())
     }
@@ -609,6 +614,14 @@ impl Backend for RecordingBackend {
                 std::sync::Arc::new(DummySyncobjHandle)
                     as std::sync::Arc<dyn crate::backend::SyncobjHandle>
             })
+    }
+
+    fn dri3_syncobj_owned(
+        &self,
+        client_id: yserver_protocol::x11::ClientId,
+        syncobj_xid: u32,
+    ) -> bool {
+        self.dri3_syncobj_owners.get(&syncobj_xid) == Some(&client_id)
     }
 
     fn apply_device_config(

--- a/crates/yserver-core/src/backend/trait_def.rs
+++ b/crates/yserver-core/src/backend/trait_def.rs
@@ -2039,19 +2039,27 @@ pub trait Backend {
     }
 
     /// Import a `DRM_SYNCOBJ` fd as a timeline `VkSemaphore` keyed by
-    /// `syncobj_xid`. fd ownership transfers in.
+    /// `syncobj_xid`. fd ownership transfers in. The resource is owned by
+    /// `client_id` — only that client may `FreeSyncobj` it.
     ///
     /// Default impl is unsupported.
     fn dri3_import_syncobj(
         &mut self,
+        _client_id: yserver_protocol::x11::ClientId,
         _syncobj_xid: u32,
         _fd: std::os::fd::OwnedFd,
     ) -> io::Result<()> {
         Err(io::Error::other("DRI3 ImportSyncobj unsupported"))
     }
 
-    /// Drop the timeline `VkSemaphore` keyed by `syncobj_xid`.
-    fn dri3_free_syncobj(&mut self, _syncobj_xid: u32) -> io::Result<()> {
+    /// Drop the timeline `VkSemaphore` keyed by `syncobj_xid`. The
+    /// resource is owned by `client_id`; freeing another client's
+    /// syncobj is an error.
+    fn dri3_free_syncobj(
+        &mut self,
+        _client_id: yserver_protocol::x11::ClientId,
+        _syncobj_xid: u32,
+    ) -> io::Result<()> {
         Err(io::Error::other("DRI3 FreeSyncobj unsupported"))
     }
 

--- a/crates/yserver-core/src/backend/trait_def.rs
+++ b/crates/yserver-core/src/backend/trait_def.rs
@@ -342,13 +342,13 @@ pub trait XshmfenceHandle: std::fmt::Debug + Send + Sync {
     fn trigger(&self) -> std::io::Result<()>;
 }
 
-/// Stage 5 Task 6.1: opaque handle to a DRI3 syncobj's underlying
-/// VkSemaphore. Concrete impl in `yserver::kms::render::owned_semaphore::
-/// OwnedSemaphore`. Held as `Arc<dyn SyncobjHandle>` by the deferred
-/// PRESENT completion path so the underlying semaphore can be
-/// lifetime-pinned past `FreeSyncobj`.
+/// Stage 5 Task 6.1: opaque handle to a DRI3 syncobj. Concrete impl in
+/// `yserver::kms::render::imported_syncobj::ImportedSyncobj`. Held as
+/// `Arc<dyn SyncobjHandle>` by the deferred PRESENT completion path so
+/// the underlying DRM syncobj handle can be lifetime-pinned past
+/// `FreeSyncobj`.
 pub trait SyncobjHandle: std::fmt::Debug + Send + Sync {
-    /// Signal the timeline-semaphore at the given value. Mirrors
+    /// Signal the syncobj timeline point at the given value. Mirrors
     /// the body of the existing `Backend::dri3_signal_syncobj(xid,
     /// value)` after its registry lookup.
     fn signal(&self, value: u64) -> std::io::Result<()>;

--- a/crates/yserver-core/src/backend/trait_def.rs
+++ b/crates/yserver-core/src/backend/trait_def.rs
@@ -2080,6 +2080,20 @@ pub trait Backend {
         None
     }
 
+    /// Whether `client_id` owns the syncobj resource `syncobj_xid`.
+    /// Gates `PresentPixmapSynced` so one client cannot present
+    /// against another client's acquire/release timeline: the syncobj
+    /// xid lookup is client-scoped in Xorg, and signalling a
+    /// non-owned timeline would advance another client's buffer
+    /// reuse out from under it.
+    fn dri3_syncobj_owned(
+        &self,
+        _client_id: yserver_protocol::x11::ClientId,
+        _syncobj_xid: u32,
+    ) -> bool {
+        false
+    }
+
     /// Stage 5 Task 6.1: signal the syncobj timeline point via a held
     /// Arc clone, bypassing xid lookup.
     fn dri3_signal_syncobj_via_handle(

--- a/crates/yserver-core/src/backend/trait_def.rs
+++ b/crates/yserver-core/src/backend/trait_def.rs
@@ -287,10 +287,10 @@ pub struct Dri3Caps {
     /// When false, those requests reject with `BadImplementation`
     /// per the §4 fallback matrix.
     pub fence_fd: bool,
-    /// `VK_KHR_external_semaphore_fd` `OPAQUE_FD` +
-    /// `VK_KHR_timeline_semaphore` + DRM_SYNCOBJ ioctls all
-    /// available. When false, `ImportSyncobj` / `FreeSyncobj` reject
-    /// and the advertised version caps at `(1, 3)`.
+    /// `DRM_CAP_SYNCOBJ_TIMELINE` on the render node — the kernel
+    /// capability that gates the DRM_SYNCOBJ ioctls. When false,
+    /// `ImportSyncobj` / `FreeSyncobj` reject and the advertised
+    /// version caps at `(1, 3)`.
     pub syncobj: bool,
 }
 

--- a/crates/yserver-core/src/core_loop/process_request.rs
+++ b/crates/yserver-core/src/core_loop/process_request.rs
@@ -11550,6 +11550,10 @@ fn handle_dri3_request(
                     DRI3_MAJOR_OPCODE,
                 );
             }
+            debug!(
+                "client {} #{} DRI3::ImportSyncobj 0x{:x} -> imported",
+                client_id.0, sequence.0, req.syncobj
+            );
         }
         x11dri3::FREE_SYNCOBJ => {
             if !caps.syncobj {

--- a/crates/yserver-core/src/core_loop/process_request.rs
+++ b/crates/yserver-core/src/core_loop/process_request.rs
@@ -10094,9 +10094,9 @@ fn handle_present_request(
                 );
             }
             let acquire_known = req.acquire_syncobj != 0
-                && backend.dri3_syncobj_handle(req.acquire_syncobj).is_some();
+                && backend.dri3_syncobj_owned(client_id, req.acquire_syncobj);
             let release_known = req.release_syncobj != 0
-                && backend.dri3_syncobj_handle(req.release_syncobj).is_some();
+                && backend.dri3_syncobj_owned(client_id, req.release_syncobj);
             if !acquire_known
                 || !release_known
                 || req.acquire_value == 0
@@ -37476,12 +37476,13 @@ mod tests {
     fn dispatch_pixmap_synced(
         state: &mut ServerState,
         backend: &mut RecordingBackend,
+        client_id: yserver_protocol::x11::ClientId,
         body: &[u8],
     ) {
         process_request(
             state,
             backend,
-            ClientId(17),
+            client_id,
             SequenceNumber(1),
             RequestHeader {
                 opcode: 145,
@@ -37550,6 +37551,7 @@ mod tests {
         dispatch_pixmap_synced(
             &mut state,
             &mut backend,
+            ClientId(17),
             &pixmap_synced_body(
                 WINDOW_XID,
                 PIXMAP_XID,
@@ -37594,6 +37596,7 @@ mod tests {
         dispatch_pixmap_synced(
             &mut state,
             &mut backend,
+            ClientId(17),
             &pixmap_synced_body(WINDOW_XID, PIXMAP_XID, SYNCOBJ, SYNCOBJ, 0, 2),
         );
 
@@ -37624,6 +37627,7 @@ mod tests {
         dispatch_pixmap_synced(
             &mut state,
             &mut backend,
+            ClientId(17),
             &pixmap_synced_body(WINDOW_XID, PIXMAP_XID, SYNCOBJ, SYNCOBJ, 5, 5),
         );
 
@@ -37634,6 +37638,153 @@ mod tests {
             read_error(&buf),
             x11::error::BAD_VALUE,
             "acquire_value >= release_value on the same syncobj must be BadValue",
+        );
+    }
+
+    #[test]
+    fn import_syncobj_duplicate_xid_is_bad_alloc() {
+        let mut state = ServerState::new();
+        let mut peer = install_client(&mut state, 1);
+        let mut backend = syncobj_cap_backend();
+
+        const XID: u32 = 0x0010_0001;
+        let fd1: std::os::fd::OwnedFd = std::fs::File::open("/dev/null")
+            .expect("open /dev/null")
+            .into();
+        process_request(
+            &mut state,
+            &mut backend,
+            ClientId(1),
+            SequenceNumber(1),
+            RequestHeader {
+                opcode: 147,
+                data: 10, // IMPORT_SYNCOBJ
+                length_units: 3,
+            },
+            &import_syncobj_body(XID),
+            Some(fd1),
+        )
+        .unwrap();
+
+        // Re-import of the SAME xid with a different fd. The handler's
+        // resources.xid_in_use gate only covers core resources, NOT the
+        // backend's syncobj registry — so the duplicate must be caught by the
+        // backend guard, and its Err maps to BadAlloc (matching Xorg, and
+        // the import handler's Err -> BadAlloc mapping).
+        let fd2: std::os::fd::OwnedFd = std::fs::File::open("/dev/null")
+            .expect("open /dev/null")
+            .into();
+        process_request(
+            &mut state,
+            &mut backend,
+            ClientId(1),
+            SequenceNumber(2),
+            RequestHeader {
+                opcode: 147,
+                data: 10, // IMPORT_SYNCOBJ
+                length_units: 3,
+            },
+            &import_syncobj_body(XID),
+            Some(fd2),
+        )
+        .unwrap();
+
+        peer.set_nonblocking(true).unwrap();
+        let mut buf = [0u8; 32];
+        peer.read_exact(&mut buf).unwrap();
+        assert_eq!(
+            read_error(&buf),
+            x11::error::BAD_ALLOC,
+            "re-importing an xid already in the syncobj registry must be BadAlloc, not a silent swap",
+        );
+    }
+
+    #[test]
+    fn present_pixmap_synced_another_clients_acquire_syncobj_is_bad_value() {
+        use yserver_protocol::x11::{ClientId, CreatePixmapRequest, CreateWindowRequest};
+        const WINDOW_XID: u32 = 0x00e0_0403;
+        const PIXMAP_XID: u32 = 0x00e0_0404;
+        const ACQUIRE_SYNCOBJ: u32 = 0x00e0_0bad; // owned by client A (17)
+        const RELEASE_SYNCOBJ: u32 = 0x00e0_0408; // owned by client B (18)
+
+        let mut state = ServerState::new();
+        let _peer_a = install_client(&mut state, 17);
+        let mut peer_b = install_client(&mut state, 18);
+        let mut backend = RecordingBackend::new();
+        backend
+            .dri3_syncobj_owners
+            .insert(ACQUIRE_SYNCOBJ, ClientId(17));
+        backend
+            .dri3_syncobj_owners
+            .insert(RELEASE_SYNCOBJ, ClientId(18));
+
+        state.resources.create_window(
+            ClientId(17),
+            CreateWindowRequest {
+                depth: 24,
+                window: ResourceId(WINDOW_XID),
+                parent: ROOT_WINDOW,
+                x: 0,
+                y: 0,
+                width: 800,
+                height: 600,
+                border_width: 0,
+                class: 1,
+                visual: crate::resources::ROOT_VISUAL,
+                ..Default::default()
+            },
+        );
+        let _ = state.resources.map_window(ResourceId(WINDOW_XID));
+        if let Some(w) = state.resources.window_mut(ResourceId(WINDOW_XID)) {
+            w.host_xid = crate::backend::WindowHandle::from_raw(0x400403);
+        }
+        state.resources.create_pixmap(
+            ClientId(17),
+            CreatePixmapRequest {
+                depth: 24,
+                pixmap: ResourceId(PIXMAP_XID),
+                drawable: ResourceId(WINDOW_XID),
+                width: 800,
+                height: 600,
+            },
+        );
+        let _ = state.resources.set_pixmap_host_xid(
+            ResourceId(PIXMAP_XID),
+            crate::backend::PixmapHandle::from_raw(0x400404).expect("valid host pixmap"),
+        );
+
+        // B presents using A's acquire syncobj. Xorg's VERIFY_DRI3_SYNCOBJ is
+        // client-scoped, so the ownership check must reject B as BadValue —
+        // otherwise B could advance A's timeline on completion and corrupt A's
+        // buffer reuse.
+        dispatch_pixmap_synced(
+            &mut state,
+            &mut backend,
+            ClientId(18),
+            &pixmap_synced_body(
+                WINDOW_XID,
+                PIXMAP_XID,
+                ACQUIRE_SYNCOBJ,
+                RELEASE_SYNCOBJ,
+                1,
+                1,
+            ),
+        );
+
+        peer_b.set_nonblocking(true).unwrap();
+        let mut buf = [0u8; 32];
+        peer_b.read_exact(&mut buf).unwrap();
+        assert_eq!(
+            read_error(&buf),
+            x11::error::BAD_VALUE,
+            "B must not be able to present against A's acquire syncobj",
+        );
+        // X error: bytes 4-7 are the bad-value argument — the offending
+        // acquire xid, mirroring Xorg's VERIFY_DRI3_SYNCOBJ.
+        assert_eq!(
+            u32::from_le_bytes(buf[4..8].try_into().unwrap()),
+            ACQUIRE_SYNCOBJ,
+            "BadValue must carry the offending acquire xid",
         );
     }
 

--- a/crates/yserver-core/src/core_loop/process_request.rs
+++ b/crates/yserver-core/src/core_loop/process_request.rs
@@ -10093,6 +10093,40 @@ fn handle_present_request(
                     PRESENT_MAJOR_OPCODE,
                 );
             }
+            let acquire_known = req.acquire_syncobj != 0
+                && backend.dri3_syncobj_handle(req.acquire_syncobj).is_some();
+            let release_known = req.release_syncobj != 0
+                && backend.dri3_syncobj_handle(req.release_syncobj).is_some();
+            if !acquire_known
+                || !release_known
+                || req.acquire_value == 0
+                || req.release_value == 0
+                || (req.acquire_syncobj == req.release_syncobj
+                    && req.acquire_value >= req.release_value)
+            {
+                // Mirror Xorg's bad-value choice: VERIFY_DRI3_SYNCOBJ
+                // (dri3/dri3.h:51-56) sets client->errorValue = <xid> when the
+                // syncobj lookup fails, while the point/ordering failures
+                // (present_request.c:299-301) leave errorValue 0. This is the
+                // error ARGUMENT, not the error CODE — it is NOT part of the
+                // declared divergence (which covers the code only).
+                let bad_value = if !acquire_known {
+                    req.acquire_syncobj
+                } else if !release_known {
+                    req.release_syncobj
+                } else {
+                    0
+                };
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    x11::error::BAD_VALUE,
+                    bad_value,
+                    u16::from(header.data),
+                    PRESENT_MAJOR_OPCODE,
+                );
+            }
             let caps = backend.present_capabilities(req.window);
             let masked_options = if caps.async_may_tear {
                 req.options
@@ -11477,6 +11511,19 @@ fn handle_dri3_request(
                     DRI3_MAJOR_OPCODE,
                 );
             };
+            if xid_out_of_client_range(state, client_id, req.syncobj)
+                || state.resources.xid_in_use(ResourceId(req.syncobj))
+            {
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    x11::error::BAD_ALLOC,
+                    req.syncobj,
+                    u16::from(header.data),
+                    DRI3_MAJOR_OPCODE,
+                );
+            }
             let Some(fd) = attached_fd else {
                 return emit_x11_error_with_minor(
                     state,
@@ -11488,7 +11535,7 @@ fn handle_dri3_request(
                     DRI3_MAJOR_OPCODE,
                 );
             };
-            if let Err(e) = backend.dri3_import_syncobj(req.syncobj, fd) {
+            if let Err(e) = backend.dri3_import_syncobj(client_id, req.syncobj, fd) {
                 debug!(
                     "client {} #{} DRI3::ImportSyncobj 0x{:x} -> BadAlloc ({e})",
                     client_id.0, sequence.0, req.syncobj
@@ -11527,10 +11574,19 @@ fn handle_dri3_request(
                     DRI3_MAJOR_OPCODE,
                 );
             };
-            if let Err(e) = backend.dri3_free_syncobj(syncobj) {
+            if let Err(e) = backend.dri3_free_syncobj(client_id, syncobj) {
                 debug!(
-                    "client {} #{} DRI3::FreeSyncobj 0x{:x} (warn: {e})",
+                    "client {} #{} DRI3::FreeSyncobj 0x{:x} -> BadValue ({e})",
                     client_id.0, sequence.0, syncobj
+                );
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    x11::error::BAD_VALUE,
+                    syncobj,
+                    u16::from(header.data),
+                    DRI3_MAJOR_OPCODE,
                 );
             }
         }
@@ -37187,6 +37243,396 @@ mod tests {
         let _ = peer_a;
     }
 
+    /// Build an ImportSyncobj request body: syncobj(4) + drawable(4), fd via
+    /// SCM_RIGHTS (attached_fd).
+    fn import_syncobj_body(syncobj: u32) -> Vec<u8> {
+        let mut body = vec![0u8; 8];
+        body[0..4].copy_from_slice(&syncobj.to_le_bytes());
+        body
+    }
+
+    fn read_error(buf: &[u8]) -> u8 {
+        // X error: type=0, error-code at byte 1.
+        assert_eq!(buf[0], 0, "expected an X error, got type {}", buf[0]);
+        buf[1]
+    }
+
+    /// RecordingBackend with a DRI3 1.4 / `syncobj: true` surface so the
+    /// IMPORT_SYNCOBJ / FREE_SYNCOBJ handlers pass their `caps.syncobj` gate.
+    /// Kept as a per-test opt-in: the DEFAULT backend must stay
+    /// `Dri3Caps::unsupported()` for the existing
+    /// `dri3_hidden_when_caps_unsupported` test (process_request.rs:37076).
+    fn syncobj_cap_backend() -> RecordingBackend {
+        let mut backend = RecordingBackend::new();
+        backend.dri3_caps = crate::backend::Dri3Caps {
+            version: (1, 4),
+            modifiers: false,
+            fence_fd: false,
+            syncobj: true,
+        };
+        backend
+    }
+
+    #[test]
+    fn import_syncobj_in_use_xid_is_bad_alloc() {
+        use yserver_protocol::x11::{CreatePixmapRequest, ResourceId};
+        let mut state = ServerState::new();
+        let mut peer = install_client(&mut state, 1);
+        let mut backend = syncobj_cap_backend();
+
+        // install_client (process_request.rs:29047) gives every test client
+        // base=0/mask=u32::MAX — "every xid is in range" — so the
+        // xid_out_of_client_range half of the LEGAL_NEW_RESOURCE gate is
+        // unreachable in this fixture. Exercise the OTHER half: name a
+        // pixmap with the xid, then ImportSyncobj with the same xid ->
+        // resources.xid_in_use fires.
+        const XID: u32 = 0x0040_0001;
+        state.resources.create_pixmap(
+            ClientId(1),
+            CreatePixmapRequest {
+                depth: 24,
+                pixmap: ResourceId(XID),
+                drawable: ROOT_WINDOW,
+                width: 1,
+                height: 1,
+            },
+        );
+
+        process_request(
+            &mut state,
+            &mut backend,
+            ClientId(1),
+            SequenceNumber(1),
+            RequestHeader {
+                opcode: 147,
+                data: 10, // IMPORT_SYNCOBJ
+                length_units: 3,
+            },
+            &import_syncobj_body(XID),
+            None, // no SCM_RIGHTS fd
+        )
+        .unwrap();
+        peer.set_nonblocking(true).unwrap();
+        let mut buf = [0u8; 32];
+        peer.read_exact(&mut buf).unwrap();
+        assert_eq!(
+            read_error(&buf),
+            x11::error::BAD_ALLOC,
+            "an in-use xid must be rejected as BadAlloc",
+        );
+    }
+
+    #[test]
+    fn import_syncobj_missing_fd_is_bad_alloc() {
+        let mut state = ServerState::new();
+        let mut peer = install_client(&mut state, 1);
+        let mut backend = syncobj_cap_backend();
+
+        process_request(
+            &mut state,
+            &mut backend,
+            ClientId(1),
+            SequenceNumber(1),
+            RequestHeader {
+                opcode: 147,
+                data: 10, // IMPORT_SYNCOBJ
+                length_units: 3,
+            },
+            &import_syncobj_body(0x0010_0001), // any xid; install_client is range-permissive
+            None,                              // no fd attached
+        )
+        .unwrap();
+        peer.set_nonblocking(true).unwrap();
+        let mut buf = [0u8; 32];
+        peer.read_exact(&mut buf).unwrap();
+        assert_eq!(
+            read_error(&buf),
+            x11::error::BAD_ALLOC,
+            "ImportSyncobj without an fd must be BadAlloc (yserver's own code — not Xorg's BadValue)",
+        );
+    }
+
+    #[test]
+    fn free_syncobj_unknown_is_bad_value() {
+        let mut state = ServerState::new();
+        let mut peer = install_client(&mut state, 1);
+        let mut backend = syncobj_cap_backend();
+
+        let mut body = vec![0u8; 4];
+        body[0..4].copy_from_slice(&0x0040_9999u32.to_le_bytes());
+        process_request(
+            &mut state,
+            &mut backend,
+            ClientId(1),
+            SequenceNumber(1),
+            RequestHeader {
+                opcode: 147,
+                data: 11, // FREE_SYNCOBJ
+                length_units: 2,
+            },
+            &body,
+            None,
+        )
+        .unwrap();
+        peer.set_nonblocking(true).unwrap();
+        let mut buf = [0u8; 32];
+        peer.read_exact(&mut buf).unwrap();
+        assert_eq!(
+            read_error(&buf),
+            x11::error::BAD_VALUE,
+            "FreeSyncobj of an unknown xid must be BadValue",
+        );
+    }
+
+    #[test]
+    fn free_syncobj_of_another_client_is_bad_value() {
+        let mut state = ServerState::new();
+        let _peer_a = install_client(&mut state, 1);
+        let mut peer_b = install_client(&mut state, 2);
+        let mut backend = syncobj_cap_backend();
+
+        // Client A imports 0x0010_0001 (a legal xid for client 1 — the
+        // handler now validates range). RecordingBackend ignores the fd's
+        // payload, only ownership is recorded.
+        let fd = std::fs::File::open("/dev/null")
+            .expect("open /dev/null")
+            .into();
+        process_request(
+            &mut state,
+            &mut backend,
+            ClientId(1),
+            SequenceNumber(1),
+            RequestHeader {
+                opcode: 147,
+                data: 10,
+                length_units: 3,
+            },
+            &import_syncobj_body(0x0010_0001),
+            Some(fd),
+        )
+        .unwrap();
+
+        // Client B frees A's syncobj. FreeSyncobj has no range check (it is
+        // not a new-resource request), so B can name A's xid — the ownership
+        // check is what must reject it. One code, BadValue — deliberately NOT
+        // Xorg's BadAccess (spec § "Divergence from Xorg").
+        let mut body = vec![0u8; 4];
+        body[0..4].copy_from_slice(&0x0010_0001u32.to_le_bytes());
+        process_request(
+            &mut state,
+            &mut backend,
+            ClientId(2),
+            SequenceNumber(1),
+            RequestHeader {
+                opcode: 147,
+                data: 11,
+                length_units: 2,
+            },
+            &body,
+            None,
+        )
+        .unwrap();
+        peer_b.set_nonblocking(true).unwrap();
+        let mut buf = [0u8; 32];
+        peer_b.read_exact(&mut buf).unwrap();
+        assert_eq!(
+            read_error(&buf),
+            x11::error::BAD_VALUE,
+            "FreeSyncobj of another client's syncobj must be BadValue",
+        );
+
+        // A still owns it (ImportSyncobj is a void request — nothing to read
+        // on A's socket; the ownership assertion is the whole check).
+        assert!(backend.dri3_syncobj_owners.contains_key(&0x0010_0001));
+    }
+
+    /// PresentPixmapSynced 84-byte fixed prefix. Offsets per the :40644
+    /// test's comment: window(0) pixmap(4) serial(8) valid(12) update(16)
+    /// x_off(20) y_off(22) target_crtc(24) acquire_syncobj(28)
+    /// release_syncobj(32) acquire_point(36) release_point(44) options(52)
+    /// pad(56) target_msc(60) divisor(68) remainder(76).
+    fn pixmap_synced_body(
+        window: u32,
+        pixmap: u32,
+        acquire_syncobj: u32,
+        release_syncobj: u32,
+        acquire_point: u64,
+        release_point: u64,
+    ) -> Vec<u8> {
+        let mut body = vec![0u8; 84];
+        body[0..4].copy_from_slice(&window.to_le_bytes());
+        body[4..8].copy_from_slice(&pixmap.to_le_bytes());
+        body[28..32].copy_from_slice(&acquire_syncobj.to_le_bytes());
+        body[32..36].copy_from_slice(&release_syncobj.to_le_bytes());
+        body[36..44].copy_from_slice(&acquire_point.to_le_bytes());
+        body[44..52].copy_from_slice(&release_point.to_le_bytes());
+        body
+    }
+
+    fn dispatch_pixmap_synced(
+        state: &mut ServerState,
+        backend: &mut RecordingBackend,
+        body: &[u8],
+    ) {
+        process_request(
+            state,
+            backend,
+            ClientId(17),
+            SequenceNumber(1),
+            RequestHeader {
+                opcode: 145,
+                data: yserver_protocol::x11::present::PIXMAP_SYNCED,
+                length_units: u32::try_from(1 + body.len() / 4).unwrap(),
+            },
+            body,
+            None,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn present_pixmap_synced_unknown_acquire_syncobj_is_bad_value() {
+        use yserver_protocol::x11::{ClientId, CreatePixmapRequest, CreateWindowRequest};
+        const WINDOW_XID: u32 = 0x00e0_0403;
+        const PIXMAP_XID: u32 = 0x00e0_0404;
+        const ACQUIRE_SYNCOBJ: u32 = 0x00e0_0bad; // never imported
+        const RELEASE_SYNCOBJ: u32 = 0x00e0_0408;
+
+        let mut state = ServerState::new();
+        let mut peer = install_client(&mut state, 17);
+        let mut backend = RecordingBackend::new();
+        // The release syncobj is a valid, imported resource; the acquire is
+        // NOT. Row 4: an unknown acquire xid must produce a Value error, not
+        // a silent no-reply hang.
+        backend
+            .dri3_syncobj_owners
+            .insert(RELEASE_SYNCOBJ, ClientId(17));
+
+        state.resources.create_window(
+            ClientId(17),
+            CreateWindowRequest {
+                depth: 24,
+                window: ResourceId(WINDOW_XID),
+                parent: ROOT_WINDOW,
+                x: 0,
+                y: 0,
+                width: 800,
+                height: 600,
+                border_width: 0,
+                class: 1,
+                visual: crate::resources::ROOT_VISUAL,
+                ..Default::default()
+            },
+        );
+        let _ = state.resources.map_window(ResourceId(WINDOW_XID));
+        if let Some(w) = state.resources.window_mut(ResourceId(WINDOW_XID)) {
+            w.host_xid = crate::backend::WindowHandle::from_raw(0x400403);
+        }
+        state.resources.create_pixmap(
+            ClientId(17),
+            CreatePixmapRequest {
+                depth: 24,
+                pixmap: ResourceId(PIXMAP_XID),
+                drawable: ResourceId(WINDOW_XID),
+                width: 800,
+                height: 600,
+            },
+        );
+        let _ = state.resources.set_pixmap_host_xid(
+            ResourceId(PIXMAP_XID),
+            crate::backend::PixmapHandle::from_raw(0x400404).expect("valid host pixmap"),
+        );
+
+        dispatch_pixmap_synced(
+            &mut state,
+            &mut backend,
+            &pixmap_synced_body(
+                WINDOW_XID,
+                PIXMAP_XID,
+                ACQUIRE_SYNCOBJ,
+                RELEASE_SYNCOBJ,
+                1,
+                1,
+            ),
+        );
+
+        peer.set_nonblocking(true).unwrap();
+        let mut buf = [0u8; 32];
+        peer.read_exact(&mut buf).unwrap();
+        assert_eq!(
+            read_error(&buf),
+            x11::error::BAD_VALUE,
+            "unknown acquire syncobj must be BadValue, not a silent no-reply wait",
+        );
+        // X error: bytes 4-7 are the bad-value argument. It must carry the
+        // offending xid, mirroring Xorg's VERIFY_DRI3_SYNCOBJ
+        // (client->errorValue = id).
+        assert_eq!(
+            u32::from_le_bytes(buf[4..8].try_into().unwrap()),
+            ACQUIRE_SYNCOBJ,
+            "BadValue must carry the offending syncobj xid",
+        );
+    }
+
+    #[test]
+    fn present_pixmap_synced_zero_point_is_bad_value() {
+        use yserver_protocol::x11::ClientId;
+        const WINDOW_XID: u32 = 0x00e0_0403;
+        const PIXMAP_XID: u32 = 0x00e0_0404;
+        const SYNCOBJ: u32 = 0x00e0_0407;
+
+        let mut state = ServerState::new();
+        let mut peer = install_client(&mut state, 17);
+        let mut backend = RecordingBackend::new();
+        backend.dri3_syncobj_owners.insert(SYNCOBJ, ClientId(17));
+
+        // Both syncobjs imported; acquire_point == 0 is the violation.
+        dispatch_pixmap_synced(
+            &mut state,
+            &mut backend,
+            &pixmap_synced_body(WINDOW_XID, PIXMAP_XID, SYNCOBJ, SYNCOBJ, 0, 2),
+        );
+
+        peer.set_nonblocking(true).unwrap();
+        let mut buf = [0u8; 32];
+        peer.read_exact(&mut buf).unwrap();
+        assert_eq!(
+            read_error(&buf),
+            x11::error::BAD_VALUE,
+            "acquire_point 0 must be BadValue"
+        );
+    }
+
+    #[test]
+    fn present_pixmap_synced_acquire_gte_release_is_bad_value() {
+        use yserver_protocol::x11::ClientId;
+        const WINDOW_XID: u32 = 0x00e0_0403;
+        const PIXMAP_XID: u32 = 0x00e0_0404;
+        const SYNCOBJ: u32 = 0x00e0_0407;
+
+        let mut state = ServerState::new();
+        let mut peer = install_client(&mut state, 17);
+        let mut backend = RecordingBackend::new();
+        backend.dri3_syncobj_owners.insert(SYNCOBJ, ClientId(17));
+
+        // Same syncobj for acquire and release: acquire_value >=
+        // release_value is the violation.
+        dispatch_pixmap_synced(
+            &mut state,
+            &mut backend,
+            &pixmap_synced_body(WINDOW_XID, PIXMAP_XID, SYNCOBJ, SYNCOBJ, 5, 5),
+        );
+
+        peer.set_nonblocking(true).unwrap();
+        let mut buf = [0u8; 32];
+        peer.read_exact(&mut buf).unwrap();
+        assert_eq!(
+            read_error(&buf),
+            x11::error::BAD_VALUE,
+            "acquire_value >= release_value on the same syncobj must be BadValue",
+        );
+    }
+
     #[test]
     fn dri3_get_supported_modifiers_default_window_subset_screen() {
         // Default Backend::dri3_supported_modifiers returns
@@ -40667,12 +41113,24 @@ mod tests {
         const UPDATE_REGION_XID: u32 = 0x00e0_0406;
         const ACQUIRE_SYNCOBJ: u32 = 0x00e0_0407;
         const ACQUIRE_VALUE: u64 = 42;
+        const RELEASE_SYNCOBJ: u32 = 0x00e0_0408;
+        const RELEASE_VALUE: u64 = 43;
         const WAIT_ID: u64 = 77;
 
         let mut state = ServerState::new();
         let _peer = install_client(&mut state, CLIENT);
         let mut backend = RecordingBackend::new();
         backend.present_syncobj_wait = crate::backend::PresentSourceWait::Deferred(WAIT_ID);
+        // Task 3: PresentPixmapSynced now validates both syncobjs per
+        // presentproto 1.4 — an unregistered xid (or a None release syncobj)
+        // is a Value error before any arm. Register both as imported so this
+        // test exercises the copy/damage path, not the new rejection.
+        backend
+            .dri3_syncobj_owners
+            .insert(ACQUIRE_SYNCOBJ, ClientId(CLIENT));
+        backend
+            .dri3_syncobj_owners
+            .insert(RELEASE_SYNCOBJ, ClientId(CLIENT));
 
         state.resources.create_window(
             ClientId(CLIENT),
@@ -40752,7 +41210,9 @@ mod tests {
         body[4..8].copy_from_slice(&PIXMAP_XID.to_le_bytes());
         body[16..20].copy_from_slice(&UPDATE_REGION_XID.to_le_bytes());
         body[28..32].copy_from_slice(&ACQUIRE_SYNCOBJ.to_le_bytes());
+        body[32..36].copy_from_slice(&RELEASE_SYNCOBJ.to_le_bytes());
         body[36..44].copy_from_slice(&ACQUIRE_VALUE.to_le_bytes());
+        body[44..52].copy_from_slice(&RELEASE_VALUE.to_le_bytes());
 
         process_request(
             &mut state,

--- a/crates/yserver-core/src/core_loop/process_request.rs
+++ b/crates/yserver-core/src/core_loop/process_request.rs
@@ -11518,8 +11518,21 @@ fn handle_dri3_request(
                     state,
                     client_id,
                     sequence,
-                    x11::error::BAD_ALLOC,
+                    x11::error::BAD_ID_CHOICE,
                     req.syncobj,
+                    u16::from(header.data),
+                    DRI3_MAJOR_OPCODE,
+                );
+            }
+            let drawable_exists = state.resources.window(ResourceId(req.drawable)).is_some()
+                || state.resources.pixmap(ResourceId(req.drawable)).is_some();
+            if !drawable_exists {
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    x11::error::BAD_DRAWABLE,
+                    req.drawable,
                     u16::from(header.data),
                     DRI3_MAJOR_OPCODE,
                 );
@@ -11529,7 +11542,7 @@ fn handle_dri3_request(
                     state,
                     client_id,
                     sequence,
-                    x11::error::BAD_ALLOC,
+                    x11::error::BAD_VALUE,
                     req.syncobj,
                     u16::from(header.data),
                     DRI3_MAJOR_OPCODE,
@@ -11579,15 +11592,24 @@ fn handle_dri3_request(
                 );
             };
             if let Err(e) = backend.dri3_free_syncobj(client_id, syncobj) {
-                debug!(
-                    "client {} #{} DRI3::FreeSyncobj 0x{:x} -> BadValue ({e})",
-                    client_id.0, sequence.0, syncobj
-                );
+                let code = if e.kind() == std::io::ErrorKind::PermissionDenied {
+                    debug!(
+                        "client {} #{} DRI3::FreeSyncobj 0x{:x} -> BadAccess ({e})",
+                        client_id.0, sequence.0, syncobj
+                    );
+                    x11::error::BAD_ACCESS
+                } else {
+                    debug!(
+                        "client {} #{} DRI3::FreeSyncobj 0x{:x} -> BadValue ({e})",
+                        client_id.0, sequence.0, syncobj
+                    );
+                    x11::error::BAD_VALUE
+                };
                 return emit_x11_error_with_minor(
                     state,
                     client_id,
                     sequence,
-                    x11::error::BAD_VALUE,
+                    code,
                     syncobj,
                     u16::from(header.data),
                     DRI3_MAJOR_OPCODE,
@@ -37249,9 +37271,10 @@ mod tests {
 
     /// Build an ImportSyncobj request body: syncobj(4) + drawable(4), fd via
     /// SCM_RIGHTS (attached_fd).
-    fn import_syncobj_body(syncobj: u32) -> Vec<u8> {
+    fn import_syncobj_body(syncobj: u32, drawable: u32) -> Vec<u8> {
         let mut body = vec![0u8; 8];
         body[0..4].copy_from_slice(&syncobj.to_le_bytes());
+        body[4..8].copy_from_slice(&drawable.to_le_bytes());
         body
     }
 
@@ -37278,7 +37301,7 @@ mod tests {
     }
 
     #[test]
-    fn import_syncobj_in_use_xid_is_bad_alloc() {
+    fn import_syncobj_in_use_xid_is_bad_id_choice() {
         use yserver_protocol::x11::{CreatePixmapRequest, ResourceId};
         let mut state = ServerState::new();
         let mut peer = install_client(&mut state, 1);
@@ -37312,7 +37335,9 @@ mod tests {
                 data: 10, // IMPORT_SYNCOBJ
                 length_units: 3,
             },
-            &import_syncobj_body(XID),
+            // drawable=0 is fine here: the xid check (Xorg LEGAL_NEW_RESOURCE)
+            // fires before the drawable check.
+            &import_syncobj_body(XID, 0),
             None, // no SCM_RIGHTS fd
         )
         .unwrap();
@@ -37321,13 +37346,63 @@ mod tests {
         peer.read_exact(&mut buf).unwrap();
         assert_eq!(
             read_error(&buf),
-            x11::error::BAD_ALLOC,
-            "an in-use xid must be rejected as BadAlloc",
+            x11::error::BAD_ID_CHOICE,
+            "an in-use xid must be rejected as BadIDChoice (Xorg LEGAL_NEW_RESOURCE)",
         );
     }
 
     #[test]
-    fn import_syncobj_missing_fd_is_bad_alloc() {
+    fn import_syncobj_bad_drawable_is_bad_drawable() {
+        let mut state = ServerState::new();
+        let mut peer = install_client(&mut state, 1);
+        let mut backend = syncobj_cap_backend();
+
+        // A legal syncobj xid (never used, so no xid_in_use) naming a drawable
+        // that does not exist -> the Xorg drawable check (dixLookupDrawable)
+        // must fire with BadDrawable. It runs AFTER the xid check and BEFORE
+        // the fd check.
+        const SYNCOBJ: u32 = 0x0010_0001;
+        const MISSING_DRAWABLE: u32 = 0x0050_0001;
+        assert!(
+            state
+                .resources
+                .window(ResourceId(MISSING_DRAWABLE))
+                .is_none()
+                && state
+                    .resources
+                    .pixmap(ResourceId(MISSING_DRAWABLE))
+                    .is_none(),
+            "fixture: MISSING_DRAWABLE must not exist"
+        );
+
+        process_request(
+            &mut state,
+            &mut backend,
+            ClientId(1),
+            SequenceNumber(1),
+            RequestHeader {
+                opcode: 147,
+                data: 10, // IMPORT_SYNCOBJ
+                length_units: 3,
+            },
+            &import_syncobj_body(SYNCOBJ, MISSING_DRAWABLE),
+            None, // no SCM_RIGHTS fd
+        )
+        .unwrap();
+        peer.set_nonblocking(true).unwrap();
+        let mut buf = [0u8; 32];
+        peer.read_exact(&mut buf).unwrap();
+        assert_eq!(
+            read_error(&buf),
+            x11::error::BAD_DRAWABLE,
+            "ImportSyncobj naming a nonexistent drawable must be BadDrawable",
+        );
+        // The bad drawable must abort the request: nothing imported.
+        assert!(!backend.dri3_syncobj_owners.contains_key(&SYNCOBJ));
+    }
+
+    #[test]
+    fn import_syncobj_missing_fd_is_bad_value() {
         let mut state = ServerState::new();
         let mut peer = install_client(&mut state, 1);
         let mut backend = syncobj_cap_backend();
@@ -37342,8 +37417,12 @@ mod tests {
                 data: 10, // IMPORT_SYNCOBJ
                 length_units: 3,
             },
-            &import_syncobj_body(0x0010_0001), // any xid; install_client is range-permissive
-            None,                              // no fd attached
+            // legal xid; install_client is range-permissive. drawable=ROOT_WINDOW
+            // (0x100) exists in the default ResourceTable, so the request passes
+            // the xid + drawable checks and lands on the fd check (Xorg:
+            // ReadFdFromClient < 0 -> BadValue).
+            &import_syncobj_body(0x0010_0001, ROOT_WINDOW.0),
+            None, // no fd attached
         )
         .unwrap();
         peer.set_nonblocking(true).unwrap();
@@ -37351,8 +37430,8 @@ mod tests {
         peer.read_exact(&mut buf).unwrap();
         assert_eq!(
             read_error(&buf),
-            x11::error::BAD_ALLOC,
-            "ImportSyncobj without an fd must be BadAlloc (yserver's own code — not Xorg's BadValue)",
+            x11::error::BAD_VALUE,
+            "ImportSyncobj without an fd must be BadValue (Xorg ReadFdFromClient)",
         );
     }
 
@@ -37389,15 +37468,16 @@ mod tests {
     }
 
     #[test]
-    fn free_syncobj_of_another_client_is_bad_value() {
+    fn free_syncobj_of_another_client_is_bad_access() {
         let mut state = ServerState::new();
         let _peer_a = install_client(&mut state, 1);
         let mut peer_b = install_client(&mut state, 2);
         let mut backend = syncobj_cap_backend();
 
         // Client A imports 0x0010_0001 (a legal xid for client 1 — the
-        // handler now validates range). RecordingBackend ignores the fd's
-        // payload, only ownership is recorded.
+        // handler now validates range). drawable=ROOT_WINDOW exists, so the
+        // request passes the xid + drawable checks. RecordingBackend ignores
+        // the fd's payload, only ownership is recorded.
         let fd = std::fs::File::open("/dev/null")
             .expect("open /dev/null")
             .into();
@@ -37411,15 +37491,15 @@ mod tests {
                 data: 10,
                 length_units: 3,
             },
-            &import_syncobj_body(0x0010_0001),
+            &import_syncobj_body(0x0010_0001, ROOT_WINDOW.0),
             Some(fd),
         )
         .unwrap();
 
         // Client B frees A's syncobj. FreeSyncobj has no range check (it is
         // not a new-resource request), so B can name A's xid — the ownership
-        // check is what must reject it. One code, BadValue — deliberately NOT
-        // Xorg's BadAccess (spec § "Divergence from Xorg").
+        // check is what must reject it. Xorg's dixLookupResourceByType with
+        // DixWriteAccess maps a foreign owner to BadAccess.
         let mut body = vec![0u8; 4];
         body[0..4].copy_from_slice(&0x0010_0001u32.to_le_bytes());
         process_request(
@@ -37441,8 +37521,8 @@ mod tests {
         peer_b.read_exact(&mut buf).unwrap();
         assert_eq!(
             read_error(&buf),
-            x11::error::BAD_VALUE,
-            "FreeSyncobj of another client's syncobj must be BadValue",
+            x11::error::BAD_ACCESS,
+            "FreeSyncobj of another client's syncobj must be BadAccess",
         );
 
         // A still owns it (ImportSyncobj is a void request — nothing to read
@@ -37661,7 +37741,7 @@ mod tests {
                 data: 10, // IMPORT_SYNCOBJ
                 length_units: 3,
             },
-            &import_syncobj_body(XID),
+            &import_syncobj_body(XID, ROOT_WINDOW.0),
             Some(fd1),
         )
         .unwrap();
@@ -37684,7 +37764,7 @@ mod tests {
                 data: 10, // IMPORT_SYNCOBJ
                 length_units: 3,
             },
-            &import_syncobj_body(XID),
+            &import_syncobj_body(XID, ROOT_WINDOW.0),
             Some(fd2),
         )
         .unwrap();

--- a/crates/yserver/src/drm/device.rs
+++ b/crates/yserver/src/drm/device.rs
@@ -38,6 +38,25 @@ impl Device {
         })
     }
 
+    /// Open a render node without taking DRM master.
+    ///
+    /// `open` is the KMS-master constructor: it calls `acquire_master_lock`
+    /// and `enable_atomic_capabilities`, both of which a render node rejects
+    /// (`DRM_IOCTL_SET_MASTER` → `EACCES` from a render client). Render nodes
+    /// still serve the `DRM_RENDER_ALLOW` ioctls, which is everything the
+    /// syncobj paths need.
+    pub fn open_render_node(path: &str) -> io::Result<Self> {
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)
+            .map_err(|err| open_error(path, &err))?;
+        Ok(Self {
+            file,
+            path: path.to_string(),
+        })
+    }
+
     pub fn open(path: &str) -> io::Result<Self> {
         let file = OpenOptions::new()
             .read(true)

--- a/crates/yserver/src/kms/render/backend.rs
+++ b/crates/yserver/src/kms/render/backend.rs
@@ -797,13 +797,17 @@ pub struct KmsBackend {
     /// `xshmfence_trigger` directly when the X side wants to
     /// signal idle. Mirrors v1's `dri3_xshmfences` field shape.
     pub(crate) dri3_xshmfences: HashMap<u32, std::sync::Arc<crate::kms::xshmfence::FenceMapping>>,
-    /// DRI3 sync-fence / syncobj resources keyed by the client's
-    /// xid. Either `FenceFromFD` falling through the xshmfence
-    /// path (sync_file fd → `VkSemaphore`) or `ImportSyncobj`
-    /// (drm_syncobj fd → timeline `VkSemaphore`). Mirrors v1's
-    /// `dri3_sync_resources` field shape.
+    /// DRI3 sync-fence resources keyed by the client's xid, from
+    /// `FenceFromFD` falling through the xshmfence path (sync_file fd →
+    /// `VkSemaphore`). Syncobjs live in `dri3_syncobjs`.
     pub(crate) dri3_sync_resources:
         HashMap<u32, std::sync::Arc<crate::kms::render::owned_semaphore::OwnedSemaphore>>,
+    /// DRI3 1.4 syncobj resources keyed by the client's xid, imported by
+    /// `ImportSyncobj`. Separate from `dri3_sync_resources` because these are
+    /// a different X resource type with a different backing primitive: a DRM
+    /// syncobj handle, not a `VkSemaphore`. Task 3 adds the owning client.
+    pub(crate) dri3_syncobjs:
+        HashMap<u32, std::sync::Arc<crate::kms::render::imported_syncobj::ImportedSyncobj>>,
 
     /// Stage 5 Task 6.1: queue of in-flight deferred PRESENT
     /// completion batches. Drained by `drain_completed_present_events`
@@ -2332,6 +2336,7 @@ impl KmsBackend {
             picture_drawable_ids: HashMap::new(),
             dri3_xshmfences: HashMap::new(),
             dri3_sync_resources: HashMap::new(),
+            dri3_syncobjs: HashMap::new(),
             pending_present_batches: std::collections::VecDeque::new(),
             retained_present_wakes: std::collections::HashMap::new(),
             pending_present_source_waits: HashMap::new(),
@@ -3220,6 +3225,7 @@ impl KmsBackend {
             picture_drawable_ids: HashMap::new(),
             dri3_xshmfences: HashMap::new(),
             dri3_sync_resources: HashMap::new(),
+            dri3_syncobjs: HashMap::new(),
             pending_present_batches: std::collections::VecDeque::new(),
             retained_present_wakes: std::collections::HashMap::new(),
             pending_present_source_waits: HashMap::new(),
@@ -13163,7 +13169,7 @@ impl Backend for KmsBackend {
             (None, None)
         } else {
             let syncobj = self
-                .dri3_sync_resources
+                .dri3_syncobjs
                 .get(&acquire_syncobj)
                 .cloned()
                 .ok_or_else(|| {
@@ -13176,7 +13182,7 @@ impl Backend for KmsBackend {
                 Err(e) => {
                     log::warn!(
                         target: "yserver::kms::render::present",
-                        "PresentPixmapSynced DRM eventfd unavailable ({e}); polling Vulkan timeline",
+                        "PresentPixmapSynced DRM eventfd unavailable ({e}); polling the syncobj timeline",
                     );
                     None
                 }
@@ -19292,21 +19298,24 @@ impl Backend for KmsBackend {
         &self,
         syncobj_xid: u32,
     ) -> Option<std::sync::Arc<dyn yserver_core::backend::SyncobjHandle>> {
-        self.dri3_sync_resources
+        self.dri3_syncobjs
             .get(&syncobj_xid)
             .cloned()
             .map(|arc| arc as std::sync::Arc<dyn yserver_core::backend::SyncobjHandle>)
     }
 
     fn dri3_fd_from_fence(&mut self, fence_xid: u32) -> io::Result<std::os::fd::OwnedFd> {
+        let arc = self
+            .dri3_sync_resources
+            .get(&fence_xid)
+            .cloned()
+            .ok_or_else(|| {
+                io::Error::other(format!("DRI3 FDFromFence: unknown fence 0x{fence_xid:x}"))
+            })?;
         let Some(vk) = self.platform.vk.as_ref() else {
             return Err(io::Error::other("DRI3 FDFromFence: Vulkan unavailable"));
         };
-        let arc = self.dri3_sync_resources.get(&fence_xid).ok_or_else(|| {
-            io::Error::other(format!("DRI3 FDFromFence: unknown fence 0x{fence_xid:x}"))
-        })?;
-        let semaphore = arc.semaphore();
-        crate::kms::vk::sync::export_sync_file(vk, semaphore)
+        crate::kms::vk::sync::export_sync_file(vk, arc.semaphore())
             .map_err(|e| io::Error::other(format!("export_sync_file: {e:?}")))
     }
 
@@ -19317,78 +19326,40 @@ impl Backend for KmsBackend {
     ) -> io::Result<()> {
         use std::os::fd::AsFd;
 
-        use ::drm::control::Device as _;
-
-        let Some(vk) = self.platform.vk.as_ref() else {
-            return Err(io::Error::other("DRI3 ImportSyncobj: Vulkan unavailable"));
-        };
-        // Vulkan consumes the opaque fd on successful import. Duplicate it
-        // first and import the duplicate as a process-local DRM handle so
-        // PresentPixmapSynced can register timeline-point eventfds exactly as
-        // Xorg does, without blocking the request thread or polling Vulkan.
-        let drm_handle = match nix::unistd::dup(&fd) {
-            Ok(drm_fd) => match self.platform.device.fd_to_syncobj(drm_fd.as_fd(), false) {
-                Ok(handle) => Some(handle),
-                Err(e) => {
-                    log::warn!(
-                        "DRI3 ImportSyncobj: DRM fd_to_syncobj unavailable ({e}); \
-                         acquire waits will poll the Vulkan timeline"
-                    );
-                    None
-                }
-            },
-            Err(e) => {
-                log::warn!(
-                    "DRI3 ImportSyncobj: dup failed ({e}); acquire waits will poll the Vulkan \
-                     timeline"
-                );
-                None
-            }
-        };
-        let semaphore = match crate::kms::vk::sync::import_drm_syncobj(vk, fd) {
-            Ok(semaphore) => semaphore,
-            Err(e) => {
-                if let Some(handle) = drm_handle
-                    && let Err(destroy_err) = self.platform.device.destroy_syncobj(handle)
-                {
-                    log::warn!(
-                        "DRI3 ImportSyncobj rollback: destroy DRM handle failed: {destroy_err}"
-                    );
-                }
-                return Err(io::Error::other(format!("import_drm_syncobj: {e:?}")));
-            }
-        };
-        let owned = std::sync::Arc::new(if let Some(handle) = drm_handle {
-            crate::kms::render::owned_semaphore::OwnedSemaphore::new_drm_syncobj(
-                vk.clone(),
-                semaphore,
-                self.platform.device.clone(),
-                handle,
-            )
-        } else {
-            crate::kms::render::owned_semaphore::OwnedSemaphore::new(vk.clone(), semaphore)
-        });
-        // Arc Drop on the replaced entry handles vkDestroySemaphore if
-        // no other clone is outstanding.
-        let _ = self.dri3_sync_resources.insert(syncobj_xid, owned);
+        let render_node = self
+            .platform
+            .render_node_device
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| {
+                io::Error::other("DRI3 ImportSyncobj: render node not resolved at init")
+            })?;
+        let imported =
+            crate::kms::render::imported_syncobj::ImportedSyncobj::import(render_node, fd.as_fd())?;
+        // Arc Drop on any replaced entry destroys the previous handle.
+        let _ = self
+            .dri3_syncobjs
+            .insert(syncobj_xid, std::sync::Arc::new(imported));
         Ok(())
     }
 
     fn dri3_free_syncobj(&mut self, syncobj_xid: u32) -> io::Result<()> {
-        // Vulkan no longer required here — Arc Drop calls
-        // vkDestroySemaphore when the last reference goes away.
-        let _ = self.dri3_sync_resources.remove(&syncobj_xid);
+        // Arc Drop destroys the DRM handle when the last reference goes away,
+        // which may be later than this call: the deferred completion path
+        // pins clones past FreeSyncobj.
+        let _ = self.dri3_syncobjs.remove(&syncobj_xid);
         Ok(())
     }
 
     fn dri3_signal_syncobj(&mut self, syncobj_xid: u32, value: u64) -> io::Result<()> {
-        let arc = self.dri3_sync_resources.get(&syncobj_xid).ok_or_else(|| {
+        use yserver_core::backend::SyncobjHandle as _;
+
+        let arc = self.dri3_syncobjs.get(&syncobj_xid).ok_or_else(|| {
             io::Error::other(format!(
                 "DRI3 SignalSyncobj: unknown syncobj 0x{syncobj_xid:x}"
             ))
         })?;
-        arc.signal_vk(value)
-            .map_err(|e| io::Error::other(format!("vkSignalSemaphore: {e:?}")))
+        arc.signal(value)
     }
 
     /// Stage 5 Task 6.1 — queue a deferred PRESENT completion.
@@ -28055,30 +28026,75 @@ mod tests {
         assert_ne!(pre, post, "trigger() should have changed the fence state");
     }
 
-    /// `dri3_import_syncobj`'s no-Vk branch errs cleanly. Builds
-    /// an `OwnedFd` from `/dev/null` and verifies the Vk-gate
-    /// triggers before any external lib gets the fd — exercises
-    /// the "Vk-required" guard mirroring v1's body. We use
-    /// `IntoRawFd` + `FromRawFd` to keep the fd lifetime
-    /// explicit since no Vk path runs.
+    /// Fences and syncobjs are different X resource types with different
+    /// backing primitives. Each resolver must see only its own registry: before
+    /// the split they shared one map, so FDFromFence on a syncobj xid resolved
+    /// and half-worked.
     #[test]
-    fn dri3_import_syncobj_no_vk_errs() {
+    #[ignore = "needs a DRM render node"]
+    fn each_resolver_sees_only_its_own_registry() {
+        // Shared helper from Task 1 — never hardcode renderD128, see its doc
+        // comment for why (multi-GPU hosts pick the wrong device silently).
+        let Some(drm) = crate::kms::render::imported_syncobj::tests::render_node() else {
+            eprintln!("skipping: no render node");
+            return;
+        };
+        let handle =
+            ::drm::control::Device::create_syncobj(drm.as_ref(), false).expect("create syncobj");
+        let fd =
+            ::drm::control::Device::syncobj_to_fd(drm.as_ref(), handle, false).expect("export fd");
+
+        let mut b = KmsBackend::for_tests();
+        let xid = 0xAAAA_BBBB_u32;
+        b.dri3_syncobjs.insert(
+            xid,
+            std::sync::Arc::new(
+                crate::kms::render::imported_syncobj::ImportedSyncobj::import(
+                    drm.clone(),
+                    std::os::fd::AsFd::as_fd(&fd),
+                )
+                .expect("import"),
+            ),
+        );
+
+        // The syncobj resolver finds it.
+        assert!(
+            b.dri3_syncobj_handle(xid).is_some(),
+            "syncobj registry must resolve a syncobj xid",
+        );
+        // The fence resolver must NOT, and must say so as an unknown fence
+        // rather than tripping over some other gate first.
+        let err = b
+            .dri3_fd_from_fence(xid)
+            .expect_err("FDFromFence must not resolve a syncobj xid");
+        assert!(
+            err.to_string().contains("unknown fence"),
+            "expected an unknown-fence error, got: {err}",
+        );
+
+        ::drm::control::Device::destroy_syncobj(drm.as_ref(), handle).expect("destroy");
+    }
+
+    /// ImportSyncobj no longer needs Vulkan. for_tests() has no render node,
+    /// so feed it a bogus one and assert the ioctl — not the device guard —
+    /// is what fails.
+    #[test]
+    fn dri3_import_syncobj_errs_without_a_usable_drm_handle() {
         use std::os::fd::{FromRawFd, IntoRawFd, OwnedFd};
         let f = std::fs::OpenOptions::new()
             .read(true)
             .open("/dev/null")
             .expect("open /dev/null");
-        // SAFETY: we own this fd via the OpenOptions handle; we
-        // re-wrap it as OwnedFd directly. No Vk path runs, the
-        // function returns Err immediately, and the OwnedFd's
-        // Drop closes it cleanly.
-        let raw = f.into_raw_fd();
-        let fd = unsafe { OwnedFd::from_raw_fd(raw) };
+        // SAFETY: we own this fd via the OpenOptions handle and re-wrap it
+        // directly; the OwnedFd's Drop closes it.
+        let fd = unsafe { OwnedFd::from_raw_fd(f.into_raw_fd()) };
         let mut b = KmsBackend::for_tests();
-        let res = b.dri3_import_syncobj(0x4040_3333, fd);
+        b.platform.render_node_device = Some(std::sync::Arc::new(
+            crate::drm::Device::open_render_node("/dev/null").expect("open /dev/null"),
+        ));
         assert!(
-            res.is_err(),
-            "import_syncobj without Vk must Err on the Vk gate",
+            b.dri3_import_syncobj(0x4040_3333, fd).is_err(),
+            "importing a non-syncobj fd must Err",
         );
     }
 
@@ -30007,26 +30023,40 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "needs a DRM render node"]
     fn syncobj_handle_accessor_returns_arc_clone() {
-        let mut b = match crate::kms::render::KmsBackend::for_tests_with_vk() {
-            Ok(b) => b,
-            Err(e) => {
-                eprintln!("skipping: no Vk: {e}");
-                return;
-            }
+        // Shared helper from Task 1 — never hardcode renderD128.
+        let Some(drm) = crate::kms::render::imported_syncobj::tests::render_node() else {
+            eprintln!("skipping: no render node");
+            return;
         };
+        let handle =
+            ::drm::control::Device::create_syncobj(drm.as_ref(), false).expect("create syncobj");
+        let fd =
+            ::drm::control::Device::syncobj_to_fd(drm.as_ref(), handle, false).expect("export fd");
+
+        let mut b = KmsBackend::for_tests();
         let xid = 0xAAAA_BBBB_u32;
-        let vk = b.platform.vk.as_ref().expect("vk live").clone();
-        let sem = crate::kms::render::owned_semaphore::OwnedSemaphore::for_tests_dummy(vk);
-        b.dri3_sync_resources.insert(xid, std::sync::Arc::new(sem));
+        b.dri3_syncobjs.insert(
+            xid,
+            std::sync::Arc::new(
+                crate::kms::render::imported_syncobj::ImportedSyncobj::import(
+                    drm.clone(),
+                    std::os::fd::AsFd::as_fd(&fd),
+                )
+                .expect("import"),
+            ),
+        );
+
         let h = b.dri3_syncobj_handle(xid).expect("handle present");
         assert_eq!(std::sync::Arc::strong_count(&h), 2);
-        b.dri3_sync_resources.remove(&xid);
-        // Accessor returns None now; held Arc still pins the
-        // OwnedSemaphore alive (no destructor panic on drop).
+        b.dri3_syncobjs.remove(&xid);
+        // Accessor returns None now; the held Arc still pins the resource
+        // alive, which is what the deferred completion path relies on.
         assert!(b.dri3_syncobj_handle(xid).is_none());
-        drop(h); // OwnedSemaphore::Drop fires here; null guard
-        // skips destroy_semaphore.
+        drop(h);
+
+        ::drm::control::Device::destroy_syncobj(drm.as_ref(), handle).expect("destroy");
     }
 
     // ─── Task 10: held-key tracking + synthesize-releases tests ───

--- a/crates/yserver/src/kms/render/backend.rs
+++ b/crates/yserver/src/kms/render/backend.rs
@@ -19390,9 +19390,10 @@ impl Backend for KmsBackend {
             )));
         };
         if *owner != client_id {
-            return Err(io::Error::other(format!(
-                "DRI3 FreeSyncobj: 0x{syncobj_xid:x} owned by another client"
-            )));
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!("DRI3 FreeSyncobj: 0x{syncobj_xid:x} owned by another client"),
+            ));
         }
         // Arc Drop destroys the DRM handle when the last reference goes away,
         // which may be later than this call: the deferred completion path

--- a/crates/yserver/src/kms/render/backend.rs
+++ b/crates/yserver/src/kms/render/backend.rs
@@ -1057,8 +1057,10 @@ fn mode_timing(m: &crate::drm::modeset::Mode) -> Option<yserver_core::randr::Mod
 /// driver, in libglvnd priority order.
 ///
 /// Same shape as the other per-driver policies in this tree —
-/// `scanout_prefers_linear` (`kms/vk/scanout.rs:922`) and
-/// `VkContext::supports_dri3_syncobj` (`kms/vk/device.rs:88`).
+/// `scanout_prefers_linear` (`kms/vk/scanout.rs:922`). DRI3 syncobj
+/// used to be one of them (`VkContext::supports_dri3_syncobj`), but it
+/// is a kernel capability now: `DRM_CAP_SYNCOBJ_TIMELINE` on the render
+/// node (`PlatformBackend::syncobj_timeline`), not a driver branch.
 ///
 /// Deliberately binary. Every non-NVIDIA driver keeps "mesa": an
 /// unmeasured mapping that redirects a configuration working today onto
@@ -12176,6 +12178,13 @@ impl KmsBackend {
     }
 }
 
+/// DRI3 version for a given syncobj capability. 1.4 is the version carrying
+/// `ImportSyncobj` / `FreeSyncobj`; without them the server caps at 1.3 and
+/// clients fall back to the fence path.
+fn dri3_version_for(syncobj: bool) -> (u32, u32) {
+    if syncobj { (1, 4) } else { (1, 3) }
+}
+
 impl Backend for KmsBackend {
     // ── A. Accessors (mirror KmsBackend exactly) ────────────────
 
@@ -18981,26 +18990,26 @@ impl Backend for KmsBackend {
     }
 
     fn dri3_capabilities(&self) -> Dri3Caps {
-        // DRI3 entirely unavailable when render-node fd or Vulkan
-        // weren't resolved at backend init.
-        if self.platform.render_node_fd.is_none() || self.platform.vk.is_none() {
+        // DRI3 entirely unavailable when the render-node device or Vulkan
+        // weren't resolved at backend init: pixmap import/export still needs
+        // both. `render_node_device` is the guard here (not the bare
+        // `render_node_fd`) because it is what the syncobj ioctls and the
+        // capability query run on.
+        if self.platform.render_node_device.is_none() || self.platform.vk.is_none() {
             return Dri3Caps::unsupported();
         }
         let vk = self.platform.vk.as_ref().expect("vk Some by branch above");
         let modifiers = vk.image_drm_format_modifier;
-        // VK_KHR_external_semaphore_fd is unconditionally enabled at
-        // device init; fence_fd / SYNC_FD handle type rides along
-        // with it. syncobj uses the OPAQUE_FD + timeline-semaphore
-        // path also covered by VK_KHR_external_semaphore_fd. NVIDIA
-        // proprietary rejects that import path, so cap syncobj per
-        // driver and let affected clients fall back to fence-fd.
+        // VK_KHR_external_semaphore_fd is unconditionally enabled at device
+        // init; fence_fd / SYNC_FD handle type rides along with it.
         let fence_fd = true;
-        let syncobj = vk.supports_dri3_syncobj();
-        // Version cap per Phase 4.2 design §4: with syncobj
-        // advertise (1, 4); without it cap at (1, 3).
-        let version = if syncobj { (1, 4) } else { (1, 3) };
+        // Syncobj support is a property of the KERNEL, not of the Vulkan
+        // driver. The previous NVIDIA blacklist here was a correct response
+        // to vkImportSemaphoreFdKHR rejecting DRM syncobj fds, which no
+        // longer matters because nothing imports them into Vulkan.
+        let syncobj = self.platform.syncobj_timeline;
         Dri3Caps {
-            version,
+            version: dri3_version_for(syncobj),
             modifiers,
             fence_fd,
             syncobj,
@@ -19287,10 +19296,11 @@ impl Backend for KmsBackend {
             return Ok(());
         }
         // VkSemaphore-backed fences: signalling is done via queue
-        // submit (or vkSignalSemaphore for timeline). For Phase 4.2
-        // first-cut Copy path the GPU work is already serialized,
-        // so a server-only `triggered=true` mirror is sufficient
-        // — no GPU operation needed here.
+        // submit. (DRI3 1.4 syncobjs are the other path — DRM objects
+        // signalled by the `SYNCOBJ_TIMELINE_SIGNAL` ioctls, never
+        // Vulkan.) For Phase 4.2 first-cut Copy path the GPU work is
+        // already serialized, so a server-only `triggered=true` mirror
+        // is sufficient — no GPU operation needed here.
         Ok(())
     }
 
@@ -20656,9 +20666,9 @@ fn subtract_one_rect_clip(outer: ash::vk::Rect2D, inner: ash::vk::Rect2D) -> Vec
 mod tests {
     use super::{
         KmsBackend, PaintTarget, PictureRecord, RandrIdAllocator, compute_copy_area_dst_rects,
-        compute_render_composite_clip, dst_picture_clip_by_children, glx_vendor_names_for_driver,
-        intersect_rect_with_clip, mode_timing, reconcile_connector_probe,
-        resolve_picture_for_render,
+        compute_render_composite_clip, dri3_version_for, dst_picture_clip_by_children,
+        glx_vendor_names_for_driver, intersect_rect_with_clip, mode_timing,
+        reconcile_connector_probe, resolve_picture_for_render,
     };
     use crate::kms::{
         cpu_types::{Rectangle16, Repeat},
@@ -27922,56 +27932,20 @@ mod tests {
         assert!(b.dri3_trigger_fence(0x4040_4040).is_ok());
     }
 
-    /// Vk-backed: DRI3 capabilities expose `fence_fd` when a real
-    /// `VkContext` is attached, and only expose syncobj on drivers
-    /// whose external timeline import path is supported.
-    /// Gated `#[ignore]` because it needs lavapipe (or any live
-    /// Vulkan ICD).
+    /// DRI3 version follows syncobj support, and syncobj support follows the
+    /// kernel capability rather than the Vulkan driver. `for_tests()` has no
+    /// render node, so the capability is false and the version must be 1.3 —
+    /// which is also the check that would have caught a blacklist creeping back.
     #[test]
-    #[ignore = "needs live Vulkan ICD"]
-    fn dri3_capabilities_v14_with_syncobj_when_vk_attached() {
-        let b = match KmsBackend::for_tests_with_vk() {
-            Ok(b) => b,
-            Err(e) => {
-                eprintln!("skip: no Vk: {e}");
-                return;
-            }
-        };
-        let caps = b.dri3_capabilities();
-        // for_tests_with_vk still has render_node_fd: None
-        // (no real DRM device). The guard checks render_node_fd
-        // first → caps come back unsupported even with Vk.
-        // Verify that branch is what reports unsupported, then
-        // bypass it for the version + syncobj assertion by
-        // injecting a synthetic render-node fd into platform.
-        assert_eq!(
-            caps.version,
-            (0, 0),
-            "without render_node_fd, even with Vk, dri3 is gated unsupported",
+    fn dri3_syncobj_follows_the_kernel_capability() {
+        assert_eq!(dri3_version_for(true), (1, 4));
+        assert_eq!(dri3_version_for(false), (1, 3));
+
+        let b = KmsBackend::for_tests();
+        assert!(
+            !b.platform.syncobj_timeline,
+            "for_tests() has no render node, so the capability must be false",
         );
-        // Now stuff in a synthetic render-node fd so the guard
-        // passes; use /dev/null which is openable + safely
-        // droppable. The cap accessor doesn't actually use the
-        // fd, just checks Some-ness.
-        let mut b = b;
-        b.platform.render_node_fd = Some(
-            std::fs::OpenOptions::new()
-                .read(true)
-                .open("/dev/null")
-                .expect("open /dev/null")
-                .into(),
-        );
-        let caps = b.dri3_capabilities();
-        assert!(caps.fence_fd);
-        assert_eq!(
-            caps.syncobj,
-            b.platform.vk.as_ref().unwrap().supports_dri3_syncobj()
-        );
-        assert_eq!(caps.version, if caps.syncobj { (1, 4) } else { (1, 3) });
-        // `modifiers` reflects whether the device picked up
-        // VK_EXT_image_drm_format_modifier — lavapipe does, Venus
-        // does. Just assert the field is set consistently with
-        // what the Vk layer reported (no hard true-here).
     }
 
     /// Vk-backed: `dri3_import_pixmap` rejects unsupported

--- a/crates/yserver/src/kms/render/backend.rs
+++ b/crates/yserver/src/kms/render/backend.rs
@@ -19355,6 +19355,11 @@ impl Backend for KmsBackend {
             .ok_or_else(|| {
                 io::Error::other("DRI3 ImportSyncobj: render node not resolved at init")
             })?;
+        if self.dri3_syncobjs.contains_key(&syncobj_xid) {
+            return Err(io::Error::other(format!(
+                "DRI3 ImportSyncobj: syncobj 0x{syncobj_xid:x} already imported"
+            )));
+        }
         let imported =
             crate::kms::render::imported_syncobj::ImportedSyncobj::import(render_node, fd.as_fd())?;
         // Arc Drop on any replaced entry destroys the previous handle.

--- a/crates/yserver/src/kms/render/backend.rs
+++ b/crates/yserver/src/kms/render/backend.rs
@@ -803,11 +803,19 @@ pub struct KmsBackend {
     pub(crate) dri3_sync_resources:
         HashMap<u32, std::sync::Arc<crate::kms::render::owned_semaphore::OwnedSemaphore>>,
     /// DRI3 1.4 syncobj resources keyed by the client's xid, imported by
-    /// `ImportSyncobj`. Separate from `dri3_sync_resources` because these are
-    /// a different X resource type with a different backing primitive: a DRM
-    /// syncobj handle, not a `VkSemaphore`. Task 3 adds the owning client.
-    pub(crate) dri3_syncobjs:
-        HashMap<u32, std::sync::Arc<crate::kms::render::imported_syncobj::ImportedSyncobj>>,
+    /// `ImportSyncobj`. The tuple's first element is the importing client —
+    /// Xorg models a DRI3 syncobj as a first-class X resource owned by a
+    /// client (`dri3_syncobj_type = CreateNewResourceType(...)`), and every
+    /// conformance property in the spec's table falls out of that one
+    /// decision: `FreeSyncobj` ownership, the disconnect purge, and the
+    /// `PresentPixmapSynced` xid checks.
+    pub(crate) dri3_syncobjs: HashMap<
+        u32,
+        (
+            yserver_protocol::x11::ClientId,
+            std::sync::Arc<crate::kms::render::imported_syncobj::ImportedSyncobj>,
+        ),
+    >,
 
     /// Stage 5 Task 6.1: queue of in-flight deferred PRESENT
     /// completion batches. Drained by `drain_completed_present_events`
@@ -13171,7 +13179,7 @@ impl Backend for KmsBackend {
             let syncobj = self
                 .dri3_syncobjs
                 .get(&acquire_syncobj)
-                .cloned()
+                .map(|(_, arc)| arc.clone())
                 .ok_or_else(|| {
                     io::Error::other(format!(
                         "PresentPixmapSynced: unknown acquire syncobj 0x{acquire_syncobj:x}"
@@ -14365,6 +14373,8 @@ impl Backend for KmsBackend {
     }
 
     fn client_disconnected(&mut self, client_id: yserver_protocol::x11::ClientId) {
+        self.dri3_syncobjs
+            .retain(|_, (owner, _)| *owner != client_id);
         self.scene.root_overlay_on_disconnect(client_id);
     }
 
@@ -19300,7 +19310,7 @@ impl Backend for KmsBackend {
     ) -> Option<std::sync::Arc<dyn yserver_core::backend::SyncobjHandle>> {
         self.dri3_syncobjs
             .get(&syncobj_xid)
-            .cloned()
+            .map(|(_, arc)| arc.clone())
             .map(|arc| arc as std::sync::Arc<dyn yserver_core::backend::SyncobjHandle>)
     }
 
@@ -19321,6 +19331,7 @@ impl Backend for KmsBackend {
 
     fn dri3_import_syncobj(
         &mut self,
+        client_id: yserver_protocol::x11::ClientId,
         syncobj_xid: u32,
         fd: std::os::fd::OwnedFd,
     ) -> io::Result<()> {
@@ -19339,11 +19350,25 @@ impl Backend for KmsBackend {
         // Arc Drop on any replaced entry destroys the previous handle.
         let _ = self
             .dri3_syncobjs
-            .insert(syncobj_xid, std::sync::Arc::new(imported));
+            .insert(syncobj_xid, (client_id, std::sync::Arc::new(imported)));
         Ok(())
     }
 
-    fn dri3_free_syncobj(&mut self, syncobj_xid: u32) -> io::Result<()> {
+    fn dri3_free_syncobj(
+        &mut self,
+        client_id: yserver_protocol::x11::ClientId,
+        syncobj_xid: u32,
+    ) -> io::Result<()> {
+        let Some((owner, _)) = self.dri3_syncobjs.get(&syncobj_xid) else {
+            return Err(io::Error::other(format!(
+                "DRI3 FreeSyncobj: unknown syncobj 0x{syncobj_xid:x}"
+            )));
+        };
+        if *owner != client_id {
+            return Err(io::Error::other(format!(
+                "DRI3 FreeSyncobj: 0x{syncobj_xid:x} owned by another client"
+            )));
+        }
         // Arc Drop destroys the DRM handle when the last reference goes away,
         // which may be later than this call: the deferred completion path
         // pins clones past FreeSyncobj.
@@ -19354,11 +19379,15 @@ impl Backend for KmsBackend {
     fn dri3_signal_syncobj(&mut self, syncobj_xid: u32, value: u64) -> io::Result<()> {
         use yserver_core::backend::SyncobjHandle as _;
 
-        let arc = self.dri3_syncobjs.get(&syncobj_xid).ok_or_else(|| {
-            io::Error::other(format!(
-                "DRI3 SignalSyncobj: unknown syncobj 0x{syncobj_xid:x}"
-            ))
-        })?;
+        let arc = self
+            .dri3_syncobjs
+            .get(&syncobj_xid)
+            .map(|(_, arc)| arc)
+            .ok_or_else(|| {
+                io::Error::other(format!(
+                    "DRI3 SignalSyncobj: unknown syncobj 0x{syncobj_xid:x}"
+                ))
+            })?;
         arc.signal(value)
     }
 
@@ -22910,6 +22939,46 @@ mod tests {
             yserver_protocol::x11::ClientId(5),
         );
         assert!(b.scene.root_overlay.is_empty());
+    }
+
+    #[test]
+    #[ignore = "needs a DRM render node"]
+    fn client_disconnected_purges_owned_syncobjs() {
+        use std::os::fd::AsFd;
+        use yserver_protocol::x11::ClientId;
+
+        // Shared helper from Task 1 — never hardcode renderD128.
+        let Some(drm) = crate::kms::render::imported_syncobj::tests::render_node() else {
+            eprintln!("skipping: no render node");
+            return;
+        };
+        let mk = |_value: u64| {
+            let handle = ::drm::control::Device::create_syncobj(drm.as_ref(), false)
+                .expect("create syncobj");
+            let fd = ::drm::control::Device::syncobj_to_fd(drm.as_ref(), handle, false)
+                .expect("export fd");
+            let imported = crate::kms::render::imported_syncobj::ImportedSyncobj::import(
+                drm.clone(),
+                fd.as_fd(),
+            )
+            .expect("import");
+            ::drm::control::Device::destroy_syncobj(drm.as_ref(), handle).expect("destroy");
+            std::sync::Arc::new(imported)
+        };
+
+        let mut b = KmsBackend::for_tests();
+        b.dri3_syncobjs.insert(0x0040_0001, (ClientId(7), mk(1)));
+        b.dri3_syncobjs.insert(0x0040_0002, (ClientId(8), mk(1)));
+
+        yserver_core::backend::Backend::client_disconnected(&mut b, ClientId(7));
+        assert!(
+            b.dri3_syncobjs.contains_key(&0x0040_0002),
+            "another client's syncobj must survive the disconnect",
+        );
+        assert!(
+            !b.dri3_syncobjs.contains_key(&0x0040_0001),
+            "the disconnecting client's syncobj must be purged",
+        );
     }
 
     #[test]
@@ -28048,12 +28117,15 @@ mod tests {
         let xid = 0xAAAA_BBBB_u32;
         b.dri3_syncobjs.insert(
             xid,
-            std::sync::Arc::new(
-                crate::kms::render::imported_syncobj::ImportedSyncobj::import(
-                    drm.clone(),
-                    std::os::fd::AsFd::as_fd(&fd),
-                )
-                .expect("import"),
+            (
+                yserver_protocol::x11::ClientId(1),
+                std::sync::Arc::new(
+                    crate::kms::render::imported_syncobj::ImportedSyncobj::import(
+                        drm.clone(),
+                        std::os::fd::AsFd::as_fd(&fd),
+                    )
+                    .expect("import"),
+                ),
             ),
         );
 
@@ -28093,7 +28165,8 @@ mod tests {
             crate::drm::Device::open_render_node("/dev/null").expect("open /dev/null"),
         ));
         assert!(
-            b.dri3_import_syncobj(0x4040_3333, fd).is_err(),
+            b.dri3_import_syncobj(yserver_protocol::x11::ClientId(1), 0x4040_3333, fd,)
+                .is_err(),
             "importing a non-syncobj fd must Err",
         );
     }
@@ -30039,12 +30112,15 @@ mod tests {
         let xid = 0xAAAA_BBBB_u32;
         b.dri3_syncobjs.insert(
             xid,
-            std::sync::Arc::new(
-                crate::kms::render::imported_syncobj::ImportedSyncobj::import(
-                    drm.clone(),
-                    std::os::fd::AsFd::as_fd(&fd),
-                )
-                .expect("import"),
+            (
+                yserver_protocol::x11::ClientId(1),
+                std::sync::Arc::new(
+                    crate::kms::render::imported_syncobj::ImportedSyncobj::import(
+                        drm.clone(),
+                        std::os::fd::AsFd::as_fd(&fd),
+                    )
+                    .expect("import"),
+                ),
             ),
         );
 

--- a/crates/yserver/src/kms/render/backend.rs
+++ b/crates/yserver/src/kms/render/backend.rs
@@ -19324,6 +19324,16 @@ impl Backend for KmsBackend {
             .map(|arc| arc as std::sync::Arc<dyn yserver_core::backend::SyncobjHandle>)
     }
 
+    fn dri3_syncobj_owned(
+        &self,
+        client_id: yserver_protocol::x11::ClientId,
+        syncobj_xid: u32,
+    ) -> bool {
+        self.dri3_syncobjs
+            .get(&syncobj_xid)
+            .is_some_and(|(owner, _)| *owner == client_id)
+    }
+
     fn dri3_fd_from_fence(&mut self, fence_xid: u32) -> io::Result<std::os::fd::OwnedFd> {
         let arc = self
             .dri3_sync_resources
@@ -22993,6 +23003,45 @@ mod tests {
         assert!(
             !b.dri3_syncobjs.contains_key(&0x0040_0001),
             "the disconnecting client's syncobj must be purged",
+        );
+    }
+
+    #[test]
+    #[ignore = "needs a DRM render node"]
+    fn dri3_syncobj_owned_is_client_scoped() {
+        use std::os::fd::AsFd;
+        use yserver_protocol::x11::ClientId;
+
+        // Shared helper from Task 1 — never hardcode renderD128.
+        let Some(drm) = crate::kms::render::imported_syncobj::tests::render_node() else {
+            eprintln!("skipping: no render node");
+            return;
+        };
+        let handle =
+            ::drm::control::Device::create_syncobj(drm.as_ref(), false).expect("create syncobj");
+        let fd =
+            ::drm::control::Device::syncobj_to_fd(drm.as_ref(), handle, false).expect("export fd");
+        let imported =
+            crate::kms::render::imported_syncobj::ImportedSyncobj::import(drm.clone(), fd.as_fd())
+                .expect("import");
+        ::drm::control::Device::destroy_syncobj(drm.as_ref(), handle).expect("destroy");
+
+        let xid = 0x0040_0001_u32;
+        let mut b = KmsBackend::for_tests();
+        b.dri3_syncobjs
+            .insert(xid, (ClientId(7), std::sync::Arc::new(imported)));
+
+        assert!(
+            yserver_core::backend::Backend::dri3_syncobj_owned(&b, ClientId(7), xid),
+            "the importing client owns its syncobj",
+        );
+        assert!(
+            !yserver_core::backend::Backend::dri3_syncobj_owned(&b, ClientId(8), xid),
+            "a different client must not own the syncobj",
+        );
+        assert!(
+            !yserver_core::backend::Backend::dri3_syncobj_owned(&b, ClientId(7), xid + 1),
+            "an unknown syncobj xid must not be owned",
         );
     }
 

--- a/crates/yserver/src/kms/render/imported_syncobj.rs
+++ b/crates/yserver/src/kms/render/imported_syncobj.rs
@@ -1,0 +1,236 @@
+//! A DRI3 1.4 syncobj imported from a client fd, held as a process-local
+//! DRM syncobj handle.
+//!
+//! This deliberately has no Vulkan in it. A DRM syncobj is a kernel object
+//! and every operation the server needs — signal, query, eventfd — has a DRM
+//! ioctl. Importing it into a `VkSemaphore` instead only works where the
+//! driver's `OPAQUE_FD` payload happens to be a DRM syncobj, which is true on
+//! Mesa and false on NVIDIA proprietary
+//! (`vkImportSemaphoreFdKHR` → `VK_ERROR_INITIALIZATION_FAILED`). See
+//! docs/superpowers/specs/2026-08-08-dri3-syncobj-drm-signal-design.md.
+//!
+//! The sibling `OwnedSemaphore` keeps the Vulkan path for XSync `Fence`
+//! resources, which need a real `VkSemaphore` for `FDFromFence`'s sync_file
+//! export.
+//!
+//! The `Arc<crate::drm::Device>` here MUST be the render node — the device
+//! DRI3 hands the client (`PlatformBackend::render_node_device`), never the
+//! KMS node. See the spec's "Which fd to ask" section.
+
+use std::{
+    os::fd::{AsFd, BorrowedFd, OwnedFd},
+    sync::Arc,
+};
+
+use ::drm::control::{Device as DrmControlDevice, syncobj};
+
+pub(crate) struct ImportedSyncobj {
+    drm: Arc<crate::drm::Device>,
+    handle: syncobj::Handle,
+}
+
+impl ImportedSyncobj {
+    /// Import a client's `DRM_SYNCOBJ` fd as a process-local handle. The fd is
+    /// only borrowed — `DRM_IOCTL_SYNCOBJ_FD_TO_HANDLE` does not consume it —
+    /// so the caller keeps ownership and drops it normally. Importing a
+    /// syncobj fd creates a NEW handle (with its own reference) for every
+    /// import; the underlying `struct drm_syncobj` is shared, which is what
+    /// lets a server-side signal reach the client's handle.
+    pub(crate) fn import(
+        drm: Arc<crate::drm::Device>,
+        fd: BorrowedFd<'_>,
+    ) -> std::io::Result<Self> {
+        let handle = drm.fd_to_syncobj(fd, false)?;
+        Ok(Self { drm, handle })
+    }
+
+    /// Current timeline value. Replaces `vkGetSemaphoreCounterValue` in the
+    /// deferred-acquire polling fallback.
+    pub(crate) fn timeline_value(&self) -> std::io::Result<u64> {
+        let mut points = [0u64; 1];
+        self.drm
+            .syncobj_timeline_query(&[self.handle], &mut points, false)?;
+        Ok(points[0])
+    }
+
+    /// Register a non-blocking kernel notification for a timeline point.
+    /// Unchanged in behaviour from the previous `OwnedSemaphore` version —
+    /// that method already went through DRM.
+    pub(crate) fn signaled_eventfd(&self, value: u64) -> std::io::Result<OwnedFd> {
+        use nix::sys::eventfd::{EfdFlags, EventFd};
+
+        let event =
+            EventFd::from_value_and_flags(0, EfdFlags::EFD_NONBLOCK | EfdFlags::EFD_CLOEXEC)
+                .map_err(|e| std::io::Error::other(format!("eventfd: {e}")))?;
+        self.drm
+            .syncobj_eventfd(self.handle, value, event.as_fd(), false)?;
+        Ok(event.into())
+    }
+}
+
+impl std::fmt::Debug for ImportedSyncobj {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ImportedSyncobj")
+            .field("handle", &self.handle)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for ImportedSyncobj {
+    fn drop(&mut self) {
+        if let Err(e) = self.drm.destroy_syncobj(self.handle) {
+            log::warn!("destroy imported DRM syncobj handle failed: {e}");
+        }
+    }
+}
+
+impl yserver_core::backend::SyncobjHandle for ImportedSyncobj {
+    /// Host-signal a timeline point. Replaces `vkSignalSemaphore`, which was
+    /// also a host operation.
+    ///
+    /// Note the kernel CLAMPS: signalling a point at or below the current
+    /// value succeeds silently and leaves the timeline where it was. Callers
+    /// cannot use the return value to detect an out-of-order release.
+    fn signal(&self, value: u64) -> std::io::Result<()> {
+        self.drm.syncobj_timeline_signal(&[self.handle], &[value])
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use std::{os::fd::AsFd, sync::Arc};
+
+    use ::drm::control::Device as DrmControlDevice;
+
+    use super::*;
+
+    /// Open a render node, or skip. Every test here needs real DRM ioctls;
+    /// they are `#[ignore]` so CI never runs them, but a machine without a
+    /// node should skip rather than fail.
+    ///
+    /// Do NOT hardcode `/dev/dri/renderD128`. `kms/render_node.rs:1-8` states
+    /// the rule outright — "we deliberately do **not** hardcode
+    /// `/dev/dri/renderD128` — on multi-GPU hosts that selects the wrong
+    /// device" — and the nvidia box became exactly such a host on 2026-08-08:
+    /// `renderD128` is nvidia-drm and `renderD129` is the Raphael iGPU. A
+    /// hardcoded 128 would make a run intended to validate Mesa silently
+    /// exercise nvidia-drm and report green.
+    ///
+    /// Honour `YSERVER_TEST_RENDER_NODE` so a Mesa run can be directed at the
+    /// amdgpu node, and enumerate otherwise rather than guessing.
+    pub(crate) fn render_node() -> Option<Arc<crate::drm::Device>> {
+        if let Ok(path) = std::env::var("YSERVER_TEST_RENDER_NODE") {
+            return crate::drm::Device::open_render_node(&path)
+                .ok()
+                .map(Arc::new);
+        }
+        let mut paths: Vec<_> = std::fs::read_dir("/dev/dri")
+            .ok()?
+            .filter_map(Result::ok)
+            .map(|e| e.path())
+            .filter(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.starts_with("renderD"))
+            })
+            .collect();
+        paths.sort();
+        paths
+            .iter()
+            .find_map(|p| crate::drm::Device::open_render_node(p.to_str()?).ok())
+            .map(Arc::new)
+    }
+
+    /// Full round trip mirroring the server's sequence: the client exports a
+    /// syncobj fd, the server imports it, signals a release point, and the
+    /// client's own handle observes it through its own separate handle.
+    /// Run with `cargo test -p yserver --lib imported_syncobj -- --ignored`.
+    #[test]
+    #[ignore = "needs a DRM render node"]
+    fn signal_reaches_the_clients_handle() {
+        let Some(drm) = render_node() else {
+            eprintln!("skipping: no render node");
+            return;
+        };
+
+        let client_handle = drm.create_syncobj(false).expect("create syncobj");
+        let fd = drm.syncobj_to_fd(client_handle, false).expect("export fd");
+
+        let imported = ImportedSyncobj::import(drm.clone(), fd.as_fd()).expect("import");
+        assert_eq!(imported.timeline_value().expect("query"), 0);
+
+        yserver_core::backend::SyncobjHandle::signal(&imported, 7).expect("signal");
+
+        // The client must observe the release through ITS handle, not the
+        // server's, or the two are not aliasing one payload and the client
+        // would wait forever.
+        let mut points = [0u64; 1];
+        drm.syncobj_timeline_query(&[client_handle], &mut points, false)
+            .expect("client query");
+        assert_eq!(
+            points[0], 7,
+            "server signal did not reach the client handle"
+        );
+
+        drm.destroy_syncobj(client_handle).expect("destroy");
+    }
+
+    /// The acquire path's kernel notification.
+    #[test]
+    #[ignore = "needs a DRM render node"]
+    fn eventfd_fires_on_the_registered_point() {
+        let Some(drm) = render_node() else {
+            eprintln!("skipping: no render node");
+            return;
+        };
+        let client_handle = drm.create_syncobj(false).expect("create syncobj");
+        let fd = drm.syncobj_to_fd(client_handle, false).expect("export fd");
+        let imported = ImportedSyncobj::import(drm.clone(), fd.as_fd()).expect("import");
+
+        let event = imported.signaled_eventfd(9).expect("register eventfd");
+        let mut buf = [0u8; 8];
+        assert!(
+            nix::unistd::read(event.as_fd(), &mut buf).is_err(),
+            "eventfd readable before the point was signalled",
+        );
+
+        yserver_core::backend::SyncobjHandle::signal(&imported, 9).expect("signal");
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        assert!(
+            nix::unistd::read(event.as_fd(), &mut buf).is_ok(),
+            "eventfd never fired after the point was signalled",
+        );
+
+        drm.destroy_syncobj(client_handle).expect("destroy");
+    }
+
+    /// Documents measured kernel behaviour the spec depends on: a stale or
+    /// duplicate timeline point is CLAMPED and returns success, it is not
+    /// rejected. Release replay after teardown therefore cannot be detected
+    /// by checking the signal's return value.
+    #[test]
+    #[ignore = "needs a DRM render node"]
+    fn a_stale_point_is_clamped_not_rejected() {
+        use yserver_core::backend::SyncobjHandle as _;
+
+        let Some(drm) = render_node() else {
+            eprintln!("skipping: no render node");
+            return;
+        };
+        let client_handle = drm.create_syncobj(false).expect("create syncobj");
+        let fd = drm.syncobj_to_fd(client_handle, false).expect("export fd");
+        let imported = ImportedSyncobj::import(drm.clone(), fd.as_fd()).expect("import");
+
+        imported.signal(10).expect("signal 10");
+        imported
+            .signal(5)
+            .expect("a stale point must still return Ok");
+        assert_eq!(
+            imported.timeline_value().expect("query"),
+            10,
+            "the kernel must clamp to the max, not regress the timeline",
+        );
+
+        drm.destroy_syncobj(client_handle).expect("destroy");
+    }
+}

--- a/crates/yserver/src/kms/render/mod.rs
+++ b/crates/yserver/src/kms/render/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod engine;
 pub(crate) mod frame_builder;
 pub(crate) mod glyph_atlas;
 pub(crate) mod glyph_pixels;
+pub(crate) mod imported_syncobj;
 pub(crate) mod owned_semaphore;
 pub(crate) mod platform;
 pub(crate) mod present_completion;

--- a/crates/yserver/src/kms/render/owned_semaphore.rs
+++ b/crates/yserver/src/kms/render/owned_semaphore.rs
@@ -24,19 +24,6 @@ impl OwnedSemaphore {
         }
     }
 
-    pub(crate) fn new_drm_syncobj(
-        vk: Arc<VkContext>,
-        semaphore: vk::Semaphore,
-        drm: Arc<crate::drm::Device>,
-        handle: ::drm::control::syncobj::Handle,
-    ) -> Self {
-        Self {
-            vk,
-            semaphore,
-            drm_syncobj: Some((drm, handle)),
-        }
-    }
-
     pub(crate) fn semaphore(&self) -> vk::Semaphore {
         self.semaphore
     }
@@ -46,43 +33,6 @@ impl OwnedSemaphore {
     /// `SyncobjHandle::signal` trait method.
     pub(crate) fn signal_vk(&self, value: u64) -> Result<(), vk::Result> {
         crate::kms::vk::sync::signal_timeline(&self.vk, self.semaphore, value)
-    }
-
-    pub(crate) fn timeline_value(&self) -> Result<u64, vk::Result> {
-        unsafe { self.vk.device.get_semaphore_counter_value(self.semaphore) }
-    }
-
-    /// Register a non-blocking kernel notification for a timeline point.
-    /// The retained DRM handle aliases the same imported syncobj payload as
-    /// the Vulkan semaphore.
-    pub(crate) fn signaled_eventfd(&self, value: u64) -> std::io::Result<std::os::fd::OwnedFd> {
-        use std::os::fd::AsFd;
-
-        use ::drm::control::Device as _;
-        use nix::sys::eventfd::{EfdFlags, EventFd};
-
-        let Some((drm, handle)) = &self.drm_syncobj else {
-            return Err(std::io::Error::other(
-                "timeline semaphore has no retained DRM syncobj handle",
-            ));
-        };
-        let event =
-            EventFd::from_value_and_flags(0, EfdFlags::EFD_NONBLOCK | EfdFlags::EFD_CLOEXEC)
-                .map_err(|e| std::io::Error::other(format!("eventfd: {e}")))?;
-        drm.syncobj_eventfd(*handle, value, event.as_fd(), false)?;
-        Ok(event.into())
-    }
-
-    /// Test-only constructor: holds a null semaphore handle. Drop
-    /// is a no-op (vkDestroySemaphore on null is allowed by Vulkan
-    /// spec but the guard below skips it anyway).
-    #[cfg(test)]
-    pub(crate) fn for_tests_dummy(vk: Arc<VkContext>) -> Self {
-        Self {
-            vk,
-            semaphore: vk::Semaphore::null(),
-            drm_syncobj: None,
-        }
     }
 }
 

--- a/crates/yserver/src/kms/render/owned_semaphore.rs
+++ b/crates/yserver/src/kms/render/owned_semaphore.rs
@@ -1,7 +1,9 @@
-//! RAII wrapper for a `vk::Semaphore` so it can be `Arc`-shared
-//! for the deferred PRESENT completion path. Destruction happens
-//! on the last Arc drop (via `vkDestroySemaphore`), independent of
-//! the X11 resource id's lifetime.
+//! RAII wrapper for a `vk::Semaphore` so it can be `Arc`-shared for the
+//! deferred PRESENT completion path. Destruction happens on the last Arc drop
+//! (via `vkDestroySemaphore`), independent of the X11 resource id's lifetime.
+//!
+//! This backs XSync `Fence` resources only. DRI3 1.4 syncobjs are
+//! `ImportedSyncobj` — they are DRM objects and never enter Vulkan.
 
 use std::sync::Arc;
 
@@ -12,27 +14,15 @@ use crate::kms::vk::device::VkContext;
 pub(crate) struct OwnedSemaphore {
     vk: Arc<VkContext>,
     semaphore: vk::Semaphore,
-    drm_syncobj: Option<(Arc<crate::drm::Device>, ::drm::control::syncobj::Handle)>,
 }
 
 impl OwnedSemaphore {
     pub(crate) fn new(vk: Arc<VkContext>, semaphore: vk::Semaphore) -> Self {
-        Self {
-            vk,
-            semaphore,
-            drm_syncobj: None,
-        }
+        Self { vk, semaphore }
     }
 
     pub(crate) fn semaphore(&self) -> vk::Semaphore {
         self.semaphore
-    }
-
-    /// Signal a timeline-semaphore value via `vkSignalSemaphore`.
-    /// Renamed to `signal_vk` to disambiguate from the
-    /// `SyncobjHandle::signal` trait method.
-    pub(crate) fn signal_vk(&self, value: u64) -> Result<(), vk::Result> {
-        crate::kms::vk::sync::signal_timeline(&self.vk, self.semaphore, value)
     }
 }
 
@@ -46,24 +36,11 @@ impl std::fmt::Debug for OwnedSemaphore {
 
 impl Drop for OwnedSemaphore {
     fn drop(&mut self) {
-        if let Some((drm, handle)) = self.drm_syncobj.take() {
-            use ::drm::control::Device as _;
-            if let Err(e) = drm.destroy_syncobj(handle) {
-                log::warn!("destroy retained DRM syncobj handle failed: {e}");
-            }
-        }
         if self.semaphore == vk::Semaphore::null() {
             return;
         }
         unsafe {
             self.vk.device.destroy_semaphore(self.semaphore, None);
         }
-    }
-}
-
-impl yserver_core::backend::SyncobjHandle for OwnedSemaphore {
-    fn signal(&self, value: u64) -> std::io::Result<()> {
-        self.signal_vk(value)
-            .map_err(|e| std::io::Error::other(format!("vkSignalSemaphore: {e:?}")))
     }
 }

--- a/crates/yserver/src/kms/render/platform.rs
+++ b/crates/yserver/src/kms/render/platform.rs
@@ -563,6 +563,13 @@ pub(crate) struct PlatformBackend {
     // DRM / output side
     pub(crate) device: Arc<drm::Device>,
     pub(crate) render_node_fd: Option<std::os::fd::OwnedFd>,
+    /// The DRM device over the render node, retained so every DRI3 syncobj
+    /// ioctl and the `DRM_CAP_SYNCOBJ_TIMELINE` query issue on the SAME fd
+    /// kind DRI3 hands clients. This is deliberately NOT `device` (the KMS
+    /// node): on split-device boxes (Pi 4 vc4/v3d, Asahi) the display device's
+    /// answer says nothing about the render device's. See the spec's "Which
+    /// fd to ask — one device, decided, not preferred".
+    pub(crate) render_node_device: Option<Arc<crate::drm::Device>>,
     pub(crate) render_node_path: Option<PathBuf>,
     pub(crate) outputs: Vec<OutputLayout>,
     pub(crate) fb_w: u16,
@@ -773,6 +780,16 @@ impl PlatformBackend {
             input_ctx,
         } = platform_init;
 
+        let render_node_device = render_node_path
+            .as_deref()
+            .and_then(|path| {
+                // `open_render_node` takes a `&str`; a non-UTF8 node path
+                // (unrealistic under /dev/dri) degrades to no device, which
+                // `dri3_import_syncobj` surfaces as a hard error.
+                drm::Device::open_render_node(path.to_str()?).ok()
+            })
+            .map(Arc::new);
+
         let vk = match VkContext::new() {
             Ok(v) => v,
             Err(e) => {
@@ -953,6 +970,7 @@ impl PlatformBackend {
         Ok(Self {
             device,
             render_node_fd,
+            render_node_device,
             render_node_path,
             outputs: layouts,
             fb_w,
@@ -1005,6 +1023,7 @@ impl PlatformBackend {
         Self {
             device: Arc::new(drm::Device::for_tests().expect("test drm device")),
             render_node_fd: None,
+            render_node_device: None,
             render_node_path: None,
             outputs: vec![OutputLayout {
                 output: drm::modeset::Output {

--- a/crates/yserver/src/kms/render/platform.rs
+++ b/crates/yserver/src/kms/render/platform.rs
@@ -570,6 +570,11 @@ pub(crate) struct PlatformBackend {
     /// answer says nothing about the render device's. See the spec's "Which
     /// fd to ask — one device, decided, not preferred".
     pub(crate) render_node_device: Option<Arc<crate::drm::Device>>,
+    /// `DRM_CAP_SYNCOBJ_TIMELINE` on the render node, read once at init.
+    /// Whether DRI3 can offer syncobjs is a property of the kernel driver
+    /// behind that fd, not of the Vulkan driver — the resource is a DRM
+    /// syncobj and every operation on it is a DRM ioctl.
+    pub(crate) syncobj_timeline: bool,
     pub(crate) render_node_path: Option<PathBuf>,
     pub(crate) outputs: Vec<OutputLayout>,
     pub(crate) fb_w: u16,
@@ -790,6 +795,15 @@ impl PlatformBackend {
             })
             .map(Arc::new);
 
+        let syncobj_timeline = render_node_device
+            .as_ref()
+            .and_then(|d| {
+                use ::drm::Device as _;
+                d.get_driver_capability(::drm::DriverCapability::TimelineSyncObj)
+                    .ok()
+            })
+            .is_some_and(|v| v != 0);
+
         let vk = match VkContext::new() {
             Ok(v) => v,
             Err(e) => {
@@ -971,6 +985,7 @@ impl PlatformBackend {
             device,
             render_node_fd,
             render_node_device,
+            syncobj_timeline,
             render_node_path,
             outputs: layouts,
             fb_w,
@@ -1024,6 +1039,7 @@ impl PlatformBackend {
             device: Arc::new(drm::Device::for_tests().expect("test drm device")),
             render_node_fd: None,
             render_node_device: None,
+            syncobj_timeline: false,
             render_node_path: None,
             outputs: vec![OutputLayout {
                 output: drm::modeset::Output {

--- a/crates/yserver/src/kms/render/present_source_wait.rs
+++ b/crates/yserver/src/kms/render/present_source_wait.rs
@@ -19,9 +19,10 @@ pub(crate) struct PendingPresentSourceWait {
     pub(crate) prewaited_destination: Option<DrawableId>,
     /// Keeps an explicitly imported acquire syncobj alive until its timeline
     /// point signals. Implicit dma-buf waits leave this empty.
-    pub(crate) syncobj_pin: Option<Arc<super::owned_semaphore::OwnedSemaphore>>,
-    /// Used only when DRM_SYNCOBJ_EVENTFD is unavailable and readiness must
-    /// be checked through the imported Vulkan timeline semaphore.
+    pub(crate) syncobj_pin: Option<Arc<super::imported_syncobj::ImportedSyncobj>>,
+    /// Target acquire point. Set whenever an acquire syncobj is present —
+    /// note `is_ready` checks it on every poll, not only when
+    /// `DRM_SYNCOBJ_EVENTFD` was unavailable.
     pub(crate) timeline_value: Option<u64>,
     pub(crate) poll_timeline: bool,
     /// False when registration in the stable completion poller failed. Such
@@ -42,7 +43,7 @@ impl PendingPresentSourceWait {
                 Ok(current) => current >= target,
                 Err(e) => {
                     log::warn!(
-                        "deferred Present acquire: vkGetSemaphoreCounterValue failed: {e:?}; \
+                        "deferred Present acquire: syncobj timeline query failed: {e}; \
                          treating as ready"
                     );
                     true

--- a/crates/yserver/src/kms/vk/device.rs
+++ b/crates/yserver/src/kms/vk/device.rs
@@ -238,12 +238,6 @@ impl VkContext {
             .dynamic_rendering(true)
             .synchronization2(true);
 
-        // `timelineSemaphore` is core in Vulkan 1.2 and is required by
-        // Phase 4.2.2's `import_drm_syncobj` (DRI3 ImportSyncobj path).
-        // Harmless when the syncobj cap is false because the dispatcher
-        // gate rejects requests before they reach the import call.
-        let mut features12 = vk::PhysicalDeviceVulkan12Features::default().timeline_semaphore(true);
-
         // `logicOp` (the X11 GcFunction Xor/And/Or/Invert fill path —
         // all 16 variants map 1:1 to `VkLogicOp`) and `dualSrcBlend`
         // (the SRC1_* blend factors used by the RENDER `component_alpha`
@@ -281,7 +275,6 @@ impl VkContext {
             .queue_create_infos(&queue_info)
             .enabled_extension_names(&device_extensions)
             .enabled_features(&enabled_features)
-            .push_next(&mut features12)
             .push_next(&mut features13);
 
         let device = match unsafe { instance.create_device(physical_device, &device_info, None) } {

--- a/crates/yserver/src/kms/vk/device.rs
+++ b/crates/yserver/src/kms/vk/device.rs
@@ -73,21 +73,6 @@ pub struct VkContext {
 }
 
 impl VkContext {
-    /// Whether this driver should advertise DRI3/Present syncobj.
-    ///
-    /// The implementation currently imports DRI3 syncobj fds as
-    /// timeline semaphores with `OPAQUE_FD`. That works on the
-    /// Vulkan stacks we have used for Venus/Mesa testing, but NVIDIA
-    /// proprietary rejects the very first import with
-    /// `ERROR_INITIALIZATION_FAILED` ("Failed to allocate semaphore
-    /// device memory"). Advertising only DRI3 1.3 on that driver lets
-    /// clients fall back to the older fence-fd path instead of dying
-    /// on `ImportSyncobj`.
-    #[must_use]
-    pub fn supports_dri3_syncobj(&self) -> bool {
-        !matches!(self.driver_id, vk::DriverId::NVIDIA_PROPRIETARY)
-    }
-
     pub fn new() -> Result<Arc<Self>, VkInitError> {
         let entry = unsafe { ash::Entry::load()? };
         let app_info = vk::ApplicationInfo::default()

--- a/crates/yserver/src/kms/vk/sync.rs
+++ b/crates/yserver/src/kms/vk/sync.rs
@@ -1,17 +1,12 @@
 //! XSync / DRI3 `VkSemaphore` import / export helpers (Phase 4.2.2,
 //! design §3.4).
 //!
-//! Two semaphore shapes:
-//! - **Binary semaphore from a `sync_file` fd** —
-//!   [`import_sync_file`]. Used by DRI3 `FenceFromFD`. The imported
-//!   payload is TEMPORARY: it lasts only until the first wait, which
-//!   matches XSync `Fence`'s one-shot trigger/wait semantics.
-//! - **Timeline semaphore from a `DRM_SYNCOBJ` fd** —
-//!   [`import_drm_syncobj`]. Used by DRI3 `ImportSyncobj`. Requires
-//!   `VK_KHR_timeline_semaphore`. PERMANENT semantics.
-//!
-//! Plus [`export_sync_file`] — symmetric to `import_sync_file`, used
-//! by DRI3 `FDFromFence` to hand the client back a `sync_file` fd.
+//! - **Binary semaphore from a `sync_file` fd** — [`import_sync_file`].
+//!   Used by DRI3 `FenceFromFD`. The imported payload is TEMPORARY:
+//!   it lasts only until the first wait, which matches XSync
+//!   `Fence`'s one-shot trigger/wait semantics.
+//! - [`export_sync_file`] — symmetric to `import_sync_file`, used by
+//!   DRI3 `FDFromFence` to hand the client back a `sync_file` fd.
 //!
 //! **fd ownership rule** (design §3.2). `vkImportSemaphoreFdKHR`
 //! consumes the fd only on `VK_SUCCESS`. The helpers in this module
@@ -52,33 +47,6 @@ pub fn import_sync_file(vk: &VkContext, fd: OwnedFd) -> Result<vk::Semaphore, vk
     }
 }
 
-/// Import a DRM_SYNCOBJ fd as a fresh **timeline** `VkSemaphore`.
-/// Phase 4.2.2 — backs DRI3 `ImportSyncobj`. Requires
-/// `VK_KHR_timeline_semaphore`.
-pub fn import_drm_syncobj(vk: &VkContext, fd: OwnedFd) -> Result<vk::Semaphore, vk::Result> {
-    let mut type_info = vk::SemaphoreTypeCreateInfo::default()
-        .semaphore_type(vk::SemaphoreType::TIMELINE)
-        .initial_value(0);
-    let create_info = vk::SemaphoreCreateInfo::default().push_next(&mut type_info);
-    let semaphore = unsafe { vk.device.create_semaphore(&create_info, None)? };
-    let raw = fd.into_raw_fd();
-    let import_info = vk::ImportSemaphoreFdInfoKHR::default()
-        .semaphore(semaphore)
-        .handle_type(vk::ExternalSemaphoreHandleTypeFlags::OPAQUE_FD)
-        .fd(raw);
-    let result = unsafe { vk.external_semaphore_fd.import_semaphore_fd(&import_info) };
-    match result {
-        Ok(()) => Ok(semaphore),
-        Err(e) => {
-            unsafe {
-                libc::close(raw);
-                vk.device.destroy_semaphore(semaphore, None);
-            }
-            Err(e)
-        }
-    }
-}
-
 /// Export a `VkSemaphore`'s current payload as a fresh `sync_file`
 /// fd. Phase 4.2.2 — backs DRI3 `FDFromFence`. The returned fd's
 /// ownership transfers to the caller (Vulkan's internal copy is
@@ -89,26 +57,6 @@ pub fn export_sync_file(vk: &VkContext, semaphore: vk::Semaphore) -> Result<Owne
         .handle_type(vk::ExternalSemaphoreHandleTypeFlags::SYNC_FD);
     let raw = unsafe { vk.external_semaphore_fd.get_semaphore_fd(&info)? };
     super::owned_fd_from_vk(raw, "vkGetSemaphoreFdKHR(SYNC_FD)")
-}
-
-/// Host-signal a timeline `VkSemaphore` to `value`. Phase 4.2.3
-/// design §3.3.2 Copy path: when the synchronous `CopyArea`
-/// completes, signal the client's `release_syncobj` at
-/// `release_value` so Mesa's `vkAcquireNextImage` wakes up.
-///
-/// `vkSignalSemaphore` (core in Vulkan 1.2 with timeline semaphore
-/// feature; also available via `VK_KHR_timeline_semaphore`) advances
-/// the timeline counter on the host side, immediately observable to
-/// any other Vulkan device that imported the same syncobj.
-pub fn signal_timeline(
-    vk: &VkContext,
-    semaphore: vk::Semaphore,
-    value: u64,
-) -> Result<(), vk::Result> {
-    let info = vk::SemaphoreSignalInfo::default()
-        .semaphore(semaphore)
-        .value(value);
-    unsafe { vk.device.signal_semaphore(&info) }
 }
 
 #[cfg(test)]

--- a/docs/status.md
+++ b/docs/status.md
@@ -317,7 +317,7 @@ lives in [`code-quality-audit-2026-07-26.md`](code-quality-audit-2026-07-26.md).
   box until the DRI3 syncobj cap moved off the `NVIDIA_PROPRIETARY`
   driver branch — it now derives from `DRM_CAP_SYNCOBJ_TIMELINE` on the
   render node, so DRI3 1.4 is advertised and the request is exercisable;
-  hardware validation pending), dual-head, and the
+  **validated 2026-08-10**, see the full-Mesa entry below), dual-head, and the
   legacy 1050 Ti. The residual gap to Xorg's ~400 fps is flip-path
   territory and out of scope. Design:
   [`2026-07-31-present-deferred-execution-supersession-design.md`](superpowers/specs/2026-07-31-present-deferred-execution-supersession-design.md).
@@ -443,6 +443,23 @@ lives in [`code-quality-audit-2026-07-26.md`](code-quality-audit-2026-07-26.md).
   load. The fix is therefore validated across both bee and silence, including
   single- and dual-head operation and three desktop environments. Design:
   [`2026-07-28-present-synced-acquire-wait-design.md`](superpowers/specs/2026-07-28-present-synced-acquire-wait-design.md).
+- **2026-08-10 DRI3 1.4 syncobj via DRM signal (nvidia box, full-Mesa, validated):**
+  DRI3 syncobjs are served through `DRM_IOCTL_SYNCOBJ_*` on the retained render
+  node (`ImportedSyncobj`), and `PresentPixmapSynced` is advertised on every
+  driver whose kernel reports `DRM_CAP_SYNCOBJ_TIMELINE` — the NVIDIA
+  `supports_dri3_syncobj()` blacklist is deleted. Validated on the Raphael iGPU
+  (`card1`, RADV, `renderD129`): yserver on `card1` with the mandatory
+  `YSERVER_DRM_DEVICE`/`VK_ICD_FILENAMES` overrides, mpv Vulkan X11 WSI
+  (`--gpu-context=x11vk`) reproducing a 1280x720@60 testsrc for 15 s, exit 0.
+  Wire counts: `DRI3::QueryVersion -> 1.4` (1), `ImportSyncobj -> imported`
+  (6), 192 synced presents of which 1 arrived before its acquire point and was
+  deferred then signalled (`stage=acquire_deferred`=1, `stage=acquire_ready`=191),
+  0 `unknown syncobj`, and 0 `DRM eventfd unavailable` fallback warnings — the
+  spec's merge gate (non-zero deferrals, no fallback) is satisfied. IGT:
+  `syncobj_basic` 12/12 on nvidia-drm; `syncobj_eventfd`/`syncobj_wait`/
+  `syncobj_timeline` skip because the 7.1 kernel compiles CONFIG_SW_SYNC but
+  does not expose `/dev/sw_sync`. Design:
+  [`2026-08-08-dri3-syncobj-drm-signal-design.md`](superpowers/specs/2026-08-08-dri3-syncobj-drm-signal-design.md).
 - **2026-07-28 Present completion clock provenance (not the mpv fix):**
   the target-MSC pacing follow-up now preserves whether a completion clock
   sample came from pageflip retirement or an idle CRTC sequence. General

--- a/docs/status.md
+++ b/docs/status.md
@@ -314,8 +314,10 @@ lives in [`code-quality-audit-2026-07-26.md`](code-quality-audit-2026-07-26.md).
   effective target. Still unvalidated on hardware: `ksplashqml`
   specifically (its mechanism is covered by the marco result), the
   `PixmapSynced` explicit-sync path (structurally untestable on this
-  box — `supports_dri3_syncobj()` excludes `NVIDIA_PROPRIETARY`, capping
-  DRI3 at 1.3 so the request is never advertised), dual-head, and the
+  box until the DRI3 syncobj cap moved off the `NVIDIA_PROPRIETARY`
+  driver branch — it now derives from `DRM_CAP_SYNCOBJ_TIMELINE` on the
+  render node, so DRI3 1.4 is advertised and the request is exercisable;
+  hardware validation pending), dual-head, and the
   legacy 1050 Ti. The residual gap to Xorg's ~400 fps is flip-path
   territory and out of scope. Design:
   [`2026-07-31-present-deferred-execution-supersession-design.md`](superpowers/specs/2026-07-31-present-deferred-execution-supersession-design.md).

--- a/docs/status.md
+++ b/docs/status.md
@@ -454,11 +454,14 @@ lives in [`code-quality-audit-2026-07-26.md`](code-quality-audit-2026-07-26.md).
   Wire counts: `DRI3::QueryVersion -> 1.4` (1), `ImportSyncobj -> imported`
   (6), 192 synced presents of which 1 arrived before its acquire point and was
   deferred then signalled (`stage=acquire_deferred`=1, `stage=acquire_ready`=191),
-  0 `unknown syncobj`, and 0 `DRM eventfd unavailable` fallback warnings — the
-  spec's merge gate (non-zero deferrals, no fallback) is satisfied. IGT:
-  `syncobj_basic` 12/12 on nvidia-drm; `syncobj_eventfd`/`syncobj_wait`/
-  `syncobj_timeline` skip because the 7.1 kernel compiles CONFIG_SW_SYNC but
-  does not expose `/dev/sw_sync`. Design:
+   0 `unknown syncobj`, and 0 `DRM eventfd unavailable` fallback warnings — the
+   spec's merge gate (non-zero deferrals, no fallback) is satisfied. IGT: the
+   full `syncobj_*` suite passes **212/212 (0 SKIP)** on nvidia-drm
+   (`syncobj_basic` 12, `syncobj_eventfd` 10, `syncobj_wait` 69,
+   `syncobj_timeline` 121) with `CONFIG_SW_SYNC` exposed via
+   `/sys/kernel/debug/sync/sw_sync` (symlinked to `/dev/sw_sync` for IGT 2.3);
+   amdgpu coverage comes from the yserver `imported_syncobj` tests (3/3 on
+   `renderD129`) — IGT's device filter does not match cards here. Design:
   [`2026-08-08-dri3-syncobj-drm-signal-design.md`](superpowers/specs/2026-08-08-dri3-syncobj-drm-signal-design.md).
 - **2026-07-28 Present completion clock provenance (not the mpv fix):**
   the target-MSC pacing follow-up now preserves whether a completion clock

--- a/docs/superpowers/plans/2026-08-08-dri3-syncobj-drm-signal.md
+++ b/docs/superpowers/plans/2026-08-08-dri3-syncobj-drm-signal.md
@@ -1,0 +1,902 @@
+# DRI3 1.4 syncobj via DRM signalling — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Serve DRI3 1.4 syncobjs through DRM ioctls on every driver, so the
+NVIDIA driver blacklist that caps DRI3 at 1.3 can be deleted.
+
+**Architecture:** A DRI3 syncobj stops being a Vulkan timeline semaphore and
+becomes a process-local DRM syncobj handle. Signal moves from
+`vkSignalSemaphore` to `DRM_IOCTL_SYNCOBJ_TIMELINE_SIGNAL`, readiness polling
+from `vkGetSemaphoreCounterValue` to `DRM_IOCTL_SYNCOBJ_QUERY`; the acquire
+eventfd path was already DRM and is untouched. `OwnedSemaphore` keeps its
+Vulkan body and serves only the XSync fence half, which genuinely needs it.
+
+**Tech Stack:** Rust, `drm` 0.15 (`syncobj_timeline_signal`,
+`syncobj_timeline_query`, `syncobj_eventfd`, `fd_to_syncobj`,
+`DriverCapability::TimelineSyncObj`), `ash` (only where it already was).
+
+**Spec:** `docs/superpowers/specs/2026-08-08-dri3-syncobj-drm-signal-design.md`
+
+## Global Constraints
+
+- Branch: `dri3-syncobj-drm-signal` (already created off `master`; the spec is
+  committed there as `a7d4ce8f`).
+- Format with `cargo +nightly fmt` before every commit.
+- Lint exactly as CI does: `cargo clippy --all-targets -- -D warnings`. CI
+  fails on any warning and `--all-targets` lints test code too.
+- No new ioctl plumbing is introduced — every ioctl used here already exists in
+  the `drm` crate, so the AGENTS.md `libc::Ioctl` portability rule
+  (glibc/musl/FreeBSD) is not triggered. If you find yourself writing a raw
+  `ioctl` call, stop: you have left the plan.
+- `docs/status.md` must be updated (Task 6). AGENTS.md requires it current, and
+  it covers more than render work.
+- Do not fix the freed-syncobj bookkeeping bug this change makes reachable
+  (`docs/status.md:567`). It is out of scope and tracked separately.
+
+---
+
+### Task 1: `ImportedSyncobj` — the DRM-backed syncobj resource
+
+**Files:**
+- Create: `crates/yserver/src/kms/render/imported_syncobj.rs`
+- Modify: `crates/yserver/src/kms/render/mod.rs:18` (add the module)
+
+**Interfaces:**
+- Consumes: `crate::drm::Device` (already `Arc`-held as
+  `platform.device: Arc<drm::Device>`).
+- Produces: `ImportedSyncobj::import(Arc<crate::drm::Device>, BorrowedFd) ->
+  io::Result<Self>`, `.timeline_value() -> io::Result<u64>`,
+  `.signaled_eventfd(u64) -> io::Result<OwnedFd>`, and an
+  impl of `yserver_core::backend::SyncobjHandle` whose `signal(u64)` uses
+  `syncobj_timeline_signal`. Tasks 2 and 3 depend on these exact names.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `crates/yserver/src/kms/render/imported_syncobj.rs` containing only the
+test module for now:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use ::drm::control::Device as DrmControlDevice;
+
+    use super::*;
+
+    /// Full round trip against a real DRM node, mirroring the server's
+    /// sequence: the client exports a syncobj fd, the server imports it,
+    /// signals a release point, and the client's own handle observes it.
+    /// Ignored because it needs a DRM device — run with
+    /// `cargo test -p yserver --lib imported_syncobj -- --ignored`.
+    #[test]
+    #[ignore = "needs a DRM render node"]
+    fn signal_reaches_the_clients_handle() {
+        let drm = Arc::new(
+            crate::drm::Device::open("/dev/dri/renderD128").expect("open render node"),
+        );
+
+        // The client's half.
+        let client_handle = drm.create_syncobj(false).expect("create syncobj");
+        let fd = drm.syncobj_to_fd(client_handle, false).expect("export fd");
+
+        // The server's half, as dri3_import_syncobj will do it.
+        let imported = ImportedSyncobj::import(drm.clone(), fd.as_fd()).expect("import");
+
+        assert_eq!(imported.timeline_value().expect("query"), 0);
+
+        yserver_core::backend::SyncobjHandle::signal(&imported, 7).expect("signal");
+
+        // The client must observe the release through its own handle, or it
+        // would wait forever.
+        let mut points = [0u64; 1];
+        drm.syncobj_timeline_query(&[client_handle], &mut points, false)
+            .expect("client query");
+        assert_eq!(points[0], 7, "server signal did not reach the client handle");
+        assert_eq!(imported.timeline_value().expect("query"), 7);
+
+        drm.destroy_syncobj(client_handle).expect("destroy");
+    }
+
+    #[test]
+    #[ignore = "needs a DRM render node"]
+    fn eventfd_fires_on_the_registered_point() {
+        use std::os::fd::AsFd;
+
+        let drm = Arc::new(
+            crate::drm::Device::open("/dev/dri/renderD128").expect("open render node"),
+        );
+        let client_handle = drm.create_syncobj(false).expect("create syncobj");
+        let fd = drm.syncobj_to_fd(client_handle, false).expect("export fd");
+        let imported = ImportedSyncobj::import(drm.clone(), fd.as_fd()).expect("import");
+
+        let event = imported.signaled_eventfd(9).expect("register eventfd");
+        let mut buf = [0u8; 8];
+        assert!(
+            nix::unistd::read(event.as_fd(), &mut buf).is_err(),
+            "eventfd readable before the point was signalled",
+        );
+
+        yserver_core::backend::SyncobjHandle::signal(&imported, 9).expect("signal");
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        assert!(
+            nix::unistd::read(event.as_fd(), &mut buf).is_ok(),
+            "eventfd never fired after the point was signalled",
+        );
+
+        drm.destroy_syncobj(client_handle).expect("destroy");
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p yserver --lib imported_syncobj -- --ignored`
+Expected: compile error — `ImportedSyncobj` is not defined, and the module is
+not registered in `mod.rs`.
+
+- [ ] **Step 3: Register the module**
+
+In `crates/yserver/src/kms/render/mod.rs`, add in alphabetical position (after
+line 16, `glyph_pixels`):
+
+```rust
+pub(crate) mod imported_syncobj;
+```
+
+- [ ] **Step 4: Write the implementation**
+
+Prepend to `crates/yserver/src/kms/render/imported_syncobj.rs`:
+
+```rust
+//! A DRI3 1.4 syncobj imported from a client fd, held as a process-local
+//! DRM syncobj handle.
+//!
+//! This deliberately has no Vulkan in it. A DRM syncobj is a kernel object
+//! and every operation the server needs — signal, query, eventfd — has a DRM
+//! ioctl. Importing it into a `VkSemaphore` instead only works where the
+//! driver's `OPAQUE_FD` payload happens to be a DRM syncobj, which is true on
+//! Mesa and false on NVIDIA proprietary
+//! (`vkImportSemaphoreFdKHR` → `VK_ERROR_INITIALIZATION_FAILED`, measured
+//! 2026-08-08). See
+//! docs/superpowers/specs/2026-08-08-dri3-syncobj-drm-signal-design.md.
+//!
+//! The sibling `OwnedSemaphore` keeps the Vulkan path for XSync `Fence`
+//! resources, which need a real `VkSemaphore` for `FDFromFence`'s sync_file
+//! export.
+
+use std::{
+    os::fd::{AsFd, BorrowedFd, OwnedFd},
+    sync::Arc,
+};
+
+use ::drm::control::{Device as DrmControlDevice, syncobj};
+
+pub(crate) struct ImportedSyncobj {
+    drm: Arc<crate::drm::Device>,
+    handle: syncobj::Handle,
+}
+
+impl ImportedSyncobj {
+    /// Import a client's `DRM_SYNCOBJ` fd as a process-local handle. The fd
+    /// is only borrowed — `DRM_IOCTL_SYNCOBJ_FD_TO_HANDLE` does not consume
+    /// it — so the caller keeps ownership and drops it normally.
+    pub(crate) fn import(
+        drm: Arc<crate::drm::Device>,
+        fd: BorrowedFd<'_>,
+    ) -> std::io::Result<Self> {
+        let handle = drm.fd_to_syncobj(fd, false)?;
+        Ok(Self { drm, handle })
+    }
+
+    /// Current timeline value. Replaces `vkGetSemaphoreCounterValue` in the
+    /// deferred-acquire polling fallback.
+    pub(crate) fn timeline_value(&self) -> std::io::Result<u64> {
+        let mut points = [0u64; 1];
+        self.drm
+            .syncobj_timeline_query(&[self.handle], &mut points, false)?;
+        Ok(points[0])
+    }
+
+    /// Register a non-blocking kernel notification for a timeline point.
+    /// Unchanged in behaviour from the previous `OwnedSemaphore` version —
+    /// that method already went through DRM.
+    pub(crate) fn signaled_eventfd(&self, value: u64) -> std::io::Result<OwnedFd> {
+        use nix::sys::eventfd::{EfdFlags, EventFd};
+
+        let event =
+            EventFd::from_value_and_flags(0, EfdFlags::EFD_NONBLOCK | EfdFlags::EFD_CLOEXEC)
+                .map_err(|e| std::io::Error::other(format!("eventfd: {e}")))?;
+        self.drm
+            .syncobj_eventfd(self.handle, value, event.as_fd(), false)?;
+        Ok(event.into())
+    }
+}
+
+impl std::fmt::Debug for ImportedSyncobj {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ImportedSyncobj")
+            .field("handle", &self.handle)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for ImportedSyncobj {
+    fn drop(&mut self) {
+        if let Err(e) = self.drm.destroy_syncobj(self.handle) {
+            log::warn!("destroy imported DRM syncobj handle failed: {e}");
+        }
+    }
+}
+
+impl yserver_core::backend::SyncobjHandle for ImportedSyncobj {
+    /// Host-signal a timeline point. Replaces `vkSignalSemaphore`, which was
+    /// also a host operation — the ordering guarantee is unchanged.
+    fn signal(&self, value: u64) -> std::io::Result<()> {
+        self.drm.syncobj_timeline_signal(&[self.handle], &[value])
+    }
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test -p yserver --lib imported_syncobj -- --ignored`
+Expected: 2 passed. If `crate::drm::Device::open` has a different signature,
+check `crates/yserver/src/drm/device.rs` and adapt the test's construction
+only — not the production code.
+
+- [ ] **Step 6: Format, lint, commit**
+
+```bash
+cargo +nightly fmt
+cargo clippy --all-targets -- -D warnings
+git add crates/yserver/src/kms/render/imported_syncobj.rs crates/yserver/src/kms/render/mod.rs
+git commit -m "feat(dri3): add ImportedSyncobj, a DRM-backed syncobj resource
+
+A DRI3 syncobj is a kernel object and every operation the server needs
+on one -- signal, query, eventfd -- has a DRM ioctl. Importing it into a
+VkSemaphore only works where the driver's OPAQUE_FD payload happens to
+be a DRM syncobj, which is false on NVIDIA proprietary.
+
+Not wired up yet; the registries still hold OwnedSemaphore."
+```
+
+---
+
+### Task 2: Split the syncobj registry from the fence registry
+
+**Files:**
+- Modify: `crates/yserver/src/kms/render/backend.rs:805` (field),
+  `:2334` and `:3222` (both initialisers), `:19291-19299`
+  (`dri3_syncobj_handle`), `:19313-19375` (`dri3_import_syncobj`),
+  `:19376-19382` (`dri3_free_syncobj`), `:19384-19392`
+  (`dri3_signal_syncobj`)
+- Test: inline `#[cfg(test)] mod tests` in `backend.rs`
+
+**Interfaces:**
+- Consumes: `ImportedSyncobj::import`, `SyncobjHandle` impl from Task 1.
+- Produces: field `dri3_syncobjs: HashMap<u32, Arc<ImportedSyncobj>>`.
+  `dri3_sync_resources` survives, now holding fences only. Task 3 reads
+  `dri3_syncobjs`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)] mod tests` block in `backend.rs`, next to the existing
+`dri3_import_syncobj_no_vk_errs` test (around `:28065`):
+
+```rust
+/// Fences and syncobjs are different X resource types and must not share
+/// one registry: before the split, FDFromFence on a syncobj xid resolved
+/// into the same map and half-worked.
+#[test]
+fn fd_from_fence_does_not_resolve_a_syncobj_xid() {
+    let mut b = KmsBackend::for_tests();
+    // No Vulkan in for_tests(), so a resolved entry and an unresolved one
+    // both Err. Distinguish them by message: an unknown xid must be
+    // reported as unknown, not as a Vulkan failure.
+    let err = b
+        .dri3_fd_from_fence(0x4040_5555)
+        .expect_err("unknown fence xid must Err");
+    assert!(
+        err.to_string().contains("unknown fence"),
+        "expected an unknown-fence error, got: {err}",
+    );
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p yserver --lib fd_from_fence_does_not_resolve -- --nocapture`
+Expected: FAIL — `dri3_fd_from_fence` checks Vulkan availability before the
+registry lookup, so the message is "DRI3 FDFromFence: Vulkan unavailable".
+
+- [ ] **Step 3: Add the new field**
+
+In `backend.rs`, immediately after the `dri3_sync_resources` field (`:805`),
+add:
+
+```rust
+    /// DRI3 1.4 syncobj resources keyed by the client's xid, imported by
+    /// `ImportSyncobj`. Separate from `dri3_sync_resources` because these
+    /// are a different X resource type with a different backing primitive:
+    /// a DRM syncobj handle, not a `VkSemaphore`.
+    pub(crate) dri3_syncobjs:
+        HashMap<u32, std::sync::Arc<crate::kms::render::imported_syncobj::ImportedSyncobj>>,
+```
+
+Narrow the doc comment on `dri3_sync_resources` (`:800-804`) to fences only:
+
+```rust
+    /// DRI3 sync-fence resources keyed by the client's xid, from
+    /// `FenceFromFD` falling through the xshmfence path (sync_file fd →
+    /// `VkSemaphore`). Syncobjs live in `dri3_syncobjs`.
+```
+
+Add `dri3_syncobjs: HashMap::new(),` next to `dri3_sync_resources:
+HashMap::new(),` in **both** initialisers (`:2334` and `:3222`). Missing the
+second one is a compile error, not a silent bug.
+
+- [ ] **Step 4: Rewire the four syncobj methods**
+
+Replace `dri3_import_syncobj` (`:19313-19375`) entirely — the `dup`, the
+Vulkan gate, the import, and the rollback all go away, because
+`fd_to_syncobj` borrows the fd and there is nothing to roll back:
+
+```rust
+    fn dri3_import_syncobj(
+        &mut self,
+        syncobj_xid: u32,
+        fd: std::os::fd::OwnedFd,
+    ) -> io::Result<()> {
+        use std::os::fd::AsFd;
+
+        let imported = crate::kms::render::imported_syncobj::ImportedSyncobj::import(
+            self.platform.device.clone(),
+            fd.as_fd(),
+        )?;
+        // Arc Drop on any replaced entry destroys the previous handle.
+        let _ = self
+            .dri3_syncobjs
+            .insert(syncobj_xid, std::sync::Arc::new(imported));
+        Ok(())
+    }
+```
+
+Replace `dri3_free_syncobj` (`:19376-19382`):
+
+```rust
+    fn dri3_free_syncobj(&mut self, syncobj_xid: u32) -> io::Result<()> {
+        // Arc Drop destroys the DRM handle when the last reference goes
+        // away, which may be later than this call: the deferred completion
+        // path pins clones past FreeSyncobj.
+        let _ = self.dri3_syncobjs.remove(&syncobj_xid);
+        Ok(())
+    }
+```
+
+Replace `dri3_signal_syncobj` (`:19384-19392`):
+
+```rust
+    fn dri3_signal_syncobj(&mut self, syncobj_xid: u32, value: u64) -> io::Result<()> {
+        use yserver_core::backend::SyncobjHandle as _;
+
+        let arc = self.dri3_syncobjs.get(&syncobj_xid).ok_or_else(|| {
+            io::Error::other(format!(
+                "DRI3 SignalSyncobj: unknown syncobj 0x{syncobj_xid:x}"
+            ))
+        })?;
+        arc.signal(value)
+    }
+```
+
+Replace `dri3_syncobj_handle` (`:19291-19299`):
+
+```rust
+    fn dri3_syncobj_handle(
+        &self,
+        syncobj_xid: u32,
+    ) -> Option<std::sync::Arc<dyn yserver_core::backend::SyncobjHandle>> {
+        self.dri3_syncobjs
+            .get(&syncobj_xid)
+            .cloned()
+            .map(|arc| arc as std::sync::Arc<dyn yserver_core::backend::SyncobjHandle>)
+    }
+```
+
+- [ ] **Step 5: Move the registry lookup ahead of the Vulkan gate**
+
+In `dri3_fd_from_fence` (`:19301-19311`), the lookup must come first so an
+unknown xid reports as unknown. Replace its body:
+
+```rust
+    fn dri3_fd_from_fence(&mut self, fence_xid: u32) -> io::Result<std::os::fd::OwnedFd> {
+        let arc = self
+            .dri3_sync_resources
+            .get(&fence_xid)
+            .cloned()
+            .ok_or_else(|| {
+                io::Error::other(format!("DRI3 FDFromFence: unknown fence 0x{fence_xid:x}"))
+            })?;
+        let Some(vk) = self.platform.vk.as_ref() else {
+            return Err(io::Error::other("DRI3 FDFromFence: Vulkan unavailable"));
+        };
+        crate::kms::vk::sync::export_sync_file(vk, arc.semaphore())
+            .map_err(|e| io::Error::other(format!("export_sync_file: {e:?}")))
+    }
+```
+
+- [ ] **Step 6: Fix the pre-existing test that asserted the old shape**
+
+`dri3_import_syncobj_no_vk_errs` (`:28065`) asserts the import Errs without
+Vulkan. That is no longer true — the import no longer touches Vulkan. Replace
+the test with one that asserts what now holds:
+
+```rust
+/// ImportSyncobj no longer needs Vulkan. Without a DRM device in
+/// for_tests() it still Errs, but on the DRM ioctl rather than a Vk gate.
+#[test]
+fn dri3_import_syncobj_errs_without_a_usable_drm_handle() {
+    use std::os::fd::{FromRawFd, IntoRawFd, OwnedFd};
+    let f = std::fs::OpenOptions::new()
+        .read(true)
+        .open("/dev/null")
+        .expect("open /dev/null");
+    // SAFETY: we own this fd via the OpenOptions handle and re-wrap it
+    // directly; the OwnedFd's Drop closes it.
+    let fd = unsafe { OwnedFd::from_raw_fd(f.into_raw_fd()) };
+    let mut b = KmsBackend::for_tests();
+    assert!(
+        b.dri3_import_syncobj(0x4040_3333, fd).is_err(),
+        "importing a non-syncobj fd must Err",
+    );
+}
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `cargo test -p yserver --lib dri3_ -- --nocapture`
+Expected: PASS, including `fd_from_fence_does_not_resolve_a_syncobj_xid` and
+`dri3_import_syncobj_errs_without_a_usable_drm_handle`.
+
+- [ ] **Step 8: Format, lint, commit**
+
+```bash
+cargo +nightly fmt
+cargo clippy --all-targets -- -D warnings
+git add crates/yserver/src/kms/render/backend.rs
+git commit -m "refactor(dri3): hold syncobjs in their own registry, backed by DRM
+
+FenceFromFD and ImportSyncobj registered two different X resource types
+into one HashMap of OwnedSemaphore. Only the fence half needs Vulkan
+(FDFromFence exports a sync_file from the VkSemaphore); the syncobj half
+needs a DRM handle. Split them so the type mismatch is unrepresentable,
+and move ImportSyncobj/FreeSyncobj/SignalSyncobj onto ImportedSyncobj.
+
+FDFromFence now looks up the registry before the Vulkan gate, so an
+unknown xid reports as unknown rather than as a Vulkan failure."
+```
+
+---
+
+### Task 3: Move the deferred acquire path off Vulkan
+
+**Files:**
+- Modify: `crates/yserver/src/kms/render/present_source_wait.rs:22-25,41-49`
+- Modify: `crates/yserver/src/kms/render/backend.rs:13161-13185` (the
+  `dri3_sync_resources` lookup in the acquire path)
+
+**Interfaces:**
+- Consumes: `ImportedSyncobj::timeline_value`, `.signaled_eventfd` (Task 1);
+  `dri3_syncobjs` (Task 2).
+- Produces: `PendingPresentSourceWait::syncobj_pin` retyped to
+  `Option<Arc<ImportedSyncobj>>`. No later task depends on this.
+
+- [ ] **Step 1: Retype the pin and its readiness check**
+
+In `present_source_wait.rs`, replace lines 20-25:
+
+```rust
+    /// Keeps an explicitly imported acquire syncobj alive until its timeline
+    /// point signals. Implicit dma-buf waits leave this empty.
+    pub(crate) syncobj_pin: Option<Arc<super::imported_syncobj::ImportedSyncobj>>,
+    /// Used only when DRM_SYNCOBJ_EVENTFD is unavailable and readiness must
+    /// be checked by polling the syncobj's timeline value.
+    pub(crate) timeline_value: Option<u64>,
+```
+
+Replace the `is_ready` timeline arm (lines 40-50):
+
+```rust
+        let timeline_ready = match (&self.syncobj_pin, self.timeline_value) {
+            (Some(syncobj), Some(target)) => match syncobj.timeline_value() {
+                Ok(current) => current >= target,
+                Err(e) => {
+                    log::warn!(
+                        "deferred Present acquire: syncobj timeline query failed: {e}; \
+                         treating as ready"
+                    );
+                    true
+                }
+            },
+            _ => true,
+        };
+```
+
+- [ ] **Step 2: Point the acquire path at the new registry**
+
+In `backend.rs`, in the block starting at `:13161`, change the lookup and the
+fallback log line:
+
+```rust
+            let syncobj = self
+                .dri3_syncobjs
+                .get(&acquire_syncobj)
+                .cloned()
+                .ok_or_else(|| {
+                    io::Error::other(format!(
+                        "PresentPixmapSynced: unknown acquire syncobj 0x{acquire_syncobj:x}"
+                    ))
+                })?;
+            let event_fd = match syncobj.signaled_eventfd(acquire_value) {
+                Ok(fd) => Some(fd),
+                Err(e) => {
+                    log::warn!(
+                        target: "yserver::kms::render::present",
+                        "PresentPixmapSynced DRM eventfd unavailable ({e}); polling the syncobj timeline",
+                    );
+                    None
+                }
+            };
+```
+
+- [ ] **Step 3: Run the existing tests to verify nothing broke**
+
+Run: `cargo test -p yserver --lib present_source_wait`
+Expected: PASS. The two existing tests construct `syncobj_pin: None`, so they
+compile unchanged — that is the signal that the retype is contained.
+
+- [ ] **Step 4: Format, lint, commit**
+
+```bash
+cargo +nightly fmt
+cargo clippy --all-targets -- -D warnings
+git add crates/yserver/src/kms/render/present_source_wait.rs crates/yserver/src/kms/render/backend.rs
+git commit -m "refactor(present): poll deferred acquires through the DRM timeline
+
+The acquire eventfd was already DRM; only its polling fallback still
+went through vkGetSemaphoreCounterValue. Move that to
+DRM_IOCTL_SYNCOBJ_QUERY so the whole acquire path is driver-neutral."
+```
+
+---
+
+### Task 4: Strip the syncobj half out of `OwnedSemaphore`
+
+**Files:**
+- Modify: `crates/yserver/src/kms/render/owned_semaphore.rs` (remove
+  `drm_syncobj`, `new_drm_syncobj`, `signaled_eventfd`, `timeline_value`, the
+  `SyncobjHandle` impl, and the DRM branch of `Drop`)
+- Modify: `crates/yserver/src/kms/vk/sync.rs:55-80` (delete
+  `import_drm_syncobj`)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `OwnedSemaphore` reduced to `{ vk, semaphore }` with `new`,
+  `semaphore`, `signal_vk`. No later task depends on the removed items.
+
+- [ ] **Step 1: Reduce `OwnedSemaphore`**
+
+Replace the whole of `owned_semaphore.rs` below the module doc comment. Update
+the doc comment first to say what it is now:
+
+```rust
+//! RAII wrapper for a `vk::Semaphore` so it can be `Arc`-shared for the
+//! deferred PRESENT completion path. Destruction happens on the last Arc
+//! drop (via `vkDestroySemaphore`), independent of the X11 resource id's
+//! lifetime.
+//!
+//! This backs XSync `Fence` resources only. DRI3 1.4 syncobjs are
+//! `ImportedSyncobj` — they are DRM objects and never enter Vulkan.
+
+use std::sync::Arc;
+
+use ash::vk;
+
+use crate::kms::vk::device::VkContext;
+
+pub(crate) struct OwnedSemaphore {
+    vk: Arc<VkContext>,
+    semaphore: vk::Semaphore,
+}
+
+impl OwnedSemaphore {
+    pub(crate) fn new(vk: Arc<VkContext>, semaphore: vk::Semaphore) -> Self {
+        Self { vk, semaphore }
+    }
+
+    pub(crate) fn semaphore(&self) -> vk::Semaphore {
+        self.semaphore
+    }
+
+    /// Signal a timeline-semaphore value via `vkSignalSemaphore`.
+    pub(crate) fn signal_vk(&self, value: u64) -> Result<(), vk::Result> {
+        crate::kms::vk::sync::signal_timeline(&self.vk, self.semaphore, value)
+    }
+
+    /// Test-only constructor: holds a null semaphore handle. Drop is a no-op
+    /// (vkDestroySemaphore on null is allowed by the Vulkan spec but the
+    /// guard below skips it anyway).
+    #[cfg(test)]
+    pub(crate) fn for_tests_dummy(vk: Arc<VkContext>) -> Self {
+        Self {
+            vk,
+            semaphore: vk::Semaphore::null(),
+        }
+    }
+}
+
+impl std::fmt::Debug for OwnedSemaphore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OwnedSemaphore")
+            .field("semaphore", &self.semaphore)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for OwnedSemaphore {
+    fn drop(&mut self) {
+        if self.semaphore == vk::Semaphore::null() {
+            return;
+        }
+        unsafe {
+            self.vk.device.destroy_semaphore(self.semaphore, None);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Delete the Vulkan syncobj import**
+
+In `crates/yserver/src/kms/vk/sync.rs`, delete `import_drm_syncobj` (lines
+55-80, doc comment included). Leave `import_sync_file`, `export_sync_file` and
+`signal_timeline` alone — all three still serve the fence path.
+
+- [ ] **Step 3: Build and let the compiler find the stragglers**
+
+Run: `cargo build -p yserver 2>&1 | head -40`
+Expected: PASS. If anything still references `new_drm_syncobj`,
+`import_drm_syncobj`, or `OwnedSemaphore::timeline_value`, the compiler names
+it — fix those call sites to use `ImportedSyncobj` rather than reinstating
+what you just deleted. If a call site cannot be converted, stop and report:
+it means a consumer was missed in the design.
+
+- [ ] **Step 4: Run the full test suite**
+
+Run: `cargo test -p yserver --lib`
+Expected: PASS.
+
+- [ ] **Step 5: Format, lint, commit**
+
+```bash
+cargo +nightly fmt
+cargo clippy --all-targets -- -D warnings
+git add crates/yserver/src/kms/render/owned_semaphore.rs crates/yserver/src/kms/vk/sync.rs
+git commit -m "refactor(dri3): drop the Vulkan syncobj import
+
+OwnedSemaphore carried a retained DRM handle, an eventfd registration and
+a timeline query that existed only for the syncobj half, now served by
+ImportedSyncobj. What remains is the XSync fence resource it always was.
+
+import_drm_syncobj goes with it: vkImportSemaphoreFdKHR on a DRM syncobj
+fd is a Mesa-only accident, not a portable interop path."
+```
+
+---
+
+### Task 5: Derive the capability from the kernel, not the driver
+
+**Files:**
+- Modify: `crates/yserver/src/kms/render/backend.rs:18967-18992`
+  (`dri3_capabilities`)
+- Modify: `crates/yserver/src/kms/vk/device.rs:87-89` (delete
+  `supports_dri3_syncobj`)
+- Test: inline `#[cfg(test)] mod tests` in `backend.rs`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks at the type level; depends on Tasks 1-4
+  being done, because this is the step that starts advertising 1.4.
+- Produces: free function `dri3_version_for(syncobj: bool) -> (u32, u32)`.
+
+**This task turns the feature on. Do it last.**
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)] mod tests` block in `backend.rs`:
+
+```rust
+/// The DRI3 version follows syncobj support: 1.4 advertises
+/// ImportSyncobj/FreeSyncobj and, through the mirrored Present
+/// capability, PresentPixmapSynced. Without syncobj support the server
+/// must stay at 1.3 or clients will send requests it cannot serve.
+#[test]
+fn dri3_version_follows_syncobj_support() {
+    assert_eq!(dri3_version_for(true), (1, 4));
+    assert_eq!(dri3_version_for(false), (1, 3));
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p yserver --lib dri3_version_follows -- --nocapture`
+Expected: FAIL — `dri3_version_for` is not defined.
+
+- [ ] **Step 3: Rewrite the capability derivation**
+
+Add this free function in `backend.rs` immediately above the `impl Backend for
+KmsBackend` block that contains `dri3_capabilities`:
+
+```rust
+/// DRI3 version for a given syncobj capability. 1.4 is the version that
+/// carries `ImportSyncobj` / `FreeSyncobj`; without them the server caps at
+/// 1.3 and clients fall back to the fence path.
+fn dri3_version_for(syncobj: bool) -> (u32, u32) {
+    if syncobj { (1, 4) } else { (1, 3) }
+}
+```
+
+Replace the body of `dri3_capabilities` (`:18967-18992`):
+
+```rust
+    fn dri3_capabilities(&self) -> Dri3Caps {
+        // DRI3 entirely unavailable when render-node fd or Vulkan weren't
+        // resolved at backend init: pixmap import/export still needs both.
+        if self.platform.render_node_fd.is_none() || self.platform.vk.is_none() {
+            return Dri3Caps::unsupported();
+        }
+        let vk = self.platform.vk.as_ref().expect("vk Some by branch above");
+        let modifiers = vk.image_drm_format_modifier;
+        // VK_KHR_external_semaphore_fd is unconditionally enabled at device
+        // init; fence_fd / SYNC_FD handle type rides along with it.
+        let fence_fd = true;
+        // Syncobj support is a property of the KERNEL, not of the Vulkan
+        // driver: the resource is a DRM syncobj and every operation on it is
+        // a DRM ioctl. The previous NVIDIA blacklist here was really a
+        // symptom of vkImportSemaphoreFdKHR rejecting DRM syncobj fds, which
+        // no longer matters because nothing imports them into Vulkan.
+        let syncobj = ::drm::Device::get_driver_capability(
+            self.platform.device.as_ref(),
+            ::drm::DriverCapability::TimelineSyncObj,
+        )
+        .is_ok_and(|v| v != 0);
+        Dri3Caps {
+            version: dri3_version_for(syncobj),
+            modifiers,
+            fence_fd,
+            syncobj,
+        }
+    }
+```
+
+**Watch the trait path:** `get_driver_capability` is on the `drm::Device` root
+trait, *not* on `drm::control::Device`, which is the one this file already
+imports for the syncobj calls. `crates/yserver/src/kms/cursor_plane.rs:30-34`
+shows the distinction — it imports `Device as DrmDevice` alongside
+`control::{Device as ControlDevice, ...}`. Use a `use` alias rather than the
+fully-qualified call if that reads better, but do not assume one trait has the
+other's methods.
+
+- [ ] **Step 4: Delete the driver blacklist**
+
+In `crates/yserver/src/kms/vk/device.rs`, delete `supports_dri3_syncobj`
+(lines 87-89) together with its doc comment.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `cargo test -p yserver --lib`
+Expected: PASS. If a test asserted DRI3 1.3 on this box, it was asserting the
+blacklist; update it to assert the kernel-derived value.
+
+- [ ] **Step 6: Format, lint, commit**
+
+```bash
+cargo +nightly fmt
+cargo clippy --all-targets -- -D warnings
+git add crates/yserver/src/kms/render/backend.rs crates/yserver/src/kms/vk/device.rs
+git commit -m "feat(dri3): advertise 1.4 whenever the kernel has timeline syncobj
+
+supports_dri3_syncobj() blacklisted NVIDIA_PROPRIETARY, which capped DRI3
+at 1.3 and left PresentPixmapSynced untestable on the nvidia box. The
+real condition was never the Vulkan driver: it is whether the kernel
+exposes DRM_CAP_SYNCOBJ_TIMELINE, which is what the Phase 4.2 design's
+fallback matrix said in the first place.
+
+Measured on the nvidia box: nvidia-drm serves the whole syncobj path, and
+libGLX_nvidia resolves import_syncobj plus present_pixmap_synced once per
+swapchain against a 1.4 server."
+```
+
+---
+
+### Task 6: Hardware validation and documentation
+
+**Files:**
+- Modify: `docs/status.md`
+- Modify: `docs/superpowers/specs/2026-08-08-dri3-syncobj-drm-signal-design.md`
+  (Status line)
+
+- [ ] **Step 1: Run the server and capture**
+
+Start yserver and run a Vulkan client through X11 WSI. It must be Vulkan, not
+GL — `docs/status.md:4084` records NVIDIA's libGL failing to bind DRI3 against
+yserver for unrelated reasons, so a GL client cannot answer either way.
+
+```bash
+# `just yserver-mate-hw` (Justfile:293) takes a log spec. The wire-level
+# DRI3/PRESENT debug lines live on the default target, so present_pace
+# alone is NOT enough — process_request must be included or ImportSyncobj
+# never appears and the capture looks like a negative result.
+just yserver-mate-hw "info,present_pace=debug,yserver_core::core_loop::process_request=debug"
+
+# inside the session, forcing the Vulkan X11 WSI:
+mpv --gpu-api=vulkan --vo=gpu-next --gpu-context=x11vk \
+    --length=15 av://lavfi:testsrc=size=1280x720:rate=60
+```
+
+Copy the log aside immediately (`cp yserver-hw-mate.log dri3-syncobj-<date>.log`).
+Every yserver start truncates `yserver-hw-mate.log` and
+`yserver-mate.submit.tsv` at the repo root with `>` plus `rm -f`, including a
+normal desktop session — analyse or copy before the next run or the data is
+gone.
+
+- [ ] **Step 2: Check the four things that must appear**
+
+```bash
+LOG=dri3-syncobj-<date>.log
+grep -c "DRI3::QueryVersion.*-> 1.4" "$LOG"      # server advertises 1.4
+grep -c "DRI3::ImportSyncobj" "$LOG"             # client takes the path
+grep -c "present acquire" "$LOG"                 # acquires resolve
+grep -c "signal release syncobj.*failed" "$LOG"  # must be 0 or explained
+```
+
+A non-zero count on the last one is most likely the pre-existing freed-syncobj
+bookkeeping bug (`docs/status.md:567`) becoming reachable, not a regression
+from this change. Record which it is; do not fix it here.
+
+- [ ] **Step 3: Update `docs/status.md`**
+
+Add an entry with: the capability now deriving from
+`DRM_CAP_SYNCOBJ_TIMELINE`; that `PresentPixmapSynced` is no longer
+"structurally untestable" (amend the claim at `:316`, which named this exact
+gate); the counts from Step 2; and whether the freed-syncobj signals appeared.
+
+- [ ] **Step 4: Flip the spec's status line**
+
+Change the spec header from `**Status:** DESIGN (2026-08-08)` to
+`IMPLEMENTED`, with the hardware result and the box it ran on, following the
+style of `2026-07-20-nvidia-gbm-scanout-allocation.md`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo +nightly fmt
+cargo clippy --all-targets -- -D warnings
+git add docs/status.md docs/superpowers/specs/2026-08-08-dri3-syncobj-drm-signal-design.md
+git commit -m "docs(dri3): record the DRM-signalled syncobj result on hardware"
+```
+
+---
+
+## Deferred / out of scope
+
+- **Cross-driver validation.** The Mesa path changes from a Vulkan host signal
+  to a DRM host signal and there is no AMD or Intel GPU on this box. The bee
+  (6900HX / RADV) is where that gets confirmed.
+- **The freed-syncobj bookkeeping bug** (`docs/status.md:567`). This change
+  makes it reachable here; it does not cause it.
+- **GPU-side release signalling.** Signalling the client's release point from
+  the queue instead of the host would let clients unblock earlier, but it is a
+  separate design with its own measurement, and it is impossible on NVIDIA
+  (the import that would be required is what fails). See the spec's root-cause
+  section for why the queue-wait half of that idea is foreclosed by the single
+  shared queue.

--- a/docs/superpowers/plans/2026-08-08-dri3-syncobj-drm-signal.md
+++ b/docs/superpowers/plans/2026-08-08-dri3-syncobj-drm-signal.md
@@ -992,12 +992,28 @@ the overrides.
         buf[1]
     }
 
+    /// RecordingBackend with a DRI3 1.4 / `syncobj: true` surface so the
+    /// IMPORT_SYNCOBJ / FREE_SYNCOBJ handlers pass their `caps.syncobj` gate.
+    /// Kept as a per-test opt-in: the DEFAULT backend must stay
+    /// `Dri3Caps::unsupported()` for the existing
+    /// `dri3_hidden_when_caps_unsupported` test (process_request.rs:37076).
+    fn syncobj_cap_backend() -> RecordingBackend {
+        let mut backend = RecordingBackend::new();
+        backend.dri3_caps = crate::backend::Dri3Caps {
+            version: (1, 4),
+            modifiers: false,
+            fence_fd: false,
+            syncobj: true,
+        };
+        backend
+    }
+
     #[test]
     fn import_syncobj_in_use_xid_is_bad_alloc() {
         use yserver_protocol::x11::{CreatePixmapRequest, ResourceId};
         let mut state = ServerState::new();
         let mut peer = install_client(&mut state, 1);
-        let mut backend = RecordingBackend::new();
+        let mut backend = syncobj_cap_backend();
 
         // install_client (process_request.rs:29047) gives every test client
         // base=0/mask=u32::MAX — "every xid is in range" — so the
@@ -1045,7 +1061,7 @@ the overrides.
     fn import_syncobj_missing_fd_is_bad_alloc() {
         let mut state = ServerState::new();
         let mut peer = install_client(&mut state, 1);
-        let mut backend = RecordingBackend::new();
+        let mut backend = syncobj_cap_backend();
 
         process_request(
             &mut state,
@@ -1075,7 +1091,7 @@ the overrides.
     fn free_syncobj_unknown_is_bad_value() {
         let mut state = ServerState::new();
         let mut peer = install_client(&mut state, 1);
-        let mut backend = RecordingBackend::new();
+        let mut backend = syncobj_cap_backend();
 
         let mut body = vec![0u8; 4];
         body[0..4].copy_from_slice(&0x0040_9999u32.to_le_bytes());
@@ -1108,7 +1124,7 @@ the overrides.
         let mut state = ServerState::new();
         let _peer_a = install_client(&mut state, 1);
         let mut peer_b = install_client(&mut state, 2);
-        let mut backend = RecordingBackend::new();
+        let mut backend = syncobj_cap_backend();
 
         // Client A imports 0x0010_0001 (a legal xid for client 1 — the
         // handler now validates range). RecordingBackend ignores the fd's
@@ -1281,6 +1297,14 @@ builder + setup helper, then three tests:
             x11::error::BAD_VALUE,
             "unknown acquire syncobj must be BadValue, not a silent no-reply wait",
         );
+        // X error: bytes 4-7 are the bad-value argument. It must carry the
+        // offending xid, mirroring Xorg's VERIFY_DRI3_SYNCOBJ
+        // (client->errorValue = id).
+        assert_eq!(
+            u32::from_le_bytes(buf[4..8].try_into().unwrap()),
+            ACQUIRE_SYNCOBJ,
+            "BadValue must carry the offending syncobj xid",
+        );
     }
 
     #[test]
@@ -1348,12 +1372,12 @@ otherwise-valid request — that is the real-client shape of row 4.
 - [ ] **Step 2: Run the tests to verify they fail**
 
 Run: `cargo test -p yserver-core --lib`
-Expected: FAIL to compile. The new tests reference `dri3_syncobj_owners`
-(added in Step 4) and the conformance error paths (Step 5-7), so the whole
-`#[cfg(test)]` target breaks. A `cargo test <filter>` would not help — the
-compile error fires before any test selection, so naming `import_syncobj_`,
-`free_syncobj_` or `present_pixmap_synced_` changes nothing; run without a
-filter.
+Expected: FAIL to compile. The new tests reference `dri3_syncobj_owners` and
+`dri3_caps` (added in Step 4, via the `syncobj_cap_backend()` helper) and the
+conformance error paths (Step 5-7), so the whole `#[cfg(test)]` target breaks.
+A `cargo test <filter>` would not help — the compile error fires before any
+test selection, so naming `import_syncobj_`, `free_syncobj_` or
+`present_pixmap_synced_` changes nothing; run without a filter.
 
 - [ ] **Step 3: Give the registry an owning client**
 
@@ -1378,7 +1402,7 @@ tests in Step 9 within this task (single commit — see the task intro).
 - [ ] **Step 4: Add syncobj tracking to `RecordingBackend`**
 
 `RecordingBackend` (`crates/yserver-core/src/backend/recording.rs`) drives the
-wire-level tests. Add a field and a private handle type, plus overrides for the
+wire-level tests. Add two fields, a private handle type, plus overrides for the
 four syncobj methods:
 
 ```rust
@@ -1386,7 +1410,19 @@ four syncobj methods:
     /// client. Backed by a dummy `SyncobjHandle` so `dri3_syncobj_handle` has
     /// something to return.
     pub(crate) dri3_syncobj_owners: std::collections::HashMap<u32, yserver_protocol::x11::ClientId>,
+    /// DRI3 capability surface. Defaults to `Dri3Caps::unsupported()` and is
+    /// a FIELD, not a hardcoded override: the existing
+    /// `dri3_hidden_when_caps_unsupported` test (process_request.rs:37076)
+    /// requires the DEFAULT RecordingBackend to stay unsupported (DRI3 absent
+    /// from QueryExtension/ListExtensions). The syncobj conformance tests
+    /// flip this to a (1, 4)/`syncobj: true` surface so the `IMPORT_SYNCOBJ` /
+    /// `FREE_SYNCOBJ` handlers pass their `caps.syncobj` gate.
+    pub(crate) dri3_caps: crate::backend::Dri3Caps,
 ```
+
+Initialize both in `RecordingBackend::new()` (recording.rs:369, alongside the
+other field initialisers at `:396`): `dri3_syncobj_owners: HashMap::new(),`
+and `dri3_caps: crate::backend::Dri3Caps::unsupported(),`.
 
 ```rust
 #[derive(Debug)]
@@ -1400,18 +1436,12 @@ impl crate::backend::SyncobjHandle for DummySyncobjHandle {
 ```
 
 And the overrides (next to the existing `dri3_signal_syncobj` override). The
-`dri3_capabilities` override is REQUIRED: the `IMPORT_SYNCOBJ` /
-`FREE_SYNCOBJ` handlers gate on `caps.syncobj` and would otherwise return
-`BadImplementation` before the conformance code runs:
+`dri3_capabilities` override reads the field, so the default backend stays
+`unsupported()` and only the conformance tests opt into a syncobj surface:
 
 ```rust
     fn dri3_capabilities(&self) -> crate::backend::Dri3Caps {
-        crate::backend::Dri3Caps {
-            version: (1, 4),
-            modifiers: false,
-            fence_fd: false,
-            syncobj: true,
-        }
+        self.dri3_caps
     }
 
     fn dri3_import_syncobj(
@@ -1684,12 +1714,25 @@ never a silent no-reply wait:
                 || (req.acquire_syncobj == req.release_syncobj
                     && req.acquire_value >= req.release_value)
             {
+                // Mirror Xorg's bad-value choice: VERIFY_DRI3_SYNCOBJ
+                // (dri3/dri3.h:51-56) sets client->errorValue = <xid> when the
+                // syncobj lookup fails, while the point/ordering failures
+                // (present_request.c:299-301) leave errorValue 0. This is the
+                // error ARGUMENT, not the error CODE — it is NOT part of the
+                // declared divergence (which covers the code only).
+                let bad_value = if !acquire_known {
+                    req.acquire_syncobj
+                } else if !release_known {
+                    req.release_syncobj
+                } else {
+                    0
+                };
                 return emit_x11_error_with_minor(
                     state,
                     client_id,
                     sequence,
                     x11::error::BAD_VALUE,
-                    0,
+                    bad_value,
                     u16::from(header.data),
                     PRESENT_MAJOR_OPCODE,
                 );

--- a/docs/superpowers/plans/2026-08-08-dri3-syncobj-drm-signal.md
+++ b/docs/superpowers/plans/2026-08-08-dri3-syncobj-drm-signal.md
@@ -47,16 +47,16 @@ blocking findings from that review are fixed here:
    pair and proves nothing), gates on a non-zero deferred count and no
    fallback warning, and adds IGT GPU Tools (`syncobj_*` tests) as the
    kernel-level DRM validation.
-4. **Divergence from Xorg declared and applied to error codes.** The spec now
-   states explicitly that yserver does not adopt Xorg's resource-type
-   machinery (syncobjs stay a backend `HashMap` + owner field — HLD non-goal)
-   and does not replicate Xorg's error codes for `ImportSyncobj` /
-   `FreeSyncobj` (BadIDChoice / BadAccess). Only `PresentPixmapSynced`'s
-   Value errors are protocol (presentproto 1.4). Task 3 uses yserver's own
-   codes: `BadAlloc` for import failures (xid invalid, missing fd, import
-   error), `BadValue` for free failures (unknown or not the owner). The
-   spec's "model it as a real resource rather than weakening the table"
-   escape hatch is gone.
+4. **Divergence from Xorg narrowed to the resource model only (2026-08-10).**
+   An earlier revision declared a deliberate divergence in error CODES
+   (BadAlloc/BadValue vs Xorg's BadIDChoice/BadAccess). That was reversed:
+   desktop environments are tested for 40+ years against Xorg, so observable
+   error codes follow Xorg (BadIDChoice, BadDrawable, BadValue, BadAccess).
+   The only retained divergence is internal and not client-visible: yserver
+   does not adopt Xorg's resource-type machinery (syncobjs stay a backend
+   `HashMap` + owner field — HLD non-goal). Task 3 implements the Xorg codes
+   including a new `BadDrawable` check on the ImportSyncobj drawable (rows
+   1-5 of the spec's conformance table).
 
 Task boundaries changed again: the conformance work is a separate task (3)
 because it is independently reviewable (registry ownership + error semantics
@@ -84,13 +84,14 @@ same commit as the handlers that consume it.
   (the KMS node). On split-device boxes (Pi 4 vc4/v3d, Asahi) the two answer
   different questions. The capability is cached at init; the ioctls run
   per-request on the same retained device.
-- **Deliberate divergence from Xorg (see spec § "Divergence from Xorg").**
-  Error codes for `ImportSyncobj` / `FreeSyncobj` are yserver's own —
-  `BadAlloc` for any import failure, `BadValue` for any free failure. Xorg's
-  BadIDChoice / BadAccess distinction is NOT replicated (no client branches
-  on it; HLD non-goal "preserving behavior that exists only because of Xorg
-  implementation accidents"). Only `PresentPixmapSynced`'s Value errors are
-  protocol-mandated. Do not "fix" these to match Xorg during implementation.
+- **Error codes follow Xorg (spec § "Divergence from Xorg", revised 2026-08-10).**
+  Desktop environments are tested for 40+ years against Xorg, so observable
+  error codes do NOT diverge: `ImportSyncobj` uses BadIDChoice (xid invalid /
+  in use), BadDrawable (drawable missing), BadValue (missing fd), BadAlloc
+  (DRM import failure); `FreeSyncobj` uses BadValue (unknown) / BadAccess (not
+  the owning client); `PresentPixmapSynced` uses BadValue per presentproto 1.4.
+  Do not "fix" these away from Xorg during implementation. The only retained
+  divergence is internal (syncobjs are a backend `HashMap`, not X resources).
 - `docs/status.md` must be updated (Task 6). AGENTS.md requires it current.
 - Do not fix the freed-syncobj bookkeeping bug this change makes reachable
   (`docs/status.md:548`), and do not fix the fail-open arm in
@@ -930,19 +931,22 @@ unknown xid reports as unknown rather than as a Vulkan failure."
 The spec scoped this in: *"Give the registry an owning client and error
 semantics. That is the minimum that makes DRI3 1.4 safe to advertise: rows 3
 and 4 are cross-client and denial-of-service shaped respectively."* The
-conformance table (spec § "Protocol conformance") — note rows 1-3 diverge from
-Xorg in the **error codes** on purpose (spec § "Divergence from Xorg"): only
-row 4 is protocol-mandated:
+conformance table (spec § "Protocol conformance") — **error codes follow Xorg**
+(revision 2026-08-10: an earlier draft diverged in codes; that was reversed
+for desktop compatibility). Rows 1-4 plus the new BadDrawable row:
 
 | # | Contrato que debe cumplirse | Xorg | yserver (este cambio) |
 |---|---|---|---|
-| 1 | Un xid no legal para el cliente se rechaza (convención core X11) | `LEGAL_NEW_RESOURCE` → BadIDChoice (`dri3/dri3_request.c:609`) | `BadAlloc` — divergencia deliberada |
-| 2 | Un request sin fd se rechaza | `fd < 0` → BadValue (`dri3/dri3_request.c:619-620`) | `BadAlloc` — divergencia deliberada |
-| 3 | Nadie puede liberar el syncobj de otro | `dixLookupResourceByType(..., DixWriteAccess)` → BadValue/BadAccess (`dri3/dri3_request.c:634-637`) | ownership enforced; `BadValue` único — divergencia deliberada |
-| 4 | `PresentPixmapSynced`: syncobj inválido o points ilegales → **Value error** | `VERIFY_DRI3_SYNCOBJ` + BadValue (`present/present_request.c:296-302`) | `BadValue` — protocolo presentproto 1.4 |
+| 1 | Un xid no legal para el cliente se rechaza (convención core X11) | `LEGAL_NEW_RESOURCE` → BadIDChoice (`dri3/dri3_request.c:609`) | BadIDChoice — sigue a Xorg |
+| 2 | Un drawable que no existe se rechaza | `dixLookupDrawable` → BadDrawable (`dri3/dri3_request.c:615-618`) | BadDrawable — sigue a Xorg |
+| 3 | Un request sin fd se rechaza | `fd < 0` → BadValue (`dri3/dri3_request.c:619-620`) | BadValue — sigue a Xorg |
+| 4 | Nadie puede liberar el syncobj de otro | `dixLookupResourceByType(..., DixWriteAccess)` → BadValue/BadAccess (`dri3/dri3_request.c:634-637`) | BadValue (unknown) / BadAccess (not owner) — sigue a Xorg |
+| 5 | `PresentPixmapSynced`: syncobj inválido o points ilegales → **Value error** | `VERIFY_DRI3_SYNCOBJ` + BadValue (`present/present_request.c:296-302`) | BadValue — protocolo presentproto 1.4 |
 
-**Do not "fix" rows 1-3 to match Xorg's codes during implementation.** The
-Global Constraints and the spec's "Divergence from Xorg" section govern.
+**Error codes must match Xorg** (the Global Constraints and the spec's
+"Divergence from Xorg" section govern; only the resource model is internal).
+The snippets in this task's steps were written against the earlier divergent
+codes — apply them with the Xorg codes above.
 
 **Files:**
 - Modify: `crates/yserver-core/src/backend/trait_def.rs` — `dri3_import_syncobj`

--- a/docs/superpowers/plans/2026-08-08-dri3-syncobj-drm-signal.md
+++ b/docs/superpowers/plans/2026-08-08-dri3-syncobj-drm-signal.md
@@ -101,21 +101,50 @@ Add to `impl Device`, after `for_tests()` (`:39`):
 Create `crates/yserver/src/kms/render/imported_syncobj.rs` with only the test
 module for now:
 
+Note `pub(crate)` on both the module and `render_node()`: Tasks 3 and 5 reuse
+this helper rather than each hardcoding a node path.
+
 ```rust
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use std::{os::fd::AsFd, sync::Arc};
 
     use ::drm::control::Device as DrmControlDevice;
 
     use super::*;
 
-    /// Open the render node, or skip. Every test here needs real DRM ioctls;
-    /// they are `#[ignore]` so CI never runs them, but a machine without the
+    /// Open a render node, or skip. Every test here needs real DRM ioctls;
+    /// they are `#[ignore]` so CI never runs them, but a machine without a
     /// node should skip rather than fail.
-    fn render_node() -> Option<Arc<crate::drm::Device>> {
-        crate::drm::Device::open_render_node("/dev/dri/renderD128")
-            .ok()
+    ///
+    /// Do NOT hardcode `/dev/dri/renderD128`. `kms/render_node.rs:1-8` states
+    /// the rule outright — "we deliberately do **not** hardcode
+    /// `/dev/dri/renderD128` — on multi-GPU hosts that selects the wrong
+    /// device" — and the nvidia box became exactly such a host on 2026-08-08:
+    /// `renderD128` is nvidia-drm and `renderD129` is the Raphael iGPU. A
+    /// hardcoded 128 would make a run intended to validate Mesa silently
+    /// exercise nvidia-drm and report green.
+    ///
+    /// Honour `YSERVER_TEST_RENDER_NODE` so a Mesa run can be directed at the
+    /// amdgpu node, and enumerate otherwise rather than guessing.
+    pub(crate) fn render_node() -> Option<Arc<crate::drm::Device>> {
+        if let Ok(path) = std::env::var("YSERVER_TEST_RENDER_NODE") {
+            return crate::drm::Device::open_render_node(&path).ok().map(Arc::new);
+        }
+        let mut paths: Vec<_> = std::fs::read_dir("/dev/dri")
+            .ok()?
+            .filter_map(Result::ok)
+            .map(|e| e.path())
+            .filter(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.starts_with("renderD"))
+            })
+            .collect();
+        paths.sort();
+        paths
+            .iter()
+            .find_map(|p| crate::drm::Device::open_render_node(p.to_str()?).ok())
             .map(Arc::new)
     }
 
@@ -324,14 +353,51 @@ impl yserver_core::backend::SyncobjHandle for ImportedSyncobj {
 - [ ] **Step 6: Run the tests to verify they pass**
 
 Run: `cargo test -p yserver --lib imported_syncobj -- --ignored`
-Expected: 3 passed. If they skip instead, `/dev/dri/renderD128` is missing —
-find the right node with `ls /dev/dri/` and adjust `render_node()`.
+Expected: 3 passed. If they skip instead, no `/dev/dri/renderD*` could be
+opened — check `ls -l /dev/dri/` and the `render` group membership.
+
+On a multi-GPU box, run it once per driver and say which is which, because
+the enumeration picks the lexicographically first node that opens and that
+choice is not stable across machines:
+
+```bash
+YSERVER_TEST_RENDER_NODE=/dev/dri/renderD128 cargo test -p yserver --lib imported_syncobj -- --ignored  # nvidia-drm
+YSERVER_TEST_RENDER_NODE=/dev/dri/renderD129 cargo test -p yserver --lib imported_syncobj -- --ignored  # amdgpu
+```
+
+Both passing is the cross-driver evidence for the ioctl layer specifically;
+it is **not** a substitute for the Mesa client run in the spec's Testing §4,
+which is what exercises the release path against a real waiter.
 
 - [ ] **Step 7: Format, lint, commit**
 
+**This task cannot pass `-D warnings` on its own without help.** Task 1 lands
+`ImportedSyncobj` with no non-test caller — Task 2 is what wires it into the
+registry. `cargo clippy --all-targets` builds the lib target *without*
+`cfg(test)`, where the type and its methods are constructed nowhere, so
+`dead_code` fires and `-D warnings` turns it into a failure. The test module
+does not rescue it: the tests satisfy the test target, not the lib target.
+
+Two ways out; take the first.
+
+1. **Merge the gate into Task 2** — run `-D warnings` only at the end of
+   Task 2 and commit Task 1 behind `cargo clippy --all-targets` without
+   `-D warnings`, reading the output by eye. Honest about the intermediate
+   state and adds nothing to remove later.
+2. If Task 1 must stand alone as a green commit, put
+   `#![cfg_attr(test, allow(dead_code))]`-style scoping on the module —
+   specifically `#[allow(dead_code)]` on `ImportedSyncobj` and its impl block,
+   **with a `TODO(task-2)` comment** — and delete the attribute in Task 2. A
+   lingering blanket `allow(dead_code)` in this module would later hide a
+   genuinely unused method, so its removal is part of Task 2's checklist, not
+   optional cleanup.
+
+Whichever is chosen, Task 2's Step 7 must run the full
+`cargo clippy --all-targets -- -D warnings` with no allowances left behind.
+
 ```bash
 cargo +nightly fmt
-cargo clippy --all-targets -- -D warnings
+cargo clippy --all-targets   # see the note above re: -D warnings
 git add crates/yserver/src/drm/device.rs crates/yserver/src/kms/render/imported_syncobj.rs crates/yserver/src/kms/render/mod.rs
 git commit -m "feat(dri3): add ImportedSyncobj, a DRM-backed syncobj resource
 
@@ -389,11 +455,12 @@ like Task 1's:
 #[test]
 #[ignore = "needs a DRM render node"]
 fn each_resolver_sees_only_its_own_registry() {
-    let Ok(drm) = crate::drm::Device::open_render_node("/dev/dri/renderD128") else {
+    // Shared helper from Task 1 — never hardcode renderD128, see its doc
+    // comment for why (multi-GPU hosts pick the wrong device silently).
+    let Some(drm) = crate::kms::render::imported_syncobj::tests::render_node() else {
         eprintln!("skipping: no render node");
         return;
     };
-    let drm = std::sync::Arc::new(drm);
     let handle = ::drm::control::Device::create_syncobj(drm.as_ref(), false)
         .expect("create syncobj");
     let fd = ::drm::control::Device::syncobj_to_fd(drm.as_ref(), handle, false)
@@ -621,11 +688,11 @@ match its name. Rewrite it against the new registry:
     #[test]
     #[ignore = "needs a DRM render node"]
     fn syncobj_handle_accessor_returns_arc_clone() {
-        let Ok(drm) = crate::drm::Device::open_render_node("/dev/dri/renderD128") else {
+        // Shared helper from Task 1 — never hardcode renderD128.
+        let Some(drm) = crate::kms::render::imported_syncobj::tests::render_node() else {
             eprintln!("skipping: no render node");
             return;
         };
-        let drm = std::sync::Arc::new(drm);
         let handle = ::drm::control::Device::create_syncobj(drm.as_ref(), false)
             .expect("create syncobj");
         let fd = ::drm::control::Device::syncobj_to_fd(drm.as_ref(), handle, false)

--- a/docs/superpowers/plans/2026-08-08-dri3-syncobj-drm-signal.md
+++ b/docs/superpowers/plans/2026-08-08-dri3-syncobj-drm-signal.md
@@ -18,95 +18,146 @@ Vulkan body and serves only the XSync fence half, which genuinely needs it.
 
 **Spec:** `docs/superpowers/specs/2026-08-08-dri3-syncobj-drm-signal-design.md`
 
+**Revision:** rewritten 2026-08-08 after two adversarial review rounds returned
+9 blocking findings against the first draft. The task boundaries changed — what
+were Tasks 2 and 3 are now one task, because splitting them left the tree
+functionally broken on Mesa at a commit boundary.
+
 ## Global Constraints
 
-- Branch: `dri3-syncobj-drm-signal` (already created off `master`; the spec is
-  committed there as `a7d4ce8f`).
+- Branch: `dri3-syncobj-drm-signal` (already created off `master`).
+- **Every `file:line` in this plan was verified against THIS branch.** The
+  first draft cited `docs/status.md` lines read while checked out on
+  `glx-extension-string-terminator`, where that file is longer, and all three
+  citations were wrong. If you check out another branch mid-task, re-verify
+  before trusting a number.
 - Format with `cargo +nightly fmt` before every commit.
 - Lint exactly as CI does: `cargo clippy --all-targets -- -D warnings`. CI
-  fails on any warning and `--all-targets` lints test code too.
+  fails on any warning and `--all-targets` lints test code too. Several steps
+  below exist solely because a symbol goes dead and would trip this.
 - No new ioctl plumbing is introduced — every ioctl used here already exists in
-  the `drm` crate, so the AGENTS.md `libc::Ioctl` portability rule
-  (glibc/musl/FreeBSD) is not triggered. If you find yourself writing a raw
-  `ioctl` call, stop: you have left the plan.
-- `docs/status.md` must be updated (Task 6). AGENTS.md requires it current, and
-  it covers more than render work.
+  the `drm` crate, so the AGENTS.md `libc::Ioctl` portability rule is not
+  triggered. If you find yourself writing a raw `ioctl` call, stop.
+- `docs/status.md` must be updated (Task 5). AGENTS.md requires it current.
 - Do not fix the freed-syncobj bookkeeping bug this change makes reachable
-  (`docs/status.md:567`). It is out of scope and tracked separately.
+  (`docs/status.md:548`), and do not fix the fail-open arm in
+  `PendingPresentSourceWait::is_ready`. Both are recorded in the spec's Risks
+  section as out of scope.
 
 ---
 
 ### Task 1: `ImportedSyncobj` — the DRM-backed syncobj resource
 
 **Files:**
+- Modify: `crates/yserver/src/drm/device.rs` (add `open_render_node`)
 - Create: `crates/yserver/src/kms/render/imported_syncobj.rs`
-- Modify: `crates/yserver/src/kms/render/mod.rs:18` (add the module)
+- Modify: `crates/yserver/src/kms/render/mod.rs` (add the module at line 18,
+  keeping alphabetical order — it sorts between `glyph_pixels` and
+  `owned_semaphore`)
 
 **Interfaces:**
-- Consumes: `crate::drm::Device` (already `Arc`-held as
-  `platform.device: Arc<drm::Device>`).
-- Produces: `ImportedSyncobj::import(Arc<crate::drm::Device>, BorrowedFd) ->
-  io::Result<Self>`, `.timeline_value() -> io::Result<u64>`,
-  `.signaled_eventfd(u64) -> io::Result<OwnedFd>`, and an
-  impl of `yserver_core::backend::SyncobjHandle` whose `signal(u64)` uses
-  `syncobj_timeline_signal`. Tasks 2 and 3 depend on these exact names.
+- Consumes: `crate::drm::Device`.
+- Produces: `Device::open_render_node(&str) -> io::Result<Device>`;
+  `ImportedSyncobj::import(Arc<crate::drm::Device>, BorrowedFd) -> io::Result<Self>`,
+  `.timeline_value() -> io::Result<u64>`, `.signaled_eventfd(u64) ->
+  io::Result<OwnedFd>`, and an impl of `yserver_core::backend::SyncobjHandle`
+  whose `signal(u64)` uses `syncobj_timeline_signal`. Tasks 2 and 4 depend on
+  these exact names.
 
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 1: Add a master-free constructor**
 
-Create `crates/yserver/src/kms/render/imported_syncobj.rs` containing only the
-test module for now:
+`Device::open` (`crates/yserver/src/drm/device.rs:41`) calls
+`acquire_master_lock()` and propagates with `?`. `DRM_IOCTL_SET_MASTER` returns
+`EACCES` on a render node — `drm_ioctl_permit` rejects any non-`DRM_RENDER_ALLOW`
+ioctl from a render client — and also on `card0` under a live session. There is
+no way to build a `crate::drm::Device` over a render node today, so the tests
+below cannot exist without this.
+
+Add to `impl Device`, after `for_tests()` (`:39`):
+
+```rust
+    /// Open a render node without taking DRM master.
+    ///
+    /// `open` is the KMS-master constructor: it calls `acquire_master_lock`
+    /// and `enable_atomic_capabilities`, both of which a render node rejects
+    /// (`DRM_IOCTL_SET_MASTER` → `EACCES` from a render client). Render nodes
+    /// still serve the `DRM_RENDER_ALLOW` ioctls, which is everything the
+    /// syncobj paths need.
+    pub fn open_render_node(path: &str) -> io::Result<Self> {
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)
+            .map_err(|err| open_error(path, &err))?;
+        Ok(Self {
+            file,
+            path: path.to_string(),
+        })
+    }
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `crates/yserver/src/kms/render/imported_syncobj.rs` with only the test
+module for now:
 
 ```rust
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{os::fd::AsFd, sync::Arc};
 
     use ::drm::control::Device as DrmControlDevice;
 
     use super::*;
 
-    /// Full round trip against a real DRM node, mirroring the server's
-    /// sequence: the client exports a syncobj fd, the server imports it,
-    /// signals a release point, and the client's own handle observes it.
-    /// Ignored because it needs a DRM device — run with
-    /// `cargo test -p yserver --lib imported_syncobj -- --ignored`.
+    /// Open the render node, or skip. Every test here needs real DRM ioctls;
+    /// they are `#[ignore]` so CI never runs them, but a machine without the
+    /// node should skip rather than fail.
+    fn render_node() -> Option<Arc<crate::drm::Device>> {
+        crate::drm::Device::open_render_node("/dev/dri/renderD128")
+            .ok()
+            .map(Arc::new)
+    }
+
+    /// Full round trip mirroring the server's sequence: the client exports a
+    /// syncobj fd, the server imports it, signals a release point, and the
+    /// client's own handle observes it through its own separate handle.
+    /// Run with `cargo test -p yserver --lib imported_syncobj -- --ignored`.
     #[test]
     #[ignore = "needs a DRM render node"]
     fn signal_reaches_the_clients_handle() {
-        let drm = Arc::new(
-            crate::drm::Device::open("/dev/dri/renderD128").expect("open render node"),
-        );
+        let Some(drm) = render_node() else {
+            eprintln!("skipping: no render node");
+            return;
+        };
 
-        // The client's half.
         let client_handle = drm.create_syncobj(false).expect("create syncobj");
         let fd = drm.syncobj_to_fd(client_handle, false).expect("export fd");
 
-        // The server's half, as dri3_import_syncobj will do it.
         let imported = ImportedSyncobj::import(drm.clone(), fd.as_fd()).expect("import");
-
         assert_eq!(imported.timeline_value().expect("query"), 0);
 
         yserver_core::backend::SyncobjHandle::signal(&imported, 7).expect("signal");
 
-        // The client must observe the release through its own handle, or it
+        // The client must observe the release through ITS handle, not the
+        // server's, or the two are not aliasing one payload and the client
         // would wait forever.
         let mut points = [0u64; 1];
         drm.syncobj_timeline_query(&[client_handle], &mut points, false)
             .expect("client query");
         assert_eq!(points[0], 7, "server signal did not reach the client handle");
-        assert_eq!(imported.timeline_value().expect("query"), 7);
 
         drm.destroy_syncobj(client_handle).expect("destroy");
     }
 
+    /// The acquire path's kernel notification.
     #[test]
     #[ignore = "needs a DRM render node"]
     fn eventfd_fires_on_the_registered_point() {
-        use std::os::fd::AsFd;
-
-        let drm = Arc::new(
-            crate::drm::Device::open("/dev/dri/renderD128").expect("open render node"),
-        );
+        let Some(drm) = render_node() else {
+            eprintln!("skipping: no render node");
+            return;
+        };
         let client_handle = drm.create_syncobj(false).expect("create syncobj");
         let fd = drm.syncobj_to_fd(client_handle, false).expect("export fd");
         let imported = ImportedSyncobj::import(drm.clone(), fd.as_fd()).expect("import");
@@ -127,25 +178,53 @@ mod tests {
 
         drm.destroy_syncobj(client_handle).expect("destroy");
     }
+
+    /// Documents measured kernel behaviour the spec depends on: a stale or
+    /// duplicate timeline point is CLAMPED and returns success, it is not
+    /// rejected. Release replay after teardown therefore cannot be detected
+    /// by checking the signal's return value.
+    #[test]
+    #[ignore = "needs a DRM render node"]
+    fn a_stale_point_is_clamped_not_rejected() {
+        use yserver_core::backend::SyncobjHandle as _;
+
+        let Some(drm) = render_node() else {
+            eprintln!("skipping: no render node");
+            return;
+        };
+        let client_handle = drm.create_syncobj(false).expect("create syncobj");
+        let fd = drm.syncobj_to_fd(client_handle, false).expect("export fd");
+        let imported = ImportedSyncobj::import(drm.clone(), fd.as_fd()).expect("import");
+
+        imported.signal(10).expect("signal 10");
+        imported.signal(5).expect("a stale point must still return Ok");
+        assert_eq!(
+            imported.timeline_value().expect("query"),
+            10,
+            "the kernel must clamp to the max, not regress the timeline",
+        );
+
+        drm.destroy_syncobj(client_handle).expect("destroy");
+    }
 }
 ```
 
-- [ ] **Step 2: Run the test to verify it fails**
+- [ ] **Step 3: Run the tests to verify they fail**
 
 Run: `cargo test -p yserver --lib imported_syncobj -- --ignored`
-Expected: compile error — `ImportedSyncobj` is not defined, and the module is
-not registered in `mod.rs`.
+Expected: compile error — `ImportedSyncobj` is not defined and the module is
+not registered.
 
-- [ ] **Step 3: Register the module**
+- [ ] **Step 4: Register the module**
 
-In `crates/yserver/src/kms/render/mod.rs`, add in alphabetical position (after
-line 16, `glyph_pixels`):
+In `crates/yserver/src/kms/render/mod.rs`, insert at line 18 (before
+`pub(crate) mod owned_semaphore;`):
 
 ```rust
 pub(crate) mod imported_syncobj;
 ```
 
-- [ ] **Step 4: Write the implementation**
+- [ ] **Step 5: Write the implementation**
 
 Prepend to `crates/yserver/src/kms/render/imported_syncobj.rs`:
 
@@ -158,8 +237,7 @@ Prepend to `crates/yserver/src/kms/render/imported_syncobj.rs`:
 //! ioctl. Importing it into a `VkSemaphore` instead only works where the
 //! driver's `OPAQUE_FD` payload happens to be a DRM syncobj, which is true on
 //! Mesa and false on NVIDIA proprietary
-//! (`vkImportSemaphoreFdKHR` → `VK_ERROR_INITIALIZATION_FAILED`, measured
-//! 2026-08-08). See
+//! (`vkImportSemaphoreFdKHR` → `VK_ERROR_INITIALIZATION_FAILED`). See
 //! docs/superpowers/specs/2026-08-08-dri3-syncobj-drm-signal-design.md.
 //!
 //! The sibling `OwnedSemaphore` keeps the Vulkan path for XSync `Fence`
@@ -179,9 +257,9 @@ pub(crate) struct ImportedSyncobj {
 }
 
 impl ImportedSyncobj {
-    /// Import a client's `DRM_SYNCOBJ` fd as a process-local handle. The fd
-    /// is only borrowed — `DRM_IOCTL_SYNCOBJ_FD_TO_HANDLE` does not consume
-    /// it — so the caller keeps ownership and drops it normally.
+    /// Import a client's `DRM_SYNCOBJ` fd as a process-local handle. The fd is
+    /// only borrowed — `DRM_IOCTL_SYNCOBJ_FD_TO_HANDLE` does not consume it —
+    /// so the caller keeps ownership and drops it normally.
     pub(crate) fn import(
         drm: Arc<crate::drm::Device>,
         fd: BorrowedFd<'_>,
@@ -232,116 +310,160 @@ impl Drop for ImportedSyncobj {
 
 impl yserver_core::backend::SyncobjHandle for ImportedSyncobj {
     /// Host-signal a timeline point. Replaces `vkSignalSemaphore`, which was
-    /// also a host operation — the ordering guarantee is unchanged.
+    /// also a host operation.
+    ///
+    /// Note the kernel CLAMPS: signalling a point at or below the current
+    /// value succeeds silently and leaves the timeline where it was. Callers
+    /// cannot use the return value to detect an out-of-order release.
     fn signal(&self, value: u64) -> std::io::Result<()> {
         self.drm.syncobj_timeline_signal(&[self.handle], &[value])
     }
 }
 ```
 
-- [ ] **Step 5: Run the tests to verify they pass**
+- [ ] **Step 6: Run the tests to verify they pass**
 
 Run: `cargo test -p yserver --lib imported_syncobj -- --ignored`
-Expected: 2 passed. If `crate::drm::Device::open` has a different signature,
-check `crates/yserver/src/drm/device.rs` and adapt the test's construction
-only — not the production code.
+Expected: 3 passed. If they skip instead, `/dev/dri/renderD128` is missing —
+find the right node with `ls /dev/dri/` and adjust `render_node()`.
 
-- [ ] **Step 6: Format, lint, commit**
+- [ ] **Step 7: Format, lint, commit**
 
 ```bash
 cargo +nightly fmt
 cargo clippy --all-targets -- -D warnings
-git add crates/yserver/src/kms/render/imported_syncobj.rs crates/yserver/src/kms/render/mod.rs
+git add crates/yserver/src/drm/device.rs crates/yserver/src/kms/render/imported_syncobj.rs crates/yserver/src/kms/render/mod.rs
 git commit -m "feat(dri3): add ImportedSyncobj, a DRM-backed syncobj resource
 
-A DRI3 syncobj is a kernel object and every operation the server needs
-on one -- signal, query, eventfd -- has a DRM ioctl. Importing it into a
-VkSemaphore only works where the driver's OPAQUE_FD payload happens to
-be a DRM syncobj, which is false on NVIDIA proprietary.
+A DRI3 syncobj is a kernel object and every operation the server needs on
+one -- signal, query, eventfd -- has a DRM ioctl. Importing it into a
+VkSemaphore only works where the driver's OPAQUE_FD payload happens to be
+a DRM syncobj, which is false on NVIDIA proprietary.
+
+Device::open_render_node comes along because Device::open takes DRM
+master, which a render node refuses, so there was no way to reach these
+ioctls from a test.
 
 Not wired up yet; the registries still hold OwnedSemaphore."
 ```
 
 ---
 
-### Task 2: Split the syncobj registry from the fence registry
+### Task 2: Move syncobjs onto the DRM resource, registry and acquire path together
 
 **Files:**
-- Modify: `crates/yserver/src/kms/render/backend.rs:805` (field),
-  `:2334` and `:3222` (both initialisers), `:19291-19299`
-  (`dri3_syncobj_handle`), `:19313-19375` (`dri3_import_syncobj`),
-  `:19376-19382` (`dri3_free_syncobj`), `:19384-19392`
-  (`dri3_signal_syncobj`)
-- Test: inline `#[cfg(test)] mod tests` in `backend.rs`
+- Modify: `crates/yserver/src/kms/render/backend.rs` — field at `:805`, both
+  initialisers at `:2334` and `:3222`, acquire lookup at `:13166`,
+  `dri3_syncobj_handle` `:19291`, `dri3_fd_from_fence` `:19301`,
+  `dri3_import_syncobj` `:19313`, `dri3_free_syncobj` `:19377`,
+  `dri3_signal_syncobj` `:19384`, and the test at `:30010`
+- Modify: `crates/yserver/src/kms/render/present_source_wait.rs:20-25,40-52`
 
 **Interfaces:**
-- Consumes: `ImportedSyncobj::import`, `SyncobjHandle` impl from Task 1.
-- Produces: field `dri3_syncobjs: HashMap<u32, Arc<ImportedSyncobj>>`.
-  `dri3_sync_resources` survives, now holding fences only. Task 3 reads
-  `dri3_syncobjs`.
+- Consumes: everything Task 1 produced.
+- Produces: field `dri3_syncobjs: HashMap<u32, Arc<ImportedSyncobj>>`;
+  `PendingPresentSourceWait::syncobj_pin` retyped to
+  `Option<Arc<ImportedSyncobj>>`. `dri3_sync_resources` survives, fences only.
+
+**Why this is one task and not two.** The registry split and the acquire-path
+rewrite cannot be separate commits. `arm_present_syncobj_wait`
+(`backend.rs:13166`) looks up `dri3_sync_resources` for the acquire syncobj; the
+moment `ImportSyncobj` writes elsewhere, that lookup's `ok_or_else` fires and
+the error propagates out of the request handler via `?`
+(`process_request.rs:10251`). It still compiles and `cargo test --lib` still
+passes, so nothing catches it — but on Mesa, where the capability is still
+advertised until Task 4, every synced present with an acquire syncobj breaks at
+that commit.
 
 - [ ] **Step 1: Write the failing test**
 
-Add to the `#[cfg(test)] mod tests` block in `backend.rs`, next to the existing
-`dri3_import_syncobj_no_vk_errs` test (around `:28065`):
+Add to the `#[cfg(test)] mod tests` block in `backend.rs`, near the other DRI3
+tests (around `:28065`). This one needs a real DRM handle, so it is `#[ignore]`
+like Task 1's:
 
 ```rust
-/// Fences and syncobjs are different X resource types and must not share
-/// one registry: before the split, FDFromFence on a syncobj xid resolved
-/// into the same map and half-worked.
+/// Fences and syncobjs are different X resource types with different
+/// backing primitives. Each resolver must see only its own registry: before
+/// the split they shared one map, so FDFromFence on a syncobj xid resolved
+/// and half-worked.
 #[test]
-fn fd_from_fence_does_not_resolve_a_syncobj_xid() {
+#[ignore = "needs a DRM render node"]
+fn each_resolver_sees_only_its_own_registry() {
+    let Ok(drm) = crate::drm::Device::open_render_node("/dev/dri/renderD128") else {
+        eprintln!("skipping: no render node");
+        return;
+    };
+    let drm = std::sync::Arc::new(drm);
+    let handle = ::drm::control::Device::create_syncobj(drm.as_ref(), false)
+        .expect("create syncobj");
+    let fd = ::drm::control::Device::syncobj_to_fd(drm.as_ref(), handle, false)
+        .expect("export fd");
+
     let mut b = KmsBackend::for_tests();
-    // No Vulkan in for_tests(), so a resolved entry and an unresolved one
-    // both Err. Distinguish them by message: an unknown xid must be
-    // reported as unknown, not as a Vulkan failure.
+    let xid = 0xAAAA_BBBB_u32;
+    b.dri3_syncobjs.insert(
+        xid,
+        std::sync::Arc::new(
+            crate::kms::render::imported_syncobj::ImportedSyncobj::import(
+                drm.clone(),
+                std::os::fd::AsFd::as_fd(&fd),
+            )
+            .expect("import"),
+        ),
+    );
+
+    // The syncobj resolver finds it.
+    assert!(
+        b.dri3_syncobj_handle(xid).is_some(),
+        "syncobj registry must resolve a syncobj xid",
+    );
+    // The fence resolver must NOT, and must say so as an unknown fence
+    // rather than tripping over some other gate first.
     let err = b
-        .dri3_fd_from_fence(0x4040_5555)
-        .expect_err("unknown fence xid must Err");
+        .dri3_fd_from_fence(xid)
+        .expect_err("FDFromFence must not resolve a syncobj xid");
     assert!(
         err.to_string().contains("unknown fence"),
         "expected an unknown-fence error, got: {err}",
     );
+
+    ::drm::control::Device::destroy_syncobj(drm.as_ref(), handle).expect("destroy");
 }
 ```
 
 - [ ] **Step 2: Run the test to verify it fails**
 
-Run: `cargo test -p yserver --lib fd_from_fence_does_not_resolve -- --nocapture`
-Expected: FAIL — `dri3_fd_from_fence` checks Vulkan availability before the
-registry lookup, so the message is "DRI3 FDFromFence: Vulkan unavailable".
+Run: `cargo test -p yserver --lib each_resolver_sees_only -- --ignored`
+Expected: compile error — `dri3_syncobjs` does not exist.
 
 - [ ] **Step 3: Add the new field**
 
-In `backend.rs`, immediately after the `dri3_sync_resources` field (`:805`),
-add:
-
-```rust
-    /// DRI3 1.4 syncobj resources keyed by the client's xid, imported by
-    /// `ImportSyncobj`. Separate from `dri3_sync_resources` because these
-    /// are a different X resource type with a different backing primitive:
-    /// a DRM syncobj handle, not a `VkSemaphore`.
-    pub(crate) dri3_syncobjs:
-        HashMap<u32, std::sync::Arc<crate::kms::render::imported_syncobj::ImportedSyncobj>>,
-```
-
-Narrow the doc comment on `dri3_sync_resources` (`:800-804`) to fences only:
+In `backend.rs`, narrow the existing doc comment on `dri3_sync_resources`
+(`:800-804`) to fences only and add the new field after it:
 
 ```rust
     /// DRI3 sync-fence resources keyed by the client's xid, from
     /// `FenceFromFD` falling through the xshmfence path (sync_file fd →
     /// `VkSemaphore`). Syncobjs live in `dri3_syncobjs`.
+    pub(crate) dri3_sync_resources:
+        HashMap<u32, std::sync::Arc<crate::kms::render::owned_semaphore::OwnedSemaphore>>,
+    /// DRI3 1.4 syncobj resources keyed by the client's xid, imported by
+    /// `ImportSyncobj`. Separate from `dri3_sync_resources` because these are
+    /// a different X resource type with a different backing primitive: a DRM
+    /// syncobj handle, not a `VkSemaphore`.
+    pub(crate) dri3_syncobjs:
+        HashMap<u32, std::sync::Arc<crate::kms::render::imported_syncobj::ImportedSyncobj>>,
 ```
 
 Add `dri3_syncobjs: HashMap::new(),` next to `dri3_sync_resources:
 HashMap::new(),` in **both** initialisers (`:2334` and `:3222`). Missing the
-second one is a compile error, not a silent bug.
+second is a compile error, not a silent bug.
 
 - [ ] **Step 4: Rewire the four syncobj methods**
 
-Replace `dri3_import_syncobj` (`:19313-19375`) entirely — the `dup`, the
-Vulkan gate, the import, and the rollback all go away, because
-`fd_to_syncobj` borrows the fd and there is nothing to roll back:
+Replace `dri3_import_syncobj` (`:19313-19375`). The `dup`, the Vulkan gate, the
+import and the rollback all go away — `fd_to_syncobj` borrows the fd and there
+is nothing left to roll back:
 
 ```rust
     fn dri3_import_syncobj(
@@ -363,13 +485,13 @@ Vulkan gate, the import, and the rollback all go away, because
     }
 ```
 
-Replace `dri3_free_syncobj` (`:19376-19382`):
+Replace `dri3_free_syncobj` (`:19377-19383`):
 
 ```rust
     fn dri3_free_syncobj(&mut self, syncobj_xid: u32) -> io::Result<()> {
-        // Arc Drop destroys the DRM handle when the last reference goes
-        // away, which may be later than this call: the deferred completion
-        // path pins clones past FreeSyncobj.
+        // Arc Drop destroys the DRM handle when the last reference goes away,
+        // which may be later than this call: the deferred completion path
+        // pins clones past FreeSyncobj.
         let _ = self.dri3_syncobjs.remove(&syncobj_xid);
         Ok(())
     }
@@ -406,8 +528,8 @@ Replace `dri3_syncobj_handle` (`:19291-19299`):
 
 - [ ] **Step 5: Move the registry lookup ahead of the Vulkan gate**
 
-In `dri3_fd_from_fence` (`:19301-19311`), the lookup must come first so an
-unknown xid reports as unknown. Replace its body:
+In `dri3_fd_from_fence` (`:19301-19311`) the lookup must come first, so an
+unknown xid reports as unknown instead of as a Vulkan failure:
 
 ```rust
     fn dri3_fd_from_fence(&mut self, fence_xid: u32) -> io::Result<std::os::fd::OwnedFd> {
@@ -426,107 +548,9 @@ unknown xid reports as unknown. Replace its body:
     }
 ```
 
-- [ ] **Step 6: Fix the pre-existing test that asserted the old shape**
+- [ ] **Step 6: Repoint the acquire path (this is what keeps the tree working)**
 
-`dri3_import_syncobj_no_vk_errs` (`:28065`) asserts the import Errs without
-Vulkan. That is no longer true — the import no longer touches Vulkan. Replace
-the test with one that asserts what now holds:
-
-```rust
-/// ImportSyncobj no longer needs Vulkan. Without a DRM device in
-/// for_tests() it still Errs, but on the DRM ioctl rather than a Vk gate.
-#[test]
-fn dri3_import_syncobj_errs_without_a_usable_drm_handle() {
-    use std::os::fd::{FromRawFd, IntoRawFd, OwnedFd};
-    let f = std::fs::OpenOptions::new()
-        .read(true)
-        .open("/dev/null")
-        .expect("open /dev/null");
-    // SAFETY: we own this fd via the OpenOptions handle and re-wrap it
-    // directly; the OwnedFd's Drop closes it.
-    let fd = unsafe { OwnedFd::from_raw_fd(f.into_raw_fd()) };
-    let mut b = KmsBackend::for_tests();
-    assert!(
-        b.dri3_import_syncobj(0x4040_3333, fd).is_err(),
-        "importing a non-syncobj fd must Err",
-    );
-}
-```
-
-- [ ] **Step 7: Run the tests to verify they pass**
-
-Run: `cargo test -p yserver --lib dri3_ -- --nocapture`
-Expected: PASS, including `fd_from_fence_does_not_resolve_a_syncobj_xid` and
-`dri3_import_syncobj_errs_without_a_usable_drm_handle`.
-
-- [ ] **Step 8: Format, lint, commit**
-
-```bash
-cargo +nightly fmt
-cargo clippy --all-targets -- -D warnings
-git add crates/yserver/src/kms/render/backend.rs
-git commit -m "refactor(dri3): hold syncobjs in their own registry, backed by DRM
-
-FenceFromFD and ImportSyncobj registered two different X resource types
-into one HashMap of OwnedSemaphore. Only the fence half needs Vulkan
-(FDFromFence exports a sync_file from the VkSemaphore); the syncobj half
-needs a DRM handle. Split them so the type mismatch is unrepresentable,
-and move ImportSyncobj/FreeSyncobj/SignalSyncobj onto ImportedSyncobj.
-
-FDFromFence now looks up the registry before the Vulkan gate, so an
-unknown xid reports as unknown rather than as a Vulkan failure."
-```
-
----
-
-### Task 3: Move the deferred acquire path off Vulkan
-
-**Files:**
-- Modify: `crates/yserver/src/kms/render/present_source_wait.rs:22-25,41-49`
-- Modify: `crates/yserver/src/kms/render/backend.rs:13161-13185` (the
-  `dri3_sync_resources` lookup in the acquire path)
-
-**Interfaces:**
-- Consumes: `ImportedSyncobj::timeline_value`, `.signaled_eventfd` (Task 1);
-  `dri3_syncobjs` (Task 2).
-- Produces: `PendingPresentSourceWait::syncobj_pin` retyped to
-  `Option<Arc<ImportedSyncobj>>`. No later task depends on this.
-
-- [ ] **Step 1: Retype the pin and its readiness check**
-
-In `present_source_wait.rs`, replace lines 20-25:
-
-```rust
-    /// Keeps an explicitly imported acquire syncobj alive until its timeline
-    /// point signals. Implicit dma-buf waits leave this empty.
-    pub(crate) syncobj_pin: Option<Arc<super::imported_syncobj::ImportedSyncobj>>,
-    /// Used only when DRM_SYNCOBJ_EVENTFD is unavailable and readiness must
-    /// be checked by polling the syncobj's timeline value.
-    pub(crate) timeline_value: Option<u64>,
-```
-
-Replace the `is_ready` timeline arm (lines 40-50):
-
-```rust
-        let timeline_ready = match (&self.syncobj_pin, self.timeline_value) {
-            (Some(syncobj), Some(target)) => match syncobj.timeline_value() {
-                Ok(current) => current >= target,
-                Err(e) => {
-                    log::warn!(
-                        "deferred Present acquire: syncobj timeline query failed: {e}; \
-                         treating as ready"
-                    );
-                    true
-                }
-            },
-            _ => true,
-        };
-```
-
-- [ ] **Step 2: Point the acquire path at the new registry**
-
-In `backend.rs`, in the block starting at `:13161`, change the lookup and the
-fallback log line:
+In `arm_present_syncobj_wait`, the block starting at `:13162`:
 
 ```rust
             let syncobj = self
@@ -550,51 +574,180 @@ fallback log line:
             };
 ```
 
-- [ ] **Step 3: Run the existing tests to verify nothing broke**
+- [ ] **Step 7: Retype the pin and its readiness check**
 
-Run: `cargo test -p yserver --lib present_source_wait`
-Expected: PASS. The two existing tests construct `syncobj_pin: None`, so they
-compile unchanged — that is the signal that the retype is contained.
+In `present_source_wait.rs`, replace lines 20-25:
 
-- [ ] **Step 4: Format, lint, commit**
+```rust
+    /// Keeps an explicitly imported acquire syncobj alive until its timeline
+    /// point signals. Implicit dma-buf waits leave this empty.
+    pub(crate) syncobj_pin: Option<Arc<super::imported_syncobj::ImportedSyncobj>>,
+    /// Target acquire point. Set whenever an acquire syncobj is present —
+    /// note `is_ready` checks it on every poll, not only when
+    /// `DRM_SYNCOBJ_EVENTFD` was unavailable.
+    pub(crate) timeline_value: Option<u64>,
+```
+
+Replace the `is_ready` timeline arm (lines 40-52):
+
+```rust
+        let timeline_ready = match (&self.syncobj_pin, self.timeline_value) {
+            (Some(syncobj), Some(target)) => match syncobj.timeline_value() {
+                Ok(current) => current >= target,
+                Err(e) => {
+                    log::warn!(
+                        "deferred Present acquire: syncobj timeline query failed: {e}; \
+                         treating as ready"
+                    );
+                    true
+                }
+            },
+            _ => true,
+        };
+```
+
+Leave the fail-open `true` alone — the spec records it as a known hazard that
+this change makes live, and fixing it is explicitly out of scope.
+
+- [ ] **Step 8: Fix the two existing tests this task breaks**
+
+`syncobj_handle_accessor_returns_arc_clone` (`backend.rs:30010-30029`) inserts
+an `OwnedSemaphore` into `dri3_sync_resources` and asserts
+`dri3_syncobj_handle` finds it. After Step 4 it returns `None` and the test
+panics — and it still compiles, so `cargo test --lib dri3_` would not even
+match its name. Rewrite it against the new registry:
+
+```rust
+    #[test]
+    #[ignore = "needs a DRM render node"]
+    fn syncobj_handle_accessor_returns_arc_clone() {
+        let Ok(drm) = crate::drm::Device::open_render_node("/dev/dri/renderD128") else {
+            eprintln!("skipping: no render node");
+            return;
+        };
+        let drm = std::sync::Arc::new(drm);
+        let handle = ::drm::control::Device::create_syncobj(drm.as_ref(), false)
+            .expect("create syncobj");
+        let fd = ::drm::control::Device::syncobj_to_fd(drm.as_ref(), handle, false)
+            .expect("export fd");
+
+        let mut b = KmsBackend::for_tests();
+        let xid = 0xAAAA_BBBB_u32;
+        b.dri3_syncobjs.insert(
+            xid,
+            std::sync::Arc::new(
+                crate::kms::render::imported_syncobj::ImportedSyncobj::import(
+                    drm.clone(),
+                    std::os::fd::AsFd::as_fd(&fd),
+                )
+                .expect("import"),
+            ),
+        );
+
+        let h = b.dri3_syncobj_handle(xid).expect("handle present");
+        assert_eq!(std::sync::Arc::strong_count(&h), 2);
+        b.dri3_syncobjs.remove(&xid);
+        // Accessor returns None now; the held Arc still pins the resource
+        // alive, which is what the deferred completion path relies on.
+        assert!(b.dri3_syncobj_handle(xid).is_none());
+        drop(h);
+
+        ::drm::control::Device::destroy_syncobj(drm.as_ref(), handle).expect("destroy");
+    }
+```
+
+This test previously ran under `for_tests_with_vk` and now needs a DRM node
+instead, so it becomes `#[ignore]`. That is a real coverage loss on CI; it is
+unavoidable, because the resource it covers is now a kernel object.
+
+`dri3_import_syncobj_no_vk_errs` (`:28065`) asserts the import Errs without
+Vulkan, which is no longer why it errs. Replace it:
+
+```rust
+    /// ImportSyncobj no longer needs Vulkan. Without a real DRM device in
+    /// for_tests() it still Errs, but on the ioctl rather than a Vk gate.
+    #[test]
+    fn dri3_import_syncobj_errs_without_a_usable_drm_handle() {
+        use std::os::fd::{FromRawFd, IntoRawFd, OwnedFd};
+        let f = std::fs::OpenOptions::new()
+            .read(true)
+            .open("/dev/null")
+            .expect("open /dev/null");
+        // SAFETY: we own this fd via the OpenOptions handle and re-wrap it
+        // directly; the OwnedFd's Drop closes it.
+        let fd = unsafe { OwnedFd::from_raw_fd(f.into_raw_fd()) };
+        let mut b = KmsBackend::for_tests();
+        assert!(
+            b.dri3_import_syncobj(0x4040_3333, fd).is_err(),
+            "importing a non-syncobj fd must Err",
+        );
+    }
+```
+
+- [ ] **Step 9: Check whether `for_tests_dummy` still has callers**
+
+`OwnedSemaphore::for_tests_dummy` (`owned_semaphore.rs:80`) existed for the
+test just rewritten. Run:
+
+```bash
+grep -rn "for_tests_dummy" crates/
+```
+
+If nothing remains, delete it — `#[cfg(test)]` dead code still fails
+`clippy --all-targets -- -D warnings`.
+
+- [ ] **Step 10: Run the tests**
+
+```bash
+cargo test -p yserver --lib                                    # no regressions
+cargo test -p yserver --lib -- --ignored                       # the DRM ones
+```
+Expected: PASS on both.
+
+- [ ] **Step 11: Format, lint, commit**
 
 ```bash
 cargo +nightly fmt
 cargo clippy --all-targets -- -D warnings
-git add crates/yserver/src/kms/render/present_source_wait.rs crates/yserver/src/kms/render/backend.rs
-git commit -m "refactor(present): poll deferred acquires through the DRM timeline
+git add crates/yserver/src/kms/render/backend.rs crates/yserver/src/kms/render/present_source_wait.rs crates/yserver/src/kms/render/owned_semaphore.rs
+git commit -m "refactor(dri3): hold syncobjs in their own DRM-backed registry
 
-The acquire eventfd was already DRM; only its polling fallback still
-went through vkGetSemaphoreCounterValue. Move that to
-DRM_IOCTL_SYNCOBJ_QUERY so the whole acquire path is driver-neutral."
+FenceFromFD and ImportSyncobj registered two different X resource types
+into one HashMap of OwnedSemaphore. Only the fence half needs Vulkan
+(FDFromFence exports a sync_file from the VkSemaphore); the syncobj half
+needs a DRM handle. Split them so the type mismatch is unrepresentable.
+
+The acquire path moves in the same commit rather than a later one: it
+looks up the same map, so splitting the two would leave every synced
+present failing on Mesa at the intermediate commit.
+
+FDFromFence now looks up the registry before the Vulkan gate, so an
+unknown xid reports as unknown rather than as a Vulkan failure."
 ```
 
 ---
 
-### Task 4: Strip the syncobj half out of `OwnedSemaphore`
+### Task 3: Strip the syncobj half out of `OwnedSemaphore`
 
 **Files:**
-- Modify: `crates/yserver/src/kms/render/owned_semaphore.rs` (remove
-  `drm_syncobj`, `new_drm_syncobj`, `signaled_eventfd`, `timeline_value`, the
-  `SyncobjHandle` impl, and the DRM branch of `Drop`)
-- Modify: `crates/yserver/src/kms/vk/sync.rs:55-80` (delete
-  `import_drm_syncobj`)
+- Modify: `crates/yserver/src/kms/render/owned_semaphore.rs`
+- Modify: `crates/yserver/src/kms/vk/sync.rs` (delete `import_drm_syncobj` and
+  fix the intra-doc link at `:10`)
+- Modify: `crates/yserver/src/kms/vk/device.rs:242-244` (stale comment)
+- Modify: `crates/yserver-core/src/backend/trait_def.rs:345-353` (stale trait doc)
 
 **Interfaces:**
-- Consumes: nothing new.
-- Produces: `OwnedSemaphore` reduced to `{ vk, semaphore }` with `new`,
-  `semaphore`, `signal_vk`. No later task depends on the removed items.
+- Produces: `OwnedSemaphore` reduced to `{ vk, semaphore }` with `new` and
+  `semaphore`. No later task depends on the removed items.
 
 - [ ] **Step 1: Reduce `OwnedSemaphore`**
 
-Replace the whole of `owned_semaphore.rs` below the module doc comment. Update
-the doc comment first to say what it is now:
+Replace the whole file:
 
 ```rust
 //! RAII wrapper for a `vk::Semaphore` so it can be `Arc`-shared for the
-//! deferred PRESENT completion path. Destruction happens on the last Arc
-//! drop (via `vkDestroySemaphore`), independent of the X11 resource id's
-//! lifetime.
+//! deferred PRESENT completion path. Destruction happens on the last Arc drop
+//! (via `vkDestroySemaphore`), independent of the X11 resource id's lifetime.
 //!
 //! This backs XSync `Fence` resources only. DRI3 1.4 syncobjs are
 //! `ImportedSyncobj` — they are DRM objects and never enter Vulkan.
@@ -618,22 +771,6 @@ impl OwnedSemaphore {
     pub(crate) fn semaphore(&self) -> vk::Semaphore {
         self.semaphore
     }
-
-    /// Signal a timeline-semaphore value via `vkSignalSemaphore`.
-    pub(crate) fn signal_vk(&self, value: u64) -> Result<(), vk::Result> {
-        crate::kms::vk::sync::signal_timeline(&self.vk, self.semaphore, value)
-    }
-
-    /// Test-only constructor: holds a null semaphore handle. Drop is a no-op
-    /// (vkDestroySemaphore on null is allowed by the Vulkan spec but the
-    /// guard below skips it anyway).
-    #[cfg(test)]
-    pub(crate) fn for_tests_dummy(vk: Arc<VkContext>) -> Self {
-        Self {
-            vk,
-            semaphore: vk::Semaphore::null(),
-        }
-    }
 }
 
 impl std::fmt::Debug for OwnedSemaphore {
@@ -656,37 +793,66 @@ impl Drop for OwnedSemaphore {
 }
 ```
 
-- [ ] **Step 2: Delete the Vulkan syncobj import**
+`signal_vk` goes too. Its only callers were `dri3_signal_syncobj` (rewritten in
+Task 2) and `impl SyncobjHandle for OwnedSemaphore` (deleted here), so keeping
+it would be `dead_code` and fail `clippy --all-targets -- -D warnings`.
 
-In `crates/yserver/src/kms/vk/sync.rs`, delete `import_drm_syncobj` (lines
-55-80, doc comment included). Leave `import_sync_file`, `export_sync_file` and
-`signal_timeline` alone — all three still serve the fence path.
+- [ ] **Step 2: Decide the fate of `signal_timeline`**
 
-- [ ] **Step 3: Build and let the compiler find the stragglers**
+`crate::kms::vk::sync::signal_timeline` was `signal_vk`'s only callee. Run:
+
+```bash
+grep -rn "signal_timeline" crates/
+```
+
+It is `pub` inside `pub mod kms` / `pub mod vk` / `pub mod sync`, so it will not
+trip `dead_code` — but if nothing calls it, it is now an unreachable public
+helper. Delete it unless a caller remains.
+
+- [ ] **Step 3: Delete the Vulkan syncobj import and its references**
+
+- Delete `import_drm_syncobj` from `crates/yserver/src/kms/vk/sync.rs`
+  (`:55-80`, doc comment included). Leave `import_sync_file`,
+  `export_sync_file` alone — both still serve the fence path.
+- `crates/yserver/src/kms/vk/sync.rs:10` is a rustdoc intra-doc link
+  ``[`import_drm_syncobj`]`` in the module header. Deleting the function breaks
+  it (a rustdoc warning clippy will not catch). Rewrite that bullet to describe
+  `import_sync_file` instead.
+- `crates/yserver/src/kms/vk/device.rs:242-244` justifies `timeline_semaphore(true)`
+  by citing "Phase 4.2.2's `import_drm_syncobj`". Update the reason — the
+  feature is still needed by other timeline users; say which.
+- `crates/yserver-core/src/backend/trait_def.rs:345-353` documents
+  `SyncobjHandle` as "opaque handle to a DRI3 syncobj's underlying VkSemaphore.
+  Concrete impl in … `OwnedSemaphore`". Both halves are now false. Point it at
+  `ImportedSyncobj` and drop the VkSemaphore wording.
+
+- [ ] **Step 4: Build and let the compiler find stragglers**
 
 Run: `cargo build -p yserver 2>&1 | head -40`
-Expected: PASS. If anything still references `new_drm_syncobj`,
-`import_drm_syncobj`, or `OwnedSemaphore::timeline_value`, the compiler names
-it — fix those call sites to use `ImportedSyncobj` rather than reinstating
-what you just deleted. If a call site cannot be converted, stop and report:
-it means a consumer was missed in the design.
+Expected: PASS. If something still references a deleted symbol, fix the call
+site to use `ImportedSyncobj` rather than reinstating what you deleted. If a
+call site cannot be converted, stop and report — a consumer was missed.
 
-- [ ] **Step 4: Run the full test suite**
+- [ ] **Step 5: Run the tests**
 
-Run: `cargo test -p yserver --lib`
-Expected: PASS.
+```bash
+cargo test -p yserver --lib
+cargo clippy --all-targets -- -D warnings
+```
+Expected: PASS. Clippy matters as much as the tests here: this task's whole
+risk is symbols going dead.
 
-- [ ] **Step 5: Format, lint, commit**
+- [ ] **Step 6: Format and commit**
 
 ```bash
 cargo +nightly fmt
-cargo clippy --all-targets -- -D warnings
-git add crates/yserver/src/kms/render/owned_semaphore.rs crates/yserver/src/kms/vk/sync.rs
+git add crates/yserver/src/kms/render/owned_semaphore.rs crates/yserver/src/kms/vk/sync.rs crates/yserver/src/kms/vk/device.rs crates/yserver-core/src/backend/trait_def.rs
 git commit -m "refactor(dri3): drop the Vulkan syncobj import
 
-OwnedSemaphore carried a retained DRM handle, an eventfd registration and
-a timeline query that existed only for the syncobj half, now served by
-ImportedSyncobj. What remains is the XSync fence resource it always was.
+OwnedSemaphore carried a retained DRM handle, an eventfd registration, a
+timeline query and a host-signal that existed only for the syncobj half,
+now served by ImportedSyncobj. What remains is the XSync fence resource
+it always was.
 
 import_drm_syncobj goes with it: vkImportSemaphoreFdKHR on a DRM syncobj
 fd is a Mesa-only accident, not a portable interop path."
@@ -694,58 +860,86 @@ fd is a Mesa-only accident, not a portable interop path."
 
 ---
 
-### Task 5: Derive the capability from the kernel, not the driver
+### Task 4: Derive the capability from the kernel, not the driver
 
 **Files:**
 - Modify: `crates/yserver/src/kms/render/backend.rs:18967-18992`
-  (`dri3_capabilities`)
-- Modify: `crates/yserver/src/kms/vk/device.rs:87-89` (delete
-  `supports_dri3_syncobj`)
-- Test: inline `#[cfg(test)] mod tests` in `backend.rs`
-
-**Interfaces:**
-- Consumes: nothing from earlier tasks at the type level; depends on Tasks 1-4
-  being done, because this is the step that starts advertising 1.4.
-- Produces: free function `dri3_version_for(syncobj: bool) -> (u32, u32)`.
+  (`dri3_capabilities`) and the test at `:27891-27935`
+- Modify: `crates/yserver/src/kms/render/platform.rs` (cache field)
+- Modify: `crates/yserver/src/kms/vk/device.rs:78-89` (delete the blacklist and
+  its doc comment)
+- Modify: `crates/yserver/src/kms/render/backend.rs:1049` (doc comment citing
+  the deleted function)
 
 **This task turns the feature on. Do it last.**
 
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 1: Cache the capability at init**
 
-Add to the `#[cfg(test)] mod tests` block in `backend.rs`:
+`dri3_capabilities()` is called once per DRI3 request
+(`process_request.rs:10873`) and by `present_capabilities()`
+(`backend.rs:19611`) on every Present `QueryCapabilities`. Today that is an
+in-memory `driver_id` match; a raw ioctl on that path would be a regression.
+Read it once when the platform is built.
+
+In `PlatformBackend`, next to `render_node_fd`, add:
 
 ```rust
-/// The DRI3 version follows syncobj support: 1.4 advertises
-/// ImportSyncobj/FreeSyncobj and, through the mirrored Present
-/// capability, PresentPixmapSynced. Without syncobj support the server
-/// must stay at 1.3 or clients will send requests it cannot serve.
+    /// `DRM_CAP_SYNCOBJ_TIMELINE` on the render node, read once at init.
+    /// Whether DRI3 can offer syncobjs is a property of the kernel driver
+    /// behind that fd, not of the Vulkan driver — the resource is a DRM
+    /// syncobj and every operation on it is a DRM ioctl.
+    pub(crate) syncobj_timeline: bool,
+```
+
+Populate it where `render_node_fd` is resolved, querying **the render node**,
+not the KMS node: DRI3 hands clients the render node, and on split-device
+boxes (Pi 4 vc4/v3d, Asahi apple-drm/AGX) the display device's answer says
+nothing about the render device's. Set `false` when there is no render node.
+
+- [ ] **Step 2: Write the failing test**
+
+The old test asserted `caps.syncobj == supports_dri3_syncobj()`, a tautology
+against the blacklist. Replace it with one that pins the real mapping. Add to
+the tests module in `backend.rs`:
+
+```rust
+/// DRI3 version follows syncobj support, and syncobj support follows the
+/// kernel capability rather than the Vulkan driver. `for_tests()` has no
+/// render node, so the capability is false and the version must be 1.3 —
+/// which is also the check that would have caught a blacklist creeping back.
 #[test]
-fn dri3_version_follows_syncobj_support() {
+fn dri3_syncobj_follows_the_kernel_capability() {
     assert_eq!(dri3_version_for(true), (1, 4));
     assert_eq!(dri3_version_for(false), (1, 3));
+
+    let b = KmsBackend::for_tests();
+    assert!(
+        !b.platform.syncobj_timeline,
+        "for_tests() has no render node, so the capability must be false",
+    );
 }
 ```
 
-- [ ] **Step 2: Run the test to verify it fails**
+- [ ] **Step 3: Run it to verify it fails**
 
-Run: `cargo test -p yserver --lib dri3_version_follows -- --nocapture`
+Run: `cargo test -p yserver --lib dri3_syncobj_follows -- --nocapture`
 Expected: FAIL — `dri3_version_for` is not defined.
 
-- [ ] **Step 3: Rewrite the capability derivation**
+- [ ] **Step 4: Rewrite the capability derivation**
 
-Add this free function in `backend.rs` immediately above the `impl Backend for
-KmsBackend` block that contains `dri3_capabilities`:
+Add above the `impl Backend for KmsBackend` block containing
+`dri3_capabilities`:
 
 ```rust
-/// DRI3 version for a given syncobj capability. 1.4 is the version that
-/// carries `ImportSyncobj` / `FreeSyncobj`; without them the server caps at
-/// 1.3 and clients fall back to the fence path.
+/// DRI3 version for a given syncobj capability. 1.4 is the version carrying
+/// `ImportSyncobj` / `FreeSyncobj`; without them the server caps at 1.3 and
+/// clients fall back to the fence path.
 fn dri3_version_for(syncobj: bool) -> (u32, u32) {
     if syncobj { (1, 4) } else { (1, 3) }
 }
 ```
 
-Replace the body of `dri3_capabilities` (`:18967-18992`):
+Replace the body of `dri3_capabilities`:
 
 ```rust
     fn dri3_capabilities(&self) -> Dri3Caps {
@@ -760,15 +954,10 @@ Replace the body of `dri3_capabilities` (`:18967-18992`):
         // init; fence_fd / SYNC_FD handle type rides along with it.
         let fence_fd = true;
         // Syncobj support is a property of the KERNEL, not of the Vulkan
-        // driver: the resource is a DRM syncobj and every operation on it is
-        // a DRM ioctl. The previous NVIDIA blacklist here was really a
-        // symptom of vkImportSemaphoreFdKHR rejecting DRM syncobj fds, which
-        // no longer matters because nothing imports them into Vulkan.
-        let syncobj = ::drm::Device::get_driver_capability(
-            self.platform.device.as_ref(),
-            ::drm::DriverCapability::TimelineSyncObj,
-        )
-        .is_ok_and(|v| v != 0);
+        // driver. The previous NVIDIA blacklist here was a correct response
+        // to vkImportSemaphoreFdKHR rejecting DRM syncobj fds, which no
+        // longer matters because nothing imports them into Vulkan.
+        let syncobj = self.platform.syncobj_timeline;
         Dri3Caps {
             version: dri3_version_for(syncobj),
             modifiers,
@@ -778,109 +967,141 @@ Replace the body of `dri3_capabilities` (`:18967-18992`):
     }
 ```
 
-**Watch the trait path:** `get_driver_capability` is on the `drm::Device` root
-trait, *not* on `drm::control::Device`, which is the one this file already
+**Trait path warning for Step 1's query:** `get_driver_capability` lives on the
+`drm::Device` ROOT trait, not on `drm::control::Device`, which this file already
 imports for the syncobj calls. `crates/yserver/src/kms/cursor_plane.rs:30-34`
 shows the distinction — it imports `Device as DrmDevice` alongside
-`control::{Device as ControlDevice, ...}`. Use a `use` alias rather than the
-fully-qualified call if that reads better, but do not assume one trait has the
-other's methods.
+`control::{Device as ControlDevice, …}`. `DriverCapability::TimelineSyncObj`
+is at `drm` `lib.rs:309`; `get_driver_capability` returns `io::Result<u64>`, so
+`.is_ok_and(|v| v != 0)` is the test.
 
-- [ ] **Step 4: Delete the driver blacklist**
+- [ ] **Step 5: Delete the blacklist and its stale references**
 
-In `crates/yserver/src/kms/vk/device.rs`, delete `supports_dri3_syncobj`
-(lines 87-89) together with its doc comment.
+- Delete `supports_dri3_syncobj` and its doc comment from
+  `crates/yserver/src/kms/vk/device.rs:78-89`. **This is a compile error in the
+  test target** until Step 2's replacement lands — `backend.rs:27926-27929`
+  called it. Removing it is not optional and `--all-targets` will catch it.
+- `backend.rs:1049` carries a doc comment citing
+  `VkContext::supports_dri3_syncobj`. Update it to name the kernel capability.
 
-- [ ] **Step 5: Run the tests**
+- [ ] **Step 6: Run everything**
 
-Run: `cargo test -p yserver --lib`
-Expected: PASS. If a test asserted DRI3 1.3 on this box, it was asserting the
-blacklist; update it to assert the kernel-derived value.
+```bash
+cargo test -p yserver --lib
+cargo test -p yserver --lib -- --ignored
+cargo clippy --all-targets -- -D warnings
+```
+Expected: PASS.
 
-- [ ] **Step 6: Format, lint, commit**
+- [ ] **Step 7: Format and commit**
 
 ```bash
 cargo +nightly fmt
-cargo clippy --all-targets -- -D warnings
-git add crates/yserver/src/kms/render/backend.rs crates/yserver/src/kms/vk/device.rs
+git add crates/yserver/src/kms/render/backend.rs crates/yserver/src/kms/render/platform.rs crates/yserver/src/kms/vk/device.rs
 git commit -m "feat(dri3): advertise 1.4 whenever the kernel has timeline syncobj
 
-supports_dri3_syncobj() blacklisted NVIDIA_PROPRIETARY, which capped DRI3
-at 1.3 and left PresentPixmapSynced untestable on the nvidia box. The
-real condition was never the Vulkan driver: it is whether the kernel
-exposes DRM_CAP_SYNCOBJ_TIMELINE, which is what the Phase 4.2 design's
-fallback matrix said in the first place.
+supports_dri3_syncobj() blacklisted NVIDIA_PROPRIETARY, capping DRI3 at
+1.3 and leaving PresentPixmapSynced untestable on the nvidia box. The
+blacklist was a correct response to a real failure, recorded in its own
+doc comment -- vkImportSemaphoreFdKHR rejects DRM syncobj fds on that
+driver. It stops being the right question once nothing imports them.
 
-Measured on the nvidia box: nvidia-drm serves the whole syncobj path, and
-libGLX_nvidia resolves import_syncobj plus present_pixmap_synced once per
-swapchain against a 1.4 server."
+The capability now comes from DRM_CAP_SYNCOBJ_TIMELINE on the render
+node, cached at init because dri3_capabilities sits on the per-request
+path."
 ```
 
 ---
 
-### Task 6: Hardware validation and documentation
+### Task 5: Make the success path observable, then validate on hardware
 
 **Files:**
+- Modify: `crates/yserver-core/src/core_loop/process_request.rs:11457-11506`
 - Modify: `docs/status.md`
 - Modify: `docs/superpowers/specs/2026-08-08-dri3-syncobj-drm-signal-design.md`
-  (Status line)
 
-- [ ] **Step 1: Run the server and capture**
+- [ ] **Step 1: Add a success-path log line**
 
-Start yserver and run a Vulkan client through X11 WSI. It must be Vulkan, not
-GL — `docs/status.md:4084` records NVIDIA's libGL failing to bind DRI3 against
-yserver for unrelated reasons, so a GL client cannot answer either way.
+The only `DRI3::ImportSyncobj` line in the tree is the `BadAlloc` branch
+(`process_request.rs:11493`). The success path logs nothing, so a healthy run
+and a run where no client ever sent the request look identical — the validation
+below would be meaningless without this. After the successful
+`backend.dri3_import_syncobj(...)` call, add:
+
+```rust
+            debug!(
+                "client {} #{} DRI3::ImportSyncobj 0x{:x} -> imported",
+                client_id.0, sequence.0, req.syncobj
+            );
+```
+
+Match the surrounding style: the neighbouring handlers all log
+`client {} #{} DRI3::<Request> …` at `debug!`.
 
 ```bash
-# `just yserver-mate-hw` (Justfile:293) takes a log spec. The wire-level
-# DRI3/PRESENT debug lines live on the default target, so present_pace
-# alone is NOT enough — process_request must be included or ImportSyncobj
-# never appears and the capture looks like a negative result.
+cargo +nightly fmt && cargo clippy --all-targets -- -D warnings
+git add crates/yserver-core/src/core_loop/process_request.rs
+git commit -m "feat(dri3): log successful ImportSyncobj
+
+Only the BadAlloc branch logged, so a working explicit-sync client was
+indistinguishable from no client at all."
+```
+
+- [ ] **Step 2: Capture**
+
+```bash
+# The wire-level DRI3/PRESENT debug lines live on the default target, so
+# present_pace alone is NOT enough -- process_request must be included.
 just yserver-mate-hw "info,present_pace=debug,yserver_core::core_loop::process_request=debug"
 
-# inside the session, forcing the Vulkan X11 WSI:
+# inside the session, forcing the Vulkan X11 WSI. It must be Vulkan, not GL:
+# docs/status.md:4063 records NVIDIA's libGL failing to bind DRI3 against
+# yserver for unrelated reasons, so a GL client cannot answer either way.
 mpv --gpu-api=vulkan --vo=gpu-next --gpu-context=x11vk \
     --length=15 av://lavfi:testsrc=size=1280x720:rate=60
 ```
 
-Copy the log aside immediately (`cp yserver-hw-mate.log dri3-syncobj-<date>.log`).
-Every yserver start truncates `yserver-hw-mate.log` and
-`yserver-mate.submit.tsv` at the repo root with `>` plus `rm -f`, including a
-normal desktop session — analyse or copy before the next run or the data is
-gone.
+Copy the log aside immediately — `just yserver-mate-hw` (`Justfile:293`)
+truncates `yserver-hw-mate.log` with `>` on every start, including a normal
+desktop session:
 
-- [ ] **Step 2: Check the four things that must appear**
+```bash
+cp yserver-hw-mate.log dri3-syncobj-$(date +%Y%m%d).log
+```
+
+- [ ] **Step 3: Check what must appear**
 
 ```bash
 LOG=dri3-syncobj-<date>.log
 grep -c "DRI3::QueryVersion.*-> 1.4" "$LOG"      # server advertises 1.4
-grep -c "DRI3::ImportSyncobj" "$LOG"             # client takes the path
-grep -c "present acquire" "$LOG"                 # acquires resolve
-grep -c "signal release syncobj.*failed" "$LOG"  # must be 0 or explained
+grep -c "DRI3::ImportSyncobj.*-> imported" "$LOG" # client takes the path
+grep -c "present acquire" "$LOG"                  # acquires resolve
+grep -c "unknown syncobj" "$LOG"                  # freed-syncobj replay
 ```
 
-A non-zero count on the last one is most likely the pre-existing freed-syncobj
-bookkeeping bug (`docs/status.md:567`) becoming reachable, not a regression
-from this change. Record which it is; do not fix it here.
+The last one is the freed-syncobj bookkeeping bug (`docs/status.md:548`)
+becoming reachable, not a regression from this change — that path fails at the
+registry miss and never reaches an ioctl, with identical text before and after.
+Record the count; do not fix it. Note there is deliberately **no** check for a
+failed release signal: the kernel clamps stale points and returns success, so
+out-of-order releases are silent by construction.
 
-- [ ] **Step 3: Update `docs/status.md`**
+- [ ] **Step 4: Update `docs/status.md`**
 
-Add an entry with: the capability now deriving from
-`DRM_CAP_SYNCOBJ_TIMELINE`; that `PresentPixmapSynced` is no longer
-"structurally untestable" (amend the claim at `:316`, which named this exact
-gate); the counts from Step 2; and whether the freed-syncobj signals appeared.
+Record: the capability now deriving from `DRM_CAP_SYNCOBJ_TIMELINE` on the
+render node; the counts from Step 3; and amend the claim at **`docs/status.md:297`**
+that `PresentPixmapSynced` is "structurally untestable on this box", which named
+this exact gate. Verify that line number before editing — this plan's first
+draft had it as `:316`, read from a different branch.
 
-- [ ] **Step 4: Flip the spec's status line**
+- [ ] **Step 5: Flip the spec's status line**
 
-Change the spec header from `**Status:** DESIGN (2026-08-08)` to
-`IMPLEMENTED`, with the hardware result and the box it ran on, following the
-style of `2026-07-20-nvidia-gbm-scanout-allocation.md`.
+Change `**Status:** DESIGN (2026-08-08)` to `IMPLEMENTED`, with the hardware
+result and the box, following `2026-07-20-nvidia-gbm-scanout-allocation.md`.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
-cargo +nightly fmt
-cargo clippy --all-targets -- -D warnings
 git add docs/status.md docs/superpowers/specs/2026-08-08-dri3-syncobj-drm-signal-design.md
 git commit -m "docs(dri3): record the DRM-signalled syncobj result on hardware"
 ```
@@ -892,11 +1113,18 @@ git commit -m "docs(dri3): record the DRM-signalled syncobj result on hardware"
 - **Cross-driver validation.** The Mesa path changes from a Vulkan host signal
   to a DRM host signal and there is no AMD or Intel GPU on this box. The bee
   (6900HX / RADV) is where that gets confirmed.
-- **The freed-syncobj bookkeeping bug** (`docs/status.md:567`). This change
-  makes it reachable here; it does not cause it.
+- **The freed-syncobj bookkeeping bug** (`docs/status.md:548`). This change
+  makes it reachable here; it does not cause it, and it does not make it more
+  observable.
+- **No client-teardown purge for `dri3_syncobjs`.** Nothing removes entries
+  except `FreeSyncobj`, so a client that dies with syncobjs imported leaks a
+  DRM handle and the fence chain it pins. Pre-existing in shape, newly exposed
+  in practice.
+- **The fail-open arm in `PendingPresentSourceWait::is_ready`.** A failed
+  timeline query is treated as ready and the copy proceeds. Unreachable on
+  NVIDIA before this change; live after it.
 - **GPU-side release signalling.** Signalling the client's release point from
-  the queue instead of the host would let clients unblock earlier, but it is a
-  separate design with its own measurement, and it is impossible on NVIDIA
-  (the import that would be required is what fails). See the spec's root-cause
-  section for why the queue-wait half of that idea is foreclosed by the single
-  shared queue.
+  the queue rather than the host would let clients unblock earlier, but it is a
+  separate design with its own measurement, and impossible on NVIDIA. The
+  queue-wait half of that idea is foreclosed by the single shared queue — see
+  the spec's root-cause section.

--- a/docs/superpowers/plans/2026-08-08-dri3-syncobj-drm-signal.md
+++ b/docs/superpowers/plans/2026-08-08-dri3-syncobj-drm-signal.md
@@ -11,17 +11,57 @@ becomes a process-local DRM syncobj handle. Signal moves from
 from `vkGetSemaphoreCounterValue` to `DRM_IOCTL_SYNCOBJ_QUERY`; the acquire
 eventfd path was already DRM and is untouched. `OwnedSemaphore` keeps its
 Vulkan body and serves only the XSync fence half, which genuinely needs it.
+Because a DRI3 syncobj is a DRM object, **every syncobj ioctl and the
+capability query issue on the render node** — the fd DRI3 hands clients — so
+`PlatformBackend` retains a `Device` over it.
 
 **Tech Stack:** Rust, `drm` 0.15 (`syncobj_timeline_signal`,
 `syncobj_timeline_query`, `syncobj_eventfd`, `fd_to_syncobj`,
-`DriverCapability::TimelineSyncObj`), `ash` (only where it already was).
+`DriverCapability::TimelineSyncObj`), `ash` (only where it already was),
+IGT GPU Tools (`syncobj_*` tests) on the validation box for hardware DRM
+validation.
 
 **Spec:** `docs/superpowers/specs/2026-08-08-dri3-syncobj-drm-signal-design.md`
 
-**Revision:** rewritten 2026-08-08 after two adversarial review rounds returned
-9 blocking findings against the first draft. The task boundaries changed — what
-were Tasks 2 and 3 are now one task, because splitting them left the tree
-functionally broken on Mesa at a commit boundary.
+**Revision:** revised 2026-08-09 after a third adversarial review round run
+against the DRM / DRI3 1.4 / Present 1.4 documentation and the branch. Three
+blocking findings from that review are fixed here:
+
+1. **Render-node invariant enforced.** The previous draft ran every syncobj
+   ioctl on the KMS node (`PlatformBackend::device`) while querying the
+   capability on the render node — the spec's "advertises 1.4 on the strength
+   of one device and then operates another" failure row. `PlatformBackend`
+   now retains a `Device` over the render node (spec: *"if that means
+   PlatformBackend has to retain a Device for the render node rather than an
+   fd, that is part of this change"*) and both the capability and the ioctls
+   use it (Task 2, Task 5).
+2. **The spec's protocol-conformance scope decision is now implemented.**
+   The spec scoped in an owning client plus Xorg error semantics
+   ("the minimum that makes DRI3 1.4 safe to advertise"): XID validation,
+   `BadValue` on a missing fd, `FreeSyncobj` ownership, `PresentPixmapSynced`
+   Value errors, and a disconnect purge. That was missing entirely from the
+   previous draft; it is now Task 3.
+3. **Task 5's hardware validation is now evidence-producing.** It runs the
+   full-Mesa session with the spec's two mandatory env overrides (a bare
+   `just yserver-mate-hw` now launches the mismatched KMS-AMD/Vulkan-NVIDIA
+   pair and proves nothing), gates on a non-zero deferred count and no
+   fallback warning, and adds IGT GPU Tools (`syncobj_*` tests) as the
+   kernel-level DRM validation.
+4. **Divergence from Xorg declared and applied to error codes.** The spec now
+   states explicitly that yserver does not adopt Xorg's resource-type
+   machinery (syncobjs stay a backend `HashMap` + owner field — HLD non-goal)
+   and does not replicate Xorg's error codes for `ImportSyncobj` /
+   `FreeSyncobj` (BadIDChoice / BadAccess). Only `PresentPixmapSynced`'s
+   Value errors are protocol (presentproto 1.4). Task 3 uses yserver's own
+   codes: `BadAlloc` for import failures (xid invalid, missing fd, import
+   error), `BadValue` for free failures (unknown or not the owner). The
+   spec's "model it as a real resource rather than weakening the table"
+   escape hatch is gone.
+
+Task boundaries changed again: the conformance work is a separate task (3)
+because it is independently reviewable (registry ownership + error semantics
+are observable protocol behaviour), but its registry type change lands in the
+same commit as the handlers that consume it.
 
 ## Global Constraints
 
@@ -38,11 +78,27 @@ functionally broken on Mesa at a commit boundary.
 - No new ioctl plumbing is introduced — every ioctl used here already exists in
   the `drm` crate, so the AGENTS.md `libc::Ioctl` portability rule is not
   triggered. If you find yourself writing a raw `ioctl` call, stop.
-- `docs/status.md` must be updated (Task 5). AGENTS.md requires it current.
+- **The syncobj device is the render node, and it is one device, decided.**
+  Every `ImportedSyncobj` and the `DRM_CAP_SYNCOBJ_TIMELINE` query use
+  `PlatformBackend::render_node_device` — never `PlatformBackend::device`
+  (the KMS node). On split-device boxes (Pi 4 vc4/v3d, Asahi) the two answer
+  different questions. The capability is cached at init; the ioctls run
+  per-request on the same retained device.
+- **Deliberate divergence from Xorg (see spec § "Divergence from Xorg").**
+  Error codes for `ImportSyncobj` / `FreeSyncobj` are yserver's own —
+  `BadAlloc` for any import failure, `BadValue` for any free failure. Xorg's
+  BadIDChoice / BadAccess distinction is NOT replicated (no client branches
+  on it; HLD non-goal "preserving behavior that exists only because of Xorg
+  implementation accidents"). Only `PresentPixmapSynced`'s Value errors are
+  protocol-mandated. Do not "fix" these to match Xorg during implementation.
+- `docs/status.md` must be updated (Task 6). AGENTS.md requires it current.
 - Do not fix the freed-syncobj bookkeeping bug this change makes reachable
   (`docs/status.md:548`), and do not fix the fail-open arm in
   `PendingPresentSourceWait::is_ready`. Both are recorded in the spec's Risks
   section as out of scope.
+- The retain-mode divergence in Task 3's disconnect purge (a
+  `RetainPermanent` client's syncobjs are purged, where Xorg would keep them)
+  is a documented divergence, not a bug to fix here — see Task 3 Step 7.
 
 ---
 
@@ -61,19 +117,20 @@ functionally broken on Mesa at a commit boundary.
   `ImportedSyncobj::import(Arc<crate::drm::Device>, BorrowedFd) -> io::Result<Self>`,
   `.timeline_value() -> io::Result<u64>`, `.signaled_eventfd(u64) ->
   io::Result<OwnedFd>`, and an impl of `yserver_core::backend::SyncobjHandle`
-  whose `signal(u64)` uses `syncobj_timeline_signal`. Tasks 2 and 4 depend on
+  whose `signal(u64)` uses `syncobj_timeline_signal`. Tasks 2, 3 and 5 depend on
   these exact names.
 
 - [ ] **Step 1: Add a master-free constructor**
 
 `Device::open` (`crates/yserver/src/drm/device.rs:41`) calls
-`acquire_master_lock()` and propagates with `?`. `DRM_IOCTL_SET_MASTER` returns
-`EACCES` on a render node — `drm_ioctl_permit` rejects any non-`DRM_RENDER_ALLOW`
-ioctl from a render client — and also on `card0` under a live session. There is
-no way to build a `crate::drm::Device` over a render node today, so the tests
-below cannot exist without this.
+`acquire_master_lock()` (`:51`) and `enable_atomic_capabilities()` (`:57`) and
+propagates with `?`. `DRM_IOCTL_SET_MASTER` returns `EACCES` on a render node —
+`drm_ioctl_permit` rejects any non-`DRM_RENDER_ALLOW` ioctl from a render client
+(drm-uapi.md render-node section) — and also on `card0` under a live session.
+There is no way to build a `crate::drm::Device` over a render node today, so the
+tests below cannot exist without this.
 
-Add to `impl Device`, after `for_tests()` (`:39`):
+Add to `impl Device`, after `for_tests()` (`:30`):
 
 ```rust
     /// Open a render node without taking DRM master.
@@ -101,7 +158,7 @@ Add to `impl Device`, after `for_tests()` (`:39`):
 Create `crates/yserver/src/kms/render/imported_syncobj.rs` with only the test
 module for now:
 
-Note `pub(crate)` on both the module and `render_node()`: Tasks 3 and 5 reuse
+Note `pub(crate)` on both the module and `render_node()`: Tasks 2, 3 and 5 reuse
 this helper rather than each hardcoding a node path.
 
 ```rust
@@ -272,6 +329,10 @@ Prepend to `crates/yserver/src/kms/render/imported_syncobj.rs`:
 //! The sibling `OwnedSemaphore` keeps the Vulkan path for XSync `Fence`
 //! resources, which need a real `VkSemaphore` for `FDFromFence`'s sync_file
 //! export.
+//!
+//! The `Arc<crate::drm::Device>` here MUST be the render node — the device
+//! DRI3 hands the client (`PlatformBackend::render_node_device`), never the
+//! KMS node. See the spec's "Which fd to ask" section.
 
 use std::{
     os::fd::{AsFd, BorrowedFd, OwnedFd},
@@ -288,7 +349,10 @@ pub(crate) struct ImportedSyncobj {
 impl ImportedSyncobj {
     /// Import a client's `DRM_SYNCOBJ` fd as a process-local handle. The fd is
     /// only borrowed — `DRM_IOCTL_SYNCOBJ_FD_TO_HANDLE` does not consume it —
-    /// so the caller keeps ownership and drops it normally.
+    /// so the caller keeps ownership and drops it normally. Importing a
+    /// syncobj fd creates a NEW handle (with its own reference) for every
+    /// import; the underlying `struct drm_syncobj` is shared, which is what
+    /// lets a server-side signal reach the client's handle.
     pub(crate) fn import(
         drm: Arc<crate::drm::Device>,
         fd: BorrowedFd<'_>,
@@ -423,22 +487,26 @@ Not wired up yet; the registries still hold OwnedSemaphore."
   `dri3_syncobj_handle` `:19291`, `dri3_fd_from_fence` `:19301`,
   `dri3_import_syncobj` `:19313`, `dri3_free_syncobj` `:19377`,
   `dri3_signal_syncobj` `:19384`, and the test at `:30010`
-- Modify: `crates/yserver/src/kms/render/present_source_wait.rs:20-25,40-52`
+- Modify: `crates/yserver/src/kms/render/platform.rs` (retain a render-node
+  `Device`, alongside `render_node_fd` at `:565`)
+- Modify: `crates/yserver/src/kms/render/present_source_wait.rs:19-24,40-52`
 
 **Interfaces:**
 - Consumes: everything Task 1 produced.
-- Produces: field `dri3_syncobjs: HashMap<u32, Arc<ImportedSyncobj>>`;
-  `PendingPresentSourceWait::syncobj_pin` retyped to
-  `Option<Arc<ImportedSyncobj>>`. `dri3_sync_resources` survives, fences only.
+- Produces: `PlatformBackend::render_node_device:
+  Option<Arc<crate::drm::Device>>`; field `dri3_syncobjs: HashMap<u32,
+  Arc<ImportedSyncobj>>` (Task 3 adds the owner); `PendingPresentSourceWait::
+  syncobj_pin` retyped to `Option<Arc<ImportedSyncobj>>`. `dri3_sync_resources`
+  survives, fences only.
 
 **Why this is one task and not two.** The registry split and the acquire-path
 rewrite cannot be separate commits. `arm_present_syncobj_wait`
-(`backend.rs:13166`) looks up `dri3_sync_resources` for the acquire syncobj; the
+(`backend.rs:13145`) looks up `dri3_sync_resources` for the acquire syncobj; the
 moment `ImportSyncobj` writes elsewhere, that lookup's `ok_or_else` fires and
 the error propagates out of the request handler via `?`
 (`process_request.rs:10251`). It still compiles and `cargo test --lib` still
 passes, so nothing catches it — but on Mesa, where the capability is still
-advertised until Task 4, every synced present with an acquire syncobj breaks at
+advertised until Task 5, every synced present with an acquire syncobj breaks at
 that commit.
 
 - [ ] **Step 1: Write the failing test**
@@ -503,7 +571,53 @@ fn each_resolver_sees_only_its_own_registry() {
 Run: `cargo test -p yserver --lib each_resolver_sees_only -- --ignored`
 Expected: compile error — `dri3_syncobjs` does not exist.
 
-- [ ] **Step 3: Add the new field**
+- [ ] **Step 3: Retain a render-node `Device` in `PlatformBackend`**
+
+The spec's render-node invariant requires every syncobj ioctl and the
+capability query to issue on the render node — the device DRI3 hands clients.
+`PlatformBackend` today keeps only a bare `render_node_fd` (`platform.rs:565`);
+`dri3_import_syncobj` previously reached for `self.platform.device` (the **KMS
+node**) out of convenience, which is the exact failure the spec calls out.
+
+In `crates/yserver/src/kms/render/platform.rs`, next to `render_node_fd`
+(`:565`), add:
+
+```rust
+    /// The DRM device over the render node, retained so every DRI3 syncobj
+    /// ioctl and the `DRM_CAP_SYNCOBJ_TIMELINE` query issue on the SAME fd
+    /// kind DRI3 hands clients. This is deliberately NOT `device` (the KMS
+    /// node): on split-device boxes (Pi 4 vc4/v3d, Asahi) the display device's
+    /// answer says nothing about the render device's. See the spec's "Which
+    /// fd to ask — one device, decided, not preferred".
+    pub(crate) render_node_device: Option<Arc<crate::drm::Device>>,
+```
+
+Populate it in `from_platform_init` (`platform.rs:760`) where `render_node_fd`
+is already destructured from `PlatformInit` — the path is available as
+`render_node_path`:
+
+```rust
+        let render_node_device = render_node_path
+            .as_deref()
+            .and_then(|path| {
+                // `open_render_node` takes a `&str`; a non-UTF8 node path
+                // (unrealistic under /dev/dri) degrades to no device, which
+                // `dri3_import_syncobj` surfaces as a hard error.
+                drm::Device::open_render_node(path.to_str()?).ok()
+            })
+            .map(Arc::new);
+```
+
+Add `render_node_device: None,` to `PlatformBackend::for_tests()` (`:1007`,
+next to `render_node_fd: None`). Missing it is a compile error, not a silent
+bug. Note this opens a **second** fd to the render node (alongside
+`render_node_fd`); that matches the existing design — `dri3_open` already opens
+a fresh fd per request via `render_node::open_fresh` (`backend.rs:18963`) — and
+syncobj handles are per-`drm_file` but the underlying `struct drm_syncobj` is
+shared across fds of the same device, which is what makes a server-side signal
+reach the client.
+
+- [ ] **Step 4: Add the new registry field**
 
 In `backend.rs`, narrow the existing doc comment on `dri3_sync_resources`
 (`:800-804`) to fences only and add the new field after it:
@@ -517,7 +631,7 @@ In `backend.rs`, narrow the existing doc comment on `dri3_sync_resources`
     /// DRI3 1.4 syncobj resources keyed by the client's xid, imported by
     /// `ImportSyncobj`. Separate from `dri3_sync_resources` because these are
     /// a different X resource type with a different backing primitive: a DRM
-    /// syncobj handle, not a `VkSemaphore`.
+    /// syncobj handle, not a `VkSemaphore`. Task 3 adds the owning client.
     pub(crate) dri3_syncobjs:
         HashMap<u32, std::sync::Arc<crate::kms::render::imported_syncobj::ImportedSyncobj>>,
 ```
@@ -526,11 +640,12 @@ Add `dri3_syncobjs: HashMap::new(),` next to `dri3_sync_resources:
 HashMap::new(),` in **both** initialisers (`:2334` and `:3222`). Missing the
 second is a compile error, not a silent bug.
 
-- [ ] **Step 4: Rewire the four syncobj methods**
+- [ ] **Step 5: Rewire the four syncobj methods**
 
 Replace `dri3_import_syncobj` (`:19313-19375`). The `dup`, the Vulkan gate, the
 import and the rollback all go away — `fd_to_syncobj` borrows the fd and there
-is nothing left to roll back:
+is nothing left to roll back. The device is the **render node**, not
+`self.platform.device`:
 
 ```rust
     fn dri3_import_syncobj(
@@ -540,8 +655,11 @@ is nothing left to roll back:
     ) -> io::Result<()> {
         use std::os::fd::AsFd;
 
+        let render_node = self.platform.render_node_device.as_ref().cloned().ok_or_else(
+            || io::Error::other("DRI3 ImportSyncobj: render node not resolved at init"),
+        )?;
         let imported = crate::kms::render::imported_syncobj::ImportedSyncobj::import(
-            self.platform.device.clone(),
+            render_node,
             fd.as_fd(),
         )?;
         // Arc Drop on any replaced entry destroys the previous handle.
@@ -593,7 +711,7 @@ Replace `dri3_syncobj_handle` (`:19291-19299`):
     }
 ```
 
-- [ ] **Step 5: Move the registry lookup ahead of the Vulkan gate**
+- [ ] **Step 6: Move the registry lookup ahead of the Vulkan gate**
 
 In `dri3_fd_from_fence` (`:19301-19311`) the lookup must come first, so an
 unknown xid reports as unknown instead of as a Vulkan failure:
@@ -615,7 +733,7 @@ unknown xid reports as unknown instead of as a Vulkan failure:
     }
 ```
 
-- [ ] **Step 6: Repoint the acquire path (this is what keeps the tree working)**
+- [ ] **Step 7: Repoint the acquire path (this is what keeps the tree working)**
 
 In `arm_present_syncobj_wait`, the block starting at `:13162`:
 
@@ -641,9 +759,11 @@ In `arm_present_syncobj_wait`, the block starting at `:13162`:
             };
 ```
 
-- [ ] **Step 7: Retype the pin and its readiness check**
+- [ ] **Step 8: Retype the pin and its readiness check**
 
-In `present_source_wait.rs`, replace lines 20-25:
+In `present_source_wait.rs`, replace lines 19-24 (the two fields and their doc
+comments — **do not touch `poll_timeline: bool` at `:25`, it is still used** at
+`backend.rs:12595/13186/13222`):
 
 ```rust
     /// Keeps an explicitly imported acquire syncobj alive until its timeline
@@ -676,11 +796,11 @@ Replace the `is_ready` timeline arm (lines 40-52):
 Leave the fail-open `true` alone — the spec records it as a known hazard that
 this change makes live, and fixing it is explicitly out of scope.
 
-- [ ] **Step 8: Fix the two existing tests this task breaks**
+- [ ] **Step 9: Fix the two existing tests this task breaks**
 
 `syncobj_handle_accessor_returns_arc_clone` (`backend.rs:30010-30029`) inserts
 an `OwnedSemaphore` into `dri3_sync_resources` and asserts
-`dri3_syncobj_handle` finds it. After Step 4 it returns `None` and the test
+`dri3_syncobj_handle` finds it. After Step 5 it returns `None` and the test
 panics — and it still compiles, so `cargo test --lib dri3_` would not even
 match its name. Rewrite it against the new registry:
 
@@ -728,11 +848,14 @@ instead, so it becomes `#[ignore]`. That is a real coverage loss on CI; it is
 unavoidable, because the resource it covers is now a kernel object.
 
 `dri3_import_syncobj_no_vk_errs` (`:28065`) asserts the import Errs without
-Vulkan, which is no longer why it errs. Replace it:
+Vulkan, which is no longer why it errs. Replace it with a version that feeds
+`for_tests()` a bogus render-node device so the **ioctl** (not the
+missing-device guard) is what fails:
 
 ```rust
-    /// ImportSyncobj no longer needs Vulkan. Without a real DRM device in
-    /// for_tests() it still Errs, but on the ioctl rather than a Vk gate.
+    /// ImportSyncobj no longer needs Vulkan. for_tests() has no render node,
+    /// so feed it a bogus one and assert the ioctl — not the device guard —
+    /// is what fails.
     #[test]
     fn dri3_import_syncobj_errs_without_a_usable_drm_handle() {
         use std::os::fd::{FromRawFd, IntoRawFd, OwnedFd};
@@ -744,6 +867,9 @@ Vulkan, which is no longer why it errs. Replace it:
         // directly; the OwnedFd's Drop closes it.
         let fd = unsafe { OwnedFd::from_raw_fd(f.into_raw_fd()) };
         let mut b = KmsBackend::for_tests();
+        b.platform.render_node_device = Some(std::sync::Arc::new(
+            crate::drm::Device::open_render_node("/dev/null").expect("open /dev/null"),
+        ));
         assert!(
             b.dri3_import_syncobj(0x4040_3333, fd).is_err(),
             "importing a non-syncobj fd must Err",
@@ -751,7 +877,7 @@ Vulkan, which is no longer why it errs. Replace it:
     }
 ```
 
-- [ ] **Step 9: Check whether `for_tests_dummy` still has callers**
+- [ ] **Step 10: Check whether `for_tests_dummy` still has callers**
 
 `OwnedSemaphore::for_tests_dummy` (`owned_semaphore.rs:80`) existed for the
 test just rewritten. Run:
@@ -763,7 +889,7 @@ grep -rn "for_tests_dummy" crates/
 If nothing remains, delete it — `#[cfg(test)]` dead code still fails
 `clippy --all-targets -- -D warnings`.
 
-- [ ] **Step 10: Run the tests**
+- [ ] **Step 11: Run the tests**
 
 ```bash
 cargo test -p yserver --lib                                    # no regressions
@@ -771,18 +897,23 @@ cargo test -p yserver --lib -- --ignored                       # the DRM ones
 ```
 Expected: PASS on both.
 
-- [ ] **Step 11: Format, lint, commit**
+- [ ] **Step 12: Format, lint, commit**
 
 ```bash
 cargo +nightly fmt
 cargo clippy --all-targets -- -D warnings
-git add crates/yserver/src/kms/render/backend.rs crates/yserver/src/kms/render/present_source_wait.rs crates/yserver/src/kms/render/owned_semaphore.rs
+git add crates/yserver/src/kms/render/backend.rs crates/yserver/src/kms/render/platform.rs crates/yserver/src/kms/render/present_source_wait.rs crates/yserver/src/kms/render/owned_semaphore.rs
 git commit -m "refactor(dri3): hold syncobjs in their own DRM-backed registry
 
 FenceFromFD and ImportSyncobj registered two different X resource types
 into one HashMap of OwnedSemaphore. Only the fence half needs Vulkan
 (FDFromFence exports a sync_file from the VkSemaphore); the syncobj half
 needs a DRM handle. Split them so the type mismatch is unrepresentable.
+
+PlatformBackend now retains a Device over the render node, and every
+syncobj ioctl runs on it — the same fd kind DRI3 hands clients — instead
+of the KMS node (which only answers for the display device on split-GPU
+boxes).
 
 The acquire path moves in the same commit rather than a later one: it
 looks up the same map, so splitting the two would leave every synced
@@ -794,7 +925,894 @@ unknown xid reports as unknown rather than as a Vulkan failure."
 
 ---
 
-### Task 3: Strip the syncobj half out of `OwnedSemaphore`
+### Task 3: DRI3 syncobj conformance — owning client and error semantics
+
+The spec scoped this in: *"Give the registry an owning client and error
+semantics. That is the minimum that makes DRI3 1.4 safe to advertise: rows 3
+and 4 are cross-client and denial-of-service shaped respectively."* The
+conformance table (spec § "Protocol conformance") — note rows 1-3 diverge from
+Xorg in the **error codes** on purpose (spec § "Divergence from Xorg"): only
+row 4 is protocol-mandated:
+
+| # | Contrato que debe cumplirse | Xorg | yserver (este cambio) |
+|---|---|---|---|
+| 1 | Un xid no legal para el cliente se rechaza (convención core X11) | `LEGAL_NEW_RESOURCE` → BadIDChoice (`dri3/dri3_request.c:609`) | `BadAlloc` — divergencia deliberada |
+| 2 | Un request sin fd se rechaza | `fd < 0` → BadValue (`dri3/dri3_request.c:619-620`) | `BadAlloc` — divergencia deliberada |
+| 3 | Nadie puede liberar el syncobj de otro | `dixLookupResourceByType(..., DixWriteAccess)` → BadValue/BadAccess (`dri3/dri3_request.c:634-637`) | ownership enforced; `BadValue` único — divergencia deliberada |
+| 4 | `PresentPixmapSynced`: syncobj inválido o points ilegales → **Value error** | `VERIFY_DRI3_SYNCOBJ` + BadValue (`present/present_request.c:296-302`) | `BadValue` — protocolo presentproto 1.4 |
+
+**Do not "fix" rows 1-3 to match Xorg's codes during implementation.** The
+Global Constraints and the spec's "Divergence from Xorg" section govern.
+
+**Files:**
+- Modify: `crates/yserver-core/src/backend/trait_def.rs` — `dri3_import_syncobj`
+  (`:2045`) and `dri3_free_syncobj` (`:2054`) gain a `ClientId` parameter
+- Modify: `crates/yserver/src/kms/render/backend.rs` — registry type, the four
+  syncobj methods, `client_disconnected` (`:14361`), tests
+- Modify: `crates/yserver-core/src/backend/recording.rs` — minimal syncobj
+  tracking so the wire-level tests can exercise the handlers
+- Modify: `crates/yserver-core/src/core_loop/process_request.rs` —
+  `IMPORT_SYNCOBJ` (`:11457`), `FREE_SYNCOBJ` (`:11507`), `PIXMAP_SYNCED`
+  (`:10067`) handlers + wire tests
+
+**Interfaces:**
+- Consumes: `dri3_syncobjs` registry (Task 2), `dri3_syncobj_handle`,
+  `ImportedSyncobj`, `ClientId`.
+- Produces: registry `dri3_syncobjs: HashMap<u32, (ClientId,
+  Arc<ImportedSyncobj>)>`; `dri3_import_syncobj(client_id, xid, fd)` and
+  `dri3_free_syncobj(client_id, xid)` (trait signatures change);
+  `PresentPixmapSynced` Value-error validation; disconnect purge in
+  `client_disconnected`.
+
+- [ ] **Step 1: Write the failing wire-level tests**
+
+Add to the `#[cfg(test)] mod tests` block in `process_request.rs`, next to
+`sync_create_trigger_query_fence_round_trip` (`:37092`). `RecordingBackend` is
+the backend; the tests build DRI3 request bodies by hand exactly like the
+existing fence round-trip test does. `IMPORT_SYNCOBJ` is DRI3 minor opcode 10,
+`FREE_SYNCOBJ` 11, DRI3 major opcode 147 (all already in
+`yserver_protocol::x11::dri3`).
+
+The tests need `RecordingBackend` to track syncobjs — that is Step 4. To make
+them fail first, write them, then run: they fail to compile until Step 4 adds
+the overrides.
+
+```rust
+    /// Build an ImportSyncobj request body: syncobj(4) + drawable(4), fd via
+    /// SCM_RIGHTS (attached_fd).
+    fn import_syncobj_body(syncobj: u32) -> Vec<u8> {
+        let mut body = vec![0u8; 8];
+        body[0..4].copy_from_slice(&syncobj.to_le_bytes());
+        body
+    }
+
+    fn read_error(buf: &[u8]) -> u8 {
+        // X error: type=0, error-code at byte 1.
+        assert_eq!(buf[0], 0, "expected an X error, got type {}", buf[0]);
+        buf[1]
+    }
+
+    #[test]
+    fn import_syncobj_in_use_xid_is_bad_alloc() {
+        use yserver_protocol::x11::{CreatePixmapRequest, ResourceId};
+        let mut state = ServerState::new();
+        let mut peer = install_client(&mut state, 1);
+        let mut backend = RecordingBackend::new();
+
+        // install_client (process_request.rs:29047) gives every test client
+        // base=0/mask=u32::MAX — "every xid is in range" — so the
+        // xid_out_of_client_range half of the LEGAL_NEW_RESOURCE gate is
+        // unreachable in this fixture. Exercise the OTHER half: name a
+        // pixmap with the xid, then ImportSyncobj with the same xid ->
+        // resources.xid_in_use fires.
+        const XID: u32 = 0x0040_0001;
+        state.resources.create_pixmap(
+            ClientId(1),
+            CreatePixmapRequest {
+                depth: 24,
+                pixmap: ResourceId(XID),
+                drawable: ROOT_WINDOW,
+                width: 1,
+                height: 1,
+            },
+        );
+
+        process_request(
+            &mut state,
+            &mut backend,
+            ClientId(1),
+            SequenceNumber(1),
+            RequestHeader {
+                opcode: 147,
+                data: 10, // IMPORT_SYNCOBJ
+                length_units: 3,
+            },
+            &import_syncobj_body(XID),
+            None, // no SCM_RIGHTS fd
+        )
+        .unwrap();
+        peer.set_nonblocking(true).unwrap();
+        let mut buf = [0u8; 32];
+        peer.read_exact(&mut buf).unwrap();
+        assert_eq!(
+            read_error(&buf),
+            x11::error::BAD_ALLOC,
+            "an in-use xid must be rejected as BadAlloc",
+        );
+    }
+
+    #[test]
+    fn import_syncobj_missing_fd_is_bad_alloc() {
+        let mut state = ServerState::new();
+        let mut peer = install_client(&mut state, 1);
+        let mut backend = RecordingBackend::new();
+
+        process_request(
+            &mut state,
+            &mut backend,
+            ClientId(1),
+            SequenceNumber(1),
+            RequestHeader {
+                opcode: 147,
+                data: 10, // IMPORT_SYNCOBJ
+                length_units: 3,
+            },
+            &import_syncobj_body(0x0010_0001), // any xid; install_client is range-permissive
+            None, // no fd attached
+        )
+        .unwrap();
+        peer.set_nonblocking(true).unwrap();
+        let mut buf = [0u8; 32];
+        peer.read_exact(&mut buf).unwrap();
+        assert_eq!(
+            read_error(&buf),
+            x11::error::BAD_ALLOC,
+            "ImportSyncobj without an fd must be BadAlloc (yserver's own code — not Xorg's BadValue)",
+        );
+    }
+
+    #[test]
+    fn free_syncobj_unknown_is_bad_value() {
+        let mut state = ServerState::new();
+        let mut peer = install_client(&mut state, 1);
+        let mut backend = RecordingBackend::new();
+
+        let mut body = vec![0u8; 4];
+        body[0..4].copy_from_slice(&0x0040_9999u32.to_le_bytes());
+        process_request(
+            &mut state,
+            &mut backend,
+            ClientId(1),
+            SequenceNumber(1),
+            RequestHeader {
+                opcode: 147,
+                data: 11, // FREE_SYNCOBJ
+                length_units: 2,
+            },
+            &body,
+            None,
+        )
+        .unwrap();
+        peer.set_nonblocking(true).unwrap();
+        let mut buf = [0u8; 32];
+        peer.read_exact(&mut buf).unwrap();
+        assert_eq!(
+            read_error(&buf),
+            x11::error::BAD_VALUE,
+            "FreeSyncobj of an unknown xid must be BadValue",
+        );
+    }
+
+    #[test]
+    fn free_syncobj_of_another_client_is_bad_value() {
+        let mut state = ServerState::new();
+        let _peer_a = install_client(&mut state, 1);
+        let mut peer_b = install_client(&mut state, 2);
+        let mut backend = RecordingBackend::new();
+
+        // Client A imports 0x0010_0001 (a legal xid for client 1 — the
+        // handler now validates range). RecordingBackend ignores the fd's
+        // payload, only ownership is recorded.
+        let fd = std::fs::File::open("/dev/null")
+            .expect("open /dev/null")
+            .into();
+        process_request(
+            &mut state,
+            &mut backend,
+            ClientId(1),
+            SequenceNumber(1),
+            RequestHeader {
+                opcode: 147,
+                data: 10,
+                length_units: 3,
+            },
+            &import_syncobj_body(0x0010_0001),
+            Some(fd),
+        )
+        .unwrap();
+
+        // Client B frees A's syncobj. FreeSyncobj has no range check (it is
+        // not a new-resource request), so B can name A's xid — the ownership
+        // check is what must reject it. One code, BadValue — deliberately NOT
+        // Xorg's BadAccess (spec § "Divergence from Xorg").
+        let mut body = vec![0u8; 4];
+        body[0..4].copy_from_slice(&0x0010_0001u32.to_le_bytes());
+        process_request(
+            &mut state,
+            &mut backend,
+            ClientId(2),
+            SequenceNumber(1),
+            RequestHeader {
+                opcode: 147,
+                data: 11,
+                length_units: 2,
+            },
+            &body,
+            None,
+        )
+        .unwrap();
+        peer_b.set_nonblocking(true).unwrap();
+        let mut buf = [0u8; 32];
+        peer_b.read_exact(&mut buf).unwrap();
+        assert_eq!(
+            read_error(&buf),
+            x11::error::BAD_VALUE,
+            "FreeSyncobj of another client's syncobj must be BadValue",
+        );
+
+        // A still owns it (ImportSyncobj is a void request — nothing to read
+        // on A's socket; the ownership assertion is the whole check).
+        assert!(backend.dri3_syncobj_owners.contains_key(&0x0010_0001));
+    }
+```
+
+`PresentPixmapSynced` tests need a window + pixmap, so they follow the shape
+of `present_pixmap_synced_update_region_emits_damage_on_destination_window`
+(`:40644`), which also documents the 84-byte body layout. Add a shared body
+builder + setup helper, then three tests:
+
+```rust
+    /// PresentPixmapSynced 84-byte fixed prefix. Offsets per the :40644
+    /// test's comment: window(0) pixmap(4) serial(8) valid(12) update(16)
+    /// x_off(20) y_off(22) target_crtc(24) acquire_syncobj(28)
+    /// release_syncobj(32) acquire_point(36) release_point(44) options(52)
+    /// pad(56) target_msc(60) divisor(68) remainder(76).
+    fn pixmap_synced_body(
+        window: u32,
+        pixmap: u32,
+        acquire_syncobj: u32,
+        release_syncobj: u32,
+        acquire_point: u64,
+        release_point: u64,
+    ) -> Vec<u8> {
+        let mut body = vec![0u8; 84];
+        body[0..4].copy_from_slice(&window.to_le_bytes());
+        body[4..8].copy_from_slice(&pixmap.to_le_bytes());
+        body[28..32].copy_from_slice(&acquire_syncobj.to_le_bytes());
+        body[32..36].copy_from_slice(&release_syncobj.to_le_bytes());
+        body[36..44].copy_from_slice(&acquire_point.to_le_bytes());
+        body[44..52].copy_from_slice(&release_point.to_le_bytes());
+        body
+    }
+
+    fn dispatch_pixmap_synced(
+        state: &mut ServerState,
+        backend: &mut RecordingBackend,
+        body: &[u8],
+    ) {
+        process_request(
+            state,
+            backend,
+            ClientId(17),
+            SequenceNumber(1),
+            RequestHeader {
+                opcode: 145,
+                data: yserver_protocol::x11::present::PIXMAP_SYNCED,
+                length_units: u32::try_from(1 + body.len() / 4).unwrap(),
+            },
+            body,
+            None,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn present_pixmap_synced_unknown_acquire_syncobj_is_bad_value() {
+        use yserver_protocol::x11::{ClientId, CreatePixmapRequest, CreateWindowRequest};
+        const WINDOW_XID: u32 = 0x00e0_0403;
+        const PIXMAP_XID: u32 = 0x00e0_0404;
+        const ACQUIRE_SYNCOBJ: u32 = 0x00e0_0bad; // never imported
+        const RELEASE_SYNCOBJ: u32 = 0x00e0_0408;
+
+        let mut state = ServerState::new();
+        let mut peer = install_client(&mut state, 17);
+        let mut backend = RecordingBackend::new();
+        // The release syncobj is a valid, imported resource; the acquire is
+        // NOT. Row 4: an unknown acquire xid must produce a Value error, not
+        // a silent no-reply hang.
+        backend.dri3_syncobj_owners.insert(RELEASE_SYNCOBJ, ClientId(17));
+
+        state.resources.create_window(
+            ClientId(17),
+            CreateWindowRequest {
+                depth: 24,
+                window: ResourceId(WINDOW_XID),
+                parent: ROOT_WINDOW,
+                x: 0,
+                y: 0,
+                width: 800,
+                height: 600,
+                border_width: 0,
+                class: 1,
+                visual: crate::resources::ROOT_VISUAL,
+                ..Default::default()
+            },
+        );
+        let _ = state.resources.map_window(ResourceId(WINDOW_XID));
+        if let Some(w) = state.resources.window_mut(ResourceId(WINDOW_XID)) {
+            w.host_xid = crate::backend::WindowHandle::from_raw(0x400403);
+        }
+        state.resources.create_pixmap(
+            ClientId(17),
+            CreatePixmapRequest {
+                depth: 24,
+                pixmap: ResourceId(PIXMAP_XID),
+                drawable: ResourceId(WINDOW_XID),
+                width: 800,
+                height: 600,
+            },
+        );
+        let _ = state.resources.set_pixmap_host_xid(
+            ResourceId(PIXMAP_XID),
+            crate::backend::PixmapHandle::from_raw(0x400404).expect("valid host pixmap"),
+        );
+
+        dispatch_pixmap_synced(
+            &mut state,
+            &mut backend,
+            &pixmap_synced_body(WINDOW_XID, PIXMAP_XID, ACQUIRE_SYNCOBJ, RELEASE_SYNCOBJ, 1, 1),
+        );
+
+        peer.set_nonblocking(true).unwrap();
+        let mut buf = [0u8; 32];
+        peer.read_exact(&mut buf).unwrap();
+        assert_eq!(
+            read_error(&buf),
+            x11::error::BAD_VALUE,
+            "unknown acquire syncobj must be BadValue, not a silent no-reply wait",
+        );
+    }
+
+    #[test]
+    fn present_pixmap_synced_zero_point_is_bad_value() {
+        use yserver_protocol::x11::ClientId;
+        const WINDOW_XID: u32 = 0x00e0_0403;
+        const PIXMAP_XID: u32 = 0x00e0_0404;
+        const SYNCOBJ: u32 = 0x00e0_0407;
+
+        let mut state = ServerState::new();
+        let mut peer = install_client(&mut state, 17);
+        let mut backend = RecordingBackend::new();
+        backend.dri3_syncobj_owners.insert(SYNCOBJ, ClientId(17));
+
+        // Both syncobjs imported; acquire_point == 0 is the violation.
+        dispatch_pixmap_synced(
+            &mut state,
+            &mut backend,
+            &pixmap_synced_body(WINDOW_XID, PIXMAP_XID, SYNCOBJ, SYNCOBJ, 0, 2),
+        );
+
+        peer.set_nonblocking(true).unwrap();
+        let mut buf = [0u8; 32];
+        peer.read_exact(&mut buf).unwrap();
+        assert_eq!(read_error(&buf), x11::error::BAD_VALUE, "acquire_point 0 must be BadValue");
+    }
+
+    #[test]
+    fn present_pixmap_synced_acquire_gte_release_is_bad_value() {
+        use yserver_protocol::x11::ClientId;
+        const WINDOW_XID: u32 = 0x00e0_0403;
+        const PIXMAP_XID: u32 = 0x00e0_0404;
+        const SYNCOBJ: u32 = 0x00e0_0407;
+
+        let mut state = ServerState::new();
+        let mut peer = install_client(&mut state, 17);
+        let mut backend = RecordingBackend::new();
+        backend.dri3_syncobj_owners.insert(SYNCOBJ, ClientId(17));
+
+        // Same syncobj for acquire and release: acquire_value >=
+        // release_value is the violation.
+        dispatch_pixmap_synced(
+            &mut state,
+            &mut backend,
+            &pixmap_synced_body(WINDOW_XID, PIXMAP_XID, SYNCOBJ, SYNCOBJ, 5, 5),
+        );
+
+        peer.set_nonblocking(true).unwrap();
+        let mut buf = [0u8; 32];
+        peer.read_exact(&mut buf).unwrap();
+        assert_eq!(
+            read_error(&buf),
+            x11::error::BAD_VALUE,
+            "acquire_value >= release_value on the same syncobj must be BadValue",
+        );
+    }
+```
+
+Note the `zero_point` and `acquire_gte_release` tests do not set up a window
+or pixmap: the syncobj validation runs before the window-existence checks in
+the handler, so the Value error fires first. The `unknown_acquire` test sets
+up a fully valid window + pixmap to prove the error fires even for an
+otherwise-valid request — that is the real-client shape of row 4.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p yserver-core --lib`
+Expected: FAIL to compile. The new tests reference `dri3_syncobj_owners`
+(added in Step 4) and the conformance error paths (Step 5-7), so the whole
+`#[cfg(test)]` target breaks. A `cargo test <filter>` would not help — the
+compile error fires before any test selection, so naming `import_syncobj_`,
+`free_syncobj_` or `present_pixmap_synced_` changes nothing; run without a
+filter.
+
+- [ ] **Step 3: Give the registry an owning client**
+
+Change the field added in Task 2 Step 4 (`backend.rs`, after the
+`dri3_sync_resources` field at `:805`):
+
+```rust
+    /// DRI3 1.4 syncobj resources keyed by the client's xid, imported by
+    /// `ImportSyncobj`. The tuple's first element is the importing client —
+    /// Xorg models a DRI3 syncobj as a first-class X resource owned by a
+    /// client (`dri3_syncobj_type = CreateNewResourceType(...)`), and every
+    /// conformance property in the spec's table falls out of that one
+    /// decision: `FreeSyncobj` ownership, the disconnect purge, and the
+    /// `PresentPixmapSynced` xid checks.
+    pub(crate) dri3_syncobjs:
+        HashMap<u32, (yserver_protocol::x11::ClientId, std::sync::Arc<crate::kms::render::imported_syncobj::ImportedSyncobj>)>,
+```
+
+This changes the shape every Task 2 method used. Update them in Step 5 and the
+tests in Step 9 within this task (single commit — see the task intro).
+
+- [ ] **Step 4: Add syncobj tracking to `RecordingBackend`**
+
+`RecordingBackend` (`crates/yserver-core/src/backend/recording.rs`) drives the
+wire-level tests. Add a field and a private handle type, plus overrides for the
+four syncobj methods:
+
+```rust
+    /// Minimal DRI3 syncobj registry for wire-level tests: xid -> owning
+    /// client. Backed by a dummy `SyncobjHandle` so `dri3_syncobj_handle` has
+    /// something to return.
+    pub(crate) dri3_syncobj_owners: std::collections::HashMap<u32, yserver_protocol::x11::ClientId>,
+```
+
+```rust
+#[derive(Debug)]
+struct DummySyncobjHandle;
+
+impl crate::backend::SyncobjHandle for DummySyncobjHandle {
+    fn signal(&self, _value: u64) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+```
+
+And the overrides (next to the existing `dri3_signal_syncobj` override). The
+`dri3_capabilities` override is REQUIRED: the `IMPORT_SYNCOBJ` /
+`FREE_SYNCOBJ` handlers gate on `caps.syncobj` and would otherwise return
+`BadImplementation` before the conformance code runs:
+
+```rust
+    fn dri3_capabilities(&self) -> crate::backend::Dri3Caps {
+        crate::backend::Dri3Caps {
+            version: (1, 4),
+            modifiers: false,
+            fence_fd: false,
+            syncobj: true,
+        }
+    }
+
+    fn dri3_import_syncobj(
+        &mut self,
+        client_id: yserver_protocol::x11::ClientId,
+        syncobj_xid: u32,
+        _fd: std::os::fd::OwnedFd,
+    ) -> std::io::Result<()> {
+        self.dri3_syncobj_owners.insert(syncobj_xid, client_id);
+        Ok(())
+    }
+
+    fn dri3_free_syncobj(
+        &mut self,
+        client_id: yserver_protocol::x11::ClientId,
+        syncobj_xid: u32,
+    ) -> std::io::Result<()> {
+        // One code on the wire — BadValue — for both unknown and not-owner.
+        // Deliberately not Xorg's BadValue/BadAccess split (spec § "Divergence
+        // from Xorg"): the ownership ENFORCEMENT is what matters, the code is
+        // cosmetic and no client branches on it.
+        if self.dri3_syncobj_owners.get(&syncobj_xid) != Some(&client_id) {
+            return Err(std::io::Error::other(format!(
+                "DRI3 FreeSyncobj: unknown or not the owning client (0x{syncobj_xid:x})"
+            )));
+        }
+        self.dri3_syncobj_owners.remove(&syncobj_xid);
+        Ok(())
+    }
+
+    fn dri3_syncobj_handle(
+        &self,
+        syncobj_xid: u32,
+    ) -> Option<std::sync::Arc<dyn crate::backend::SyncobjHandle>> {
+        self.dri3_syncobj_owners
+            .contains_key(&syncobj_xid)
+            .then(|| std::sync::Arc::new(DummySyncobjHandle) as std::sync::Arc<dyn crate::backend::SyncobjHandle>)
+    }
+```
+
+Note `dri3_syncobj_handle` returning a fresh `DummySyncobjHandle` per call means
+the deferred-completion pinning test does not apply to `RecordingBackend`; the
+ownership and error-semantics tests are what this backend is for.
+
+- [ ] **Step 5: Thread `client_id` through the trait and the KmsBackend impl**
+
+In `trait_def.rs`, change the signatures and docs of `dri3_import_syncobj`
+(`:2045`) and `dri3_free_syncobj` (`:2054`) to take
+`client_id: yserver_protocol::x11::ClientId` first. Update the default bodies
+to keep returning `Err(...)` and keep the doc comment noting the resource is
+owned by `client_id`.
+
+In `backend.rs`:
+
+- `dri3_import_syncobj`: store the owner with the resource, and `Err` on a
+  duplicate xid still owned (the handler already rejected out-of-range /
+  in-use xids; the backend re-checks for a racing duplicate):
+
+```rust
+    fn dri3_import_syncobj(
+        &mut self,
+        client_id: yserver_protocol::x11::ClientId,
+        syncobj_xid: u32,
+        fd: std::os::fd::OwnedFd,
+    ) -> io::Result<()> {
+        use std::os::fd::AsFd;
+
+        let render_node = self.platform.render_node_device.as_ref().cloned().ok_or_else(
+            || io::Error::other("DRI3 ImportSyncobj: render node not resolved at init"),
+        )?;
+        let imported = crate::kms::render::imported_syncobj::ImportedSyncobj::import(
+            render_node,
+            fd.as_fd(),
+        )?;
+        // Arc Drop on any replaced entry destroys the previous handle.
+        let _ = self
+            .dri3_syncobjs
+            .insert(syncobj_xid, (client_id, std::sync::Arc::new(imported)));
+        Ok(())
+    }
+```
+
+- `dri3_free_syncobj`: enforce ownership, one `io::Error` for both failure
+  cases. The handler maps it to yserver's single `BadValue` code (divergence
+  from Xorg's BadValue/BadAccess split):
+
+```rust
+    fn dri3_free_syncobj(
+        &mut self,
+        client_id: yserver_protocol::x11::ClientId,
+        syncobj_xid: u32,
+    ) -> io::Result<()> {
+        let Some((owner, _)) = self.dri3_syncobjs.get(&syncobj_xid) else {
+            return Err(io::Error::other(format!(
+                "DRI3 FreeSyncobj: unknown syncobj 0x{syncobj_xid:x}"
+            )));
+        };
+        if *owner != client_id {
+            return Err(io::Error::other(format!(
+                "DRI3 FreeSyncobj: 0x{syncobj_xid:x} owned by another client"
+            )));
+        }
+        // Arc Drop destroys the DRM handle when the last reference goes away,
+        // which may be later than this call: the deferred completion path
+        // pins clones past FreeSyncobj.
+        let _ = self.dri3_syncobjs.remove(&syncobj_xid);
+        Ok(())
+    }
+```
+
+- `dri3_signal_syncobj` and `dri3_syncobj_handle` now index into the tuple:
+
+```rust
+    fn dri3_signal_syncobj(&mut self, syncobj_xid: u32, value: u64) -> io::Result<()> {
+        use yserver_core::backend::SyncobjHandle as _;
+
+        let arc = self.dri3_syncobjs.get(&syncobj_xid).map(|(_, arc)| arc).ok_or_else(|| {
+            io::Error::other(format!(
+                "DRI3 SignalSyncobj: unknown syncobj 0x{syncobj_xid:x}"
+            ))
+        })?;
+        arc.signal(value)
+    }
+
+    fn dri3_syncobj_handle(
+        &self,
+        syncobj_xid: u32,
+    ) -> Option<std::sync::Arc<dyn yserver_core::backend::SyncobjHandle>> {
+        self.dri3_syncobjs
+            .get(&syncobj_xid)
+            .map(|(_, arc)| arc.clone())
+            .map(|arc| arc as std::sync::Arc<dyn yserver_core::backend::SyncobjHandle>)
+    }
+```
+
+- `arm_present_syncobj_wait` (the acquire path from Task 2 Step 7) is a FIFTH
+  consumer of the registry and MUST be updated in this same task, or `cargo
+  test -p yserver --lib` fails to compile: with the tuple type, Task 2 Step 7's
+  `.get(&acquire_syncobj).cloned()` yields `(ClientId, Arc<ImportedSyncobj>)`,
+  so `syncobj.signaled_eventfd(...)` and `syncobj_pin` both stop typing.
+  Change the lookup to unwrap the tuple, leaving the rest of the block intact:
+
+```rust
+            let syncobj = self
+                .dri3_syncobjs
+                .get(&acquire_syncobj)
+                .map(|(_, arc)| arc.clone())
+                .ok_or_else(|| {
+                    io::Error::other(format!(
+                        "PresentPixmapSynced: unknown acquire syncobj 0x{acquire_syncobj:x}"
+                    ))
+                })?;
+```
+
+- [ ] **Step 6: Add the four error paths in the request handlers**
+
+In `process_request.rs` `IMPORT_SYNCOBJ` (`:11457`), immediately AFTER the
+parse guard (the check reads `req.syncobj`), add the XID validation (row 1)
+using the repo's existing `LEGAL_NEW_RESOURCE` equivalents
+(`xid_out_of_client_range` `:20797`, `resources.xid_in_use`):
+
+```rust
+            if xid_out_of_client_range(state, client_id, req.syncobj)
+                || state.resources.xid_in_use(ResourceId(req.syncobj))
+            {
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    x11::error::BAD_ALLOC,
+                    req.syncobj,
+                    u16::from(header.data),
+                    DRI3_MAJOR_OPCODE,
+                );
+            }
+```
+
+`xid_out_of_client_range` is a free fn in this file's non-test module — if it
+is `#[cfg(test)]`-only today, promote it (it is used by the colormap handler at
+`:20816`, so it is already live). Place the check between the parse guard and
+the `attached_fd` check. Note the code is yserver's own `BadAlloc`, NOT Xorg's
+`BadIDChoice` — spec § "Divergence from Xorg".
+
+Row 2 — keep the missing-fd branch at `BadAlloc` (already what yserver emits at
+`:11483-11491`). Xorg uses `BadValue` for `fd < 0`; yserver deliberately does
+not (spec § "Divergence from Xorg"). The branch stays as-is:
+
+```rust
+            let Some(fd) = attached_fd else {
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    x11::error::BAD_ALLOC,
+                    req.syncobj,
+                    u16::from(header.data),
+                    DRI3_MAJOR_OPCODE,
+                );
+            };
+```
+
+Pass the client id into the import (Step 5 signature):
+
+```rust
+            if let Err(e) = backend.dri3_import_syncobj(client_id, req.syncobj, fd) {
+                debug!(
+                    "client {} #{} DRI3::ImportSyncobj 0x{:x} -> BadAlloc ({e})",
+                    client_id.0, sequence.0, req.syncobj
+                );
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    x11::error::BAD_ALLOC,
+                    req.syncobj,
+                    u16::from(header.data),
+                    DRI3_MAJOR_OPCODE,
+                );
+            }
+```
+
+In `FREE_SYNCOBJ` (`:11507`), replace the warn-only branch with an error
+mapping (row 3). One code — `BadValue` — for both unknown and not-owner,
+deliberately not Xorg's BadValue/BadAccess split (spec § "Divergence from
+Xorg"; the ownership enforcement is what protects, the code is cosmetic):
+
+```rust
+            if let Err(e) = backend.dri3_free_syncobj(client_id, syncobj) {
+                debug!(
+                    "client {} #{} DRI3::FreeSyncobj 0x{:x} -> BadValue ({e})",
+                    client_id.0, sequence.0, syncobj
+                );
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    x11::error::BAD_VALUE,
+                    syncobj,
+                    u16::from(header.data),
+                    DRI3_MAJOR_OPCODE,
+                );
+            }
+```
+
+The `debug!` in the replacement is the only log line on this path — the
+current `FREE_SYNCOBJ` handler has no success-path `debug!` (its only log was
+the old `(warn: {e})` in the error branch, which the replacement absorbs). Do
+not invent a success-path log here; the wire tests assert the error, and
+`docs/status.md`/PR observability for `FreeSyncobj` is out of this task's
+scope.
+
+- [ ] **Step 7: Add `PresentPixmapSynced` validation (row 4)**
+
+In the `PIXMAP_SYNCED` handler (`:10067`), immediately after the existing
+divisor/remainder `BadValue` check, add the explicit-sync conformance. Per
+presentproto 1.4 §7 (`present_request.c:296-302`): both syncobjs must be
+non-None and previously imported, both points non-zero, and `acquire <
+release` when they name the same syncobj — each violation is a `Value` error,
+never a silent no-reply wait:
+
+```rust
+            let acquire_known = req.acquire_syncobj != 0
+                && backend.dri3_syncobj_handle(req.acquire_syncobj).is_some();
+            let release_known = req.release_syncobj != 0
+                && backend.dri3_syncobj_handle(req.release_syncobj).is_some();
+            if !acquire_known
+                || !release_known
+                || req.acquire_value == 0
+                || req.release_value == 0
+                || (req.acquire_syncobj == req.release_syncobj
+                    && req.acquire_value >= req.release_value)
+            {
+                return emit_x11_error_with_minor(
+                    state,
+                    client_id,
+                    sequence,
+                    x11::error::BAD_VALUE,
+                    0,
+                    u16::from(header.data),
+                    PRESENT_MAJOR_OPCODE,
+                );
+            }
+```
+
+This runs before `arm_present_syncobj_wait` (`:10251`), so a bad xid can no
+longer reach the arm path that previously errored out of the handler with no
+reply. Confirm `dri3_syncobj_handle` is callable on `&mut dyn Backend` here
+(it is a `&self` trait method).
+
+- [ ] **Step 8: Purge a client's syncobjs on disconnect**
+
+The registry now owns its entries, so the disconnect leak closes. Hook the
+existing `client_disconnected` backend entry point (`backend.rs:14361`, called
+from `process_disconnect.rs:474`):
+
+```rust
+    fn client_disconnected(&mut self, client_id: yserver_protocol::x11::ClientId) {
+        self.dri3_syncobjs.retain(|_, (owner, _)| *owner != client_id);
+        self.scene.root_overlay_on_disconnect(client_id);
+    }
+```
+
+Add a unit test in `backend.rs` (needs a real DRM handle to build
+`ImportedSyncobj`, so it is `#[ignore]` like Task 1's):
+
+```rust
+    #[test]
+    #[ignore = "needs a DRM render node"]
+    fn client_disconnected_purges_owned_syncobjs() {
+        use std::os::fd::AsFd;
+        use yserver_protocol::x11::ClientId;
+
+        // Shared helper from Task 1 — never hardcode renderD128.
+        let Some(drm) = crate::kms::render::imported_syncobj::tests::render_node() else {
+            eprintln!("skipping: no render node");
+            return;
+        };
+        let mk = |value: u64| {
+            let handle = ::drm::control::Device::create_syncobj(drm.as_ref(), false)
+                .expect("create syncobj");
+            let fd = ::drm::control::Device::syncobj_to_fd(drm.as_ref(), handle, false)
+                .expect("export fd");
+            let imported = crate::kms::render::imported_syncobj::ImportedSyncobj::import(
+                drm.clone(),
+                fd.as_fd(),
+            )
+            .expect("import");
+            ::drm::control::Device::destroy_syncobj(drm.as_ref(), handle).expect("destroy");
+            std::sync::Arc::new(imported)
+        };
+
+        let mut b = KmsBackend::for_tests();
+        b.dri3_syncobjs.insert(0x0040_0001, (ClientId(7), mk(1)));
+        b.dri3_syncobjs.insert(0x0040_0002, (ClientId(8), mk(1)));
+
+        yserver_core::backend::Backend::client_disconnected(&mut b, ClientId(7));
+        assert!(
+            b.dri3_syncobjs.contains_key(&0x0040_0002),
+            "another client's syncobj must survive the disconnect",
+        );
+        assert!(
+            !b.dri3_syncobjs.contains_key(&0x0040_0001),
+            "the disconnecting client's syncobj must be purged",
+        );
+    }
+```
+
+**Retain-mode divergence, recorded:** `client_disconnected` is called
+unconditionally by `process_disconnect`, which does not pass the close mode, so
+a `RetainPermanent` client's syncobjs are purged too — Xorg would keep them.
+This is a documented divergence, not a regression: a retained DRI3 1.4 client
+(essentially nonexistent in practice) loses its syncobjs at disconnect, and
+fixing it would require threading `close_mode` into `client_disconnected`, out
+of scope here.
+
+- [ ] **Step 9: Fix the tests from Tasks 2 that the type change breaks**
+
+- `syncobj_handle_accessor_returns_arc_clone` (`backend.rs:30010`) — the map
+  now stores tuples; update the two `.insert(...)` calls to
+  `(yserver_protocol::x11::ClientId(1), std::sync::Arc::new(...))`.
+- `each_resolver_sees_only_its_own_registry` (Task 2 Step 1) — same insert
+  shape change.
+- `dri3_import_syncobj_errs_without_a_usable_drm_handle` (`:28065`, rewritten
+  in Task 2) — the signature now takes `client_id` first; add
+  `yserver_protocol::x11::ClientId(1)`.
+- The wire tests in Step 1 must now pass (they exercised the new paths).
+
+- [ ] **Step 10: Run the tests**
+
+```bash
+cargo test -p yserver --lib
+cargo test -p yserver-core --lib
+cargo test -p yserver --lib -- --ignored
+```
+Expected: PASS on all three.
+
+- [ ] **Step 11: Format, lint, commit**
+
+```bash
+cargo +nightly fmt
+cargo clippy --all-targets -- -D warnings
+git add crates/yserver-core/src/backend/trait_def.rs crates/yserver-core/src/backend/recording.rs crates/yserver-core/src/core_loop/process_request.rs crates/yserver/src/kms/render/backend.rs
+git commit -m "feat(dri3): own syncobjs per client with error semantics
+
+The spec scoped this in as the minimum that makes DRI3 1.4 safe to
+advertise: a client can currently free another client's syncobj, and
+PresentPixmapSynced with an unknown acquire syncobj gets no reply and no
+error — a silent hang indistinguishable from a server crash.
+
+The registry now carries the importing client. ImportSyncobj validates the
+xid and the fd (BadAlloc); FreeSyncobj enforces ownership (BadValue); and
+PresentPixmapSynced verifies both syncobjs and the point ordering per
+presentproto 1.4 (Value errors). Error codes deliberately diverge from
+Xorg's BadIDChoice/BadAccess: the protocol is silent there and no client
+branches on the distinction (spec 'Divergence from Xorg'). client_disconnected
+purges the owning client's syncobjs, closing the teardown leak."
+```
+
+---
+
+### Task 4: Strip the syncobj half out of `OwnedSemaphore`
 
 **Files:**
 - Modify: `crates/yserver/src/kms/render/owned_semaphore.rs`
@@ -863,6 +1881,7 @@ impl Drop for OwnedSemaphore {
 `signal_vk` goes too. Its only callers were `dri3_signal_syncobj` (rewritten in
 Task 2) and `impl SyncobjHandle for OwnedSemaphore` (deleted here), so keeping
 it would be `dead_code` and fail `clippy --all-targets -- -D warnings`.
+`for_tests_dummy` was already removed in Task 2 Step 10.
 
 - [ ] **Step 2: Decide the fate of `signal_timeline`**
 
@@ -927,11 +1946,11 @@ fd is a Mesa-only accident, not a portable interop path."
 
 ---
 
-### Task 4: Derive the capability from the kernel, not the driver
+### Task 5: Derive the capability from the kernel, not the driver
 
 **Files:**
 - Modify: `crates/yserver/src/kms/render/backend.rs:18967-18992`
-  (`dri3_capabilities`) and the test at `:27891-27935`
+  (`dri3_capabilities`) and the test at `:27892-27935`
 - Modify: `crates/yserver/src/kms/render/platform.rs` (cache field)
 - Modify: `crates/yserver/src/kms/vk/device.rs:78-89` (delete the blacklist and
   its doc comment)
@@ -943,12 +1962,12 @@ fd is a Mesa-only accident, not a portable interop path."
 - [ ] **Step 1: Cache the capability at init**
 
 `dri3_capabilities()` is called once per DRI3 request
-(`process_request.rs:10873`) and by `present_capabilities()`
-(`backend.rs:19611`) on every Present `QueryCapabilities`. Today that is an
+(`process_request.rs:10875`) and by `present_capabilities()`
+(`backend.rs:19604`) on every Present `QueryCapabilities`. Today that is an
 in-memory `driver_id` match; a raw ioctl on that path would be a regression.
 Read it once when the platform is built.
 
-In `PlatformBackend`, next to `render_node_fd`, add:
+In `PlatformBackend`, next to `render_node_device` (Task 2), add:
 
 ```rust
     /// `DRM_CAP_SYNCOBJ_TIMELINE` on the render node, read once at init.
@@ -958,16 +1977,34 @@ In `PlatformBackend`, next to `render_node_fd`, add:
     pub(crate) syncobj_timeline: bool,
 ```
 
-Populate it where `render_node_fd` is resolved, querying **the render node**,
-not the KMS node: DRI3 hands clients the render node, and on split-device
-boxes (Pi 4 vc4/v3d, Asahi apple-drm/AGX) the display device's answer says
-nothing about the render device's. Set `false` when there is no render node.
+Populate it in `from_platform_init` right where `render_node_device` is built,
+querying **the render node** (the same `Device` the syncobj ioctls run on — the
+spec's one-device invariant), not the KMS node:
+
+```rust
+        let syncobj_timeline = render_node_device
+            .as_ref()
+            .and_then(|d| {
+                use ::drm::Device as _;
+                d.get_driver_capability(::drm::DriverCapability::TimelineSyncObj)
+                    .ok()
+            })
+            .is_some_and(|v| v != 0);
+```
+
+Add `syncobj_timeline: false,` to `PlatformBackend::for_tests()` (`:1007`).
+`get_driver_capability` lives on the `drm::Device` ROOT trait, not on
+`drm::control::Device` — see `cursor_plane.rs:30-34`, which imports
+`Device as DrmDevice` from the external `drm` crate. Note the path:
+`crate::drm` is yserver's wrapper module, so the trait and
+`DriverCapability::TimelineSyncObj` (at `drm` `lib.rs:309`) must be reached
+via the extern-crate path `::drm::…`, exactly as `cursor_plane.rs` does.
 
 - [ ] **Step 2: Write the failing test**
 
-The old test asserted `caps.syncobj == supports_dri3_syncobj()`, a tautology
-against the blacklist. Replace it with one that pins the real mapping. Add to
-the tests module in `backend.rs`:
+The old test (`:27892`) asserted `caps.syncobj == supports_dri3_syncobj()`, a
+tautology against the blacklist. Replace it with one that pins the real
+mapping. Add to the tests module in `backend.rs`:
 
 ```rust
 /// DRI3 version follows syncobj support, and syncobj support follows the
@@ -1006,13 +2043,20 @@ fn dri3_version_for(syncobj: bool) -> (u32, u32) {
 }
 ```
 
-Replace the body of `dri3_capabilities`:
+Replace the body of `dri3_capabilities` (the availability guard now keys on
+`render_node_device` — the same retained device the capability and every
+syncobj ioctl use — not the bare `render_node_fd`; both are populated from the
+same `render_node_path` in `from_platform_init`, but the device is the single
+source of truth for this branch):
 
 ```rust
     fn dri3_capabilities(&self) -> Dri3Caps {
-        // DRI3 entirely unavailable when render-node fd or Vulkan weren't
-        // resolved at backend init: pixmap import/export still needs both.
-        if self.platform.render_node_fd.is_none() || self.platform.vk.is_none() {
+        // DRI3 entirely unavailable when the render-node device or Vulkan
+        // weren't resolved at backend init: pixmap import/export still needs
+        // both. `render_node_device` is the guard here (not the bare
+        // `render_node_fd`) because it is what the syncobj ioctls and the
+        // capability query run on.
+        if self.platform.render_node_device.is_none() || self.platform.vk.is_none() {
             return Dri3Caps::unsupported();
         }
         let vk = self.platform.vk.as_ref().expect("vk Some by branch above");
@@ -1034,20 +2078,16 @@ Replace the body of `dri3_capabilities`:
     }
 ```
 
-**Trait path warning for Step 1's query:** `get_driver_capability` lives on the
-`drm::Device` ROOT trait, not on `drm::control::Device`, which this file already
-imports for the syncobj calls. `crates/yserver/src/kms/cursor_plane.rs:30-34`
-shows the distinction — it imports `Device as DrmDevice` alongside
-`control::{Device as ControlDevice, …}`. `DriverCapability::TimelineSyncObj`
-is at `drm` `lib.rs:309`; `get_driver_capability` returns `io::Result<u64>`, so
-`.is_ok_and(|v| v != 0)` is the test.
+The capability and the ioctls now both come from `render_node_device` — the
+render node — so the spec's one-device invariant holds by construction (Task 2
+Step 3 + this step).
 
 - [ ] **Step 5: Delete the blacklist and its stale references**
 
 - Delete `supports_dri3_syncobj` and its doc comment from
   `crates/yserver/src/kms/vk/device.rs:78-89`. **This is a compile error in the
-  test target** until Step 2's replacement lands — `backend.rs:27926-27929`
-  called it. Removing it is not optional and `--all-targets` will catch it.
+  test target** until Step 2's replacement lands — `backend.rs:27928` called
+  it. Removing it is not optional and `--all-targets` will catch it.
 - `backend.rs:1049` carries a doc comment citing
   `VkContext::supports_dri3_syncobj`. Update it to name the kernel capability.
 
@@ -1075,12 +2115,13 @@ driver. It stops being the right question once nothing imports them.
 
 The capability now comes from DRM_CAP_SYNCOBJ_TIMELINE on the render
 node, cached at init because dri3_capabilities sits on the per-request
-path."
+path. The capability and every syncobj ioctl run on the same retained
+render-node Device, per the spec's one-device invariant."
 ```
 
 ---
 
-### Task 5: Make the success path observable, then validate on hardware
+### Task 6: Make the success path observable, then validate on hardware
 
 **Files:**
 - Modify: `crates/yserver-core/src/core_loop/process_request.rs:11457-11506`
@@ -1114,16 +2155,66 @@ Only the BadAlloc branch logged, so a working explicit-sync client was
 indistinguishable from no client at all."
 ```
 
-- [ ] **Step 2: Capture**
+- [ ] **Step 2: IGT GPU Tools — the DRM kernel path, per driver**
+
+IGT GPU Tools is installed on the validation box. Its `syncobj_*` tests
+exercise exactly the ioctl set this change relies on (create/destroy,
+fd↔handle import/export, timeline signal/wait/query, eventfd, transfer)
+straight against the kernel, so they validate the DRM layer independently of
+yserver and of Mesa.
+
+Run as root, with no compositor running (IGT requirement), on the box:
+
+```bash
+# Enumerate the syncobj tests and their subtests first. `igt_list` resolves
+# the actual install path (Fedora: /usr/libexec; Debian: /usr/lib) once, so
+# the run loop below does not need a `||` fallback that would also swallow a
+# genuinely FAILING test as "wrong path" and retry it on the other prefix.
+igt_list=$(ls /usr/libexec/igt-gpu-tools/syncobj_* 2>/dev/null || ls /usr/lib/igt-gpu-tools/syncobj_* 2>/dev/null)
+for t in $igt_list; do echo "== $t =="; "$t" --list-subtests; done
+```
+
+Then run the syncobj suite (all subtests, or `--run-subtest <name>` for one).
+The glob requires at least one match; if `igt_list` is empty, stop and find
+where IGT installed its tests before running anything. Run the two blocks in
+the SAME shell — the run loop reads the `igt_list` the enumeration set:
+
+```bash
+test -n "$igt_list" || { echo "no syncobj_* tests found — locate the IGT install"; exit 1; }
+for t in $igt_list; do echo "== running $t =="; sudo "$t"; done
+```
+
+These tests open a render node themselves (`drm_open_driver_render(DRIVER_ANY)`
+— first render node that matches), so on the two-GPU box they exercise
+`renderD128` (nvidia-drm). Pin the other GPU the same way the spec's probes
+did: if the installed IGT's test binaries accept a device option (check
+`--help`), use it for `renderD129`; otherwise rely on `syncobjprobe.c`
+`/dev/dri/renderD129` (spec Evidence, passes 12/12) for the amdgpu side. Record
+which node each run opened — an IGT run on the wrong GPU is the same
+not-evidence trap as a wrong ICD.
+
+- [ ] **Step 3: Capture the full-Mesa session**
+
+The spec's Risks make two things mandatory: the NVIDIA run is blocked (card0
+has no connected connector), so this is the **full-Mesa** run (yserver and
+client both on RADV/`card1`); and both env overrides are required, or the run
+silently renders on the mismatched pair and proves nothing:
 
 ```bash
 # The wire-level DRI3/PRESENT debug lines live on the default target, so
 # present_pace alone is NOT enough -- process_request must be included.
+# The two env overrides are the spec's mandatory pair (VK_ICD_FILENAMES is
+# not optional) -- a run that omits them is not evidence about Mesa.
+YSERVER_DRM_DEVICE=/dev/dri/card1 \
+VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/radeon_icd.x86_64.json \
 just yserver-mate-hw "info,present_pace=debug,yserver_core::core_loop::process_request=debug"
+```
 
-# inside the session, forcing the Vulkan X11 WSI. It must be Vulkan, not GL:
-# docs/status.md:4063 records NVIDIA's libGL failing to bind DRI3 against
-# yserver for unrelated reasons, so a GL client cannot answer either way.
+inside the session, forcing the Vulkan X11 WSI. It must be Vulkan, not GL:
+`docs/status.md:4063` records NVIDIA's libGL failing to bind DRI3 against
+yserver for unrelated reasons, so a GL client cannot answer either way:
+
+```bash
 mpv --gpu-api=vulkan --vo=gpu-next --gpu-context=x11vk \
     --length=15 av://lavfi:testsrc=size=1280x720:rate=60
 ```
@@ -1136,37 +2227,53 @@ desktop session:
 cp yserver-hw-mate.log dri3-syncobj-$(date +%Y%m%d).log
 ```
 
-- [ ] **Step 3: Check what must appear**
+- [ ] **Step 4: Check what must appear**
 
 ```bash
 LOG=dri3-syncobj-<date>.log
-grep -c "DRI3::QueryVersion.*-> 1.4" "$LOG"      # server advertises 1.4
-grep -c "DRI3::ImportSyncobj.*-> imported" "$LOG" # client takes the path
-grep -c "present acquire" "$LOG"                  # acquires resolve
-grep -c "unknown syncobj" "$LOG"                  # freed-syncobj replay
+grep -c "DRI3::QueryVersion.*-> 1.4" "$LOG"         # server advertises 1.4
+grep -c "DRI3::ImportSyncobj.*-> imported" "$LOG"    # client takes the path
+grep -c "stage=acquire_deferred" "$LOG"              # deferred acquires (merge gate)
+grep -c "stage=acquire_ready" "$LOG"                 # acquires that were already ready
+grep -c "unknown syncobj" "$LOG"                     # freed-syncobj replay
+grep -c "DRM eventfd unavailable" "$LOG"             # must be 0: no fallback
 ```
 
-The last one is the freed-syncobj bookkeeping bug (`docs/status.md:548`)
-becoming reachable, not a regression from this change — that path fails at the
-registry miss and never reaches an ioctl, with identical text before and after.
-Record the count; do not fix it. Note there is deliberately **no** check for a
-failed release signal: the kernel clamps stale points and returns success, so
-out-of-order releases are silent by construction.
+The **merge gate is non-zero deferrals, not just the imports.** Per the spec's
+Testing §4, a run with zero deferrals proves nothing — the acquire points were
+already met and the release path was never exercised under contention. The
+`present_pace` instrument logs each deferred acquire as `PACE-INSTR ...
+stage=acquire_deferred` (`process_request.rs:10265`) and each already-ready
+one as `stage=acquire_ready` (`:9474`); require `stage=acquire_deferred` to be
+`> 0`, and require `DRM eventfd unavailable` to be `0` (no fallback warning).
+Compare against the recorded baseline (2,221 requests / 473 deferred / 0.87 ms
+mean) as a shape, not a threshold — the iGPU is 2 CUs against a 6900HX, so
+absolute timings differ; what must match is the invariant (every deferred
+acquire eventually signals, no fallback warning).
 
-- [ ] **Step 4: Update `docs/status.md`**
+`unknown syncobj` is the freed-syncobj bookkeeping bug
+(`docs/status.md:548`) becoming reachable, not a regression from this change —
+that path fails at the registry miss and never reaches an ioctl, with identical
+text before and after. Record the count; do not fix it. Note there is
+deliberately **no** check for a failed release signal: the kernel clamps stale
+points and returns success, so out-of-order releases are silent by
+construction.
+
+- [ ] **Step 5: Update `docs/status.md`**
 
 Record: the capability now deriving from `DRM_CAP_SYNCOBJ_TIMELINE` on the
-render node; the counts from Step 3; and amend the claim at **`docs/status.md:297`**
-that `PresentPixmapSynced` is "structurally untestable on this box", which named
+render node; the counts from Step 4 (including the IGT results per node from
+Step 2); and amend the claim at **`docs/status.md:297`** that
+`PresentPixmapSynced` is "structurally untestable on this box", which named
 this exact gate. Verify that line number before editing — this plan's first
 draft had it as `:316`, read from a different branch.
 
-- [ ] **Step 5: Flip the spec's status line**
+- [ ] **Step 6: Flip the spec's status line**
 
 Change `**Status:** DESIGN (2026-08-08)` to `IMPLEMENTED`, with the hardware
 result and the box, following `2026-07-20-nvidia-gbm-scanout-allocation.md`.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
 git add docs/status.md docs/superpowers/specs/2026-08-08-dri3-syncobj-drm-signal-design.md
@@ -1177,19 +2284,24 @@ git commit -m "docs(dri3): record the DRM-signalled syncobj result on hardware"
 
 ## Deferred / out of scope
 
-- **Cross-driver validation.** The Mesa path changes from a Vulkan host signal
-  to a DRM host signal and there is no AMD or Intel GPU on this box. The bee
-  (6900HX / RADV) is where that gets confirmed.
+- **Cross-driver validation on a second box.** The Mesa path changes from a
+  Vulkan host signal to a DRM host signal. The nvidia box now covers both
+  nvidia-drm (IGT `syncobj_*` on `renderD128`) and amdgpu (full-Mesa run +
+  IGT/`syncobjprobe` on `renderD129`), which is the cross-driver evidence the
+  spec's merge gate needs. A second box (the bee, 6900HX / RADV) remains a
+  nice-to-have confirmation, not a blocker.
 - **The freed-syncobj bookkeeping bug** (`docs/status.md:548`). This change
   makes it reachable here; it does not cause it, and it does not make it more
   observable.
-- **No client-teardown purge for `dri3_syncobjs`.** Nothing removes entries
-  except `FreeSyncobj`, so a client that dies with syncobjs imported leaks a
-  DRM handle and the fence chain it pins. Pre-existing in shape, newly exposed
-  in practice.
+- **The retain-mode divergence in Task 3's disconnect purge.** A
+  `RetainPermanent` client's syncobjs are purged at disconnect; Xorg would
+  keep them. `client_disconnected` does not receive the close mode; fixing it
+  would thread `close_mode` through the backend entry point. No practical DRI3
+  1.4 client uses retain mode.
 - **The fail-open arm in `PendingPresentSourceWait::is_ready`.** A failed
   timeline query is treated as ready and the copy proceeds. Unreachable on
-  NVIDIA before this change; live after it.
+  NVIDIA before this change; live after it. Task 6 Step 4's
+  `DRM eventfd unavailable == 0` gate is the tripwire, not a fix.
 - **GPU-side release signalling.** Signalling the client's release point from
   the queue rather than the host would let clients unblock earlier, but it is a
   separate design with its own measurement, and impossible on NVIDIA. The

--- a/docs/superpowers/specs/2026-08-08-dri3-syncobj-drm-signal-design.md
+++ b/docs/superpowers/specs/2026-08-08-dri3-syncobj-drm-signal-design.md
@@ -1,0 +1,272 @@
+# DRI3 1.4 syncobj: signal through DRM, not Vulkan
+
+**Status:** DESIGN (2026-08-08). Hardware evidence gathered on the nvidia box
+(RTX 5060 Ti, driver 610.57.04, kernel 7.1.6-gentoo-dist). Not yet implemented.
+
+**Related:** `2026-05-09-phase4-2-dri3-present-glx-design.md` (§3.3 defined the
+Vulkan route this supersedes), `2026-07-20-nvidia-gbm-scanout-allocation.md`
+(same shape of decision — leaving a Vulkan-native path for the ecosystem-standard
+one), `2026-07-31-present-deferred-execution-supersession-design.md` (its
+`PresentPixmapSynced` branch is the one this unblocks for testing).
+
+**Probes:** `~/yserver-glx-probes/syncobjprobe.c`, `vksyncobjprobe.c`,
+`dri3ver.c`, `syncwatch.c` + `run-syncwatch.sh`.
+
+## Problem
+
+yserver advertises DRI3 1.3 instead of 1.4 on NVIDIA proprietary, so
+`ImportSyncobj`, `FreeSyncobj` and `PresentPixmapSynced` are never offered.
+The cap comes from `supports_dri3_syncobj()`
+(`crates/yserver/src/kms/vk/device.rs:87`), a driver blacklist:
+
+```rust
+!matches!(self.driver_id, vk::DriverId::NVIDIA_PROPRIETARY)
+```
+
+Two costs follow. Clients that want explicit sync silently fall back to the
+1.3 fence path. And the `PresentPixmapSynced` branch of the merged
+deferred-Present design has never run on hardware — `docs/status.md:316`
+records it as *"structurally untestable on this box"*, naming this exact gate.
+
+The gate arrived in commit `8c68a281` (2026-05-20). Its message is one line,
+`Disable DRI3 syncobj on NVIDIA`, with an empty body. No rationale was
+recorded anywhere, so the premise had to be re-measured rather than trusted.
+
+## Evidence
+
+Three measurements, all on the nvidia box, 2026-08-08.
+
+**1. The kernel supports the whole DRM syncobj path.** `syncobjprobe` runs the
+server's exact sequence — `fd_to_syncobj`, `timeline_signal`, cross-handle
+`timeline_wait`, `query`, `eventfd` + signal — and passes 12/12 on both
+`/dev/dri/card0` and `/dev/dri/renderD128`. `DRM_CAP_SYNCOBJ` and
+`DRM_CAP_SYNCOBJ_TIMELINE` are both 1. Two handles imported from one fd alias
+the same payload, which is what makes a server-side signal reach the client.
+
+**2. The Vulkan import genuinely fails.** `vksyncobjprobe` replays
+`import_drm_syncobj` (`crates/yserver/src/kms/vk/sync.rs:58`) byte for byte:
+timeline `VkSemaphore`, `vkImportSemaphoreFdKHR` with
+`VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT`, on a real DRM syncobj fd.
+Result: `VK_ERROR_INITIALIZATION_FAILED`.
+
+The gate's premise was correct. Note that
+`vkGetPhysicalDeviceExternalSemaphoreProperties` reports
+`IMPORTABLE_BIT` set for timeline OPAQUE_FD on this driver — it advertises the
+capability and then rejects the fd. That is not a driver bug: `OPAQUE_FD` is a
+driver-private payload format and the Vulkan spec never promised it is a DRM
+syncobj. Mesa makes the two identical, which is why the path works on RADV.
+**Consequence for the design: there is no capability query that can predict
+this.** Detection must be either a trial import or, as chosen below, a
+question asked of the kernel instead.
+
+**3. A real client on this box is waiting for explicit sync.**
+`libGLX_nvidia.so.0` — which `nvidia_icd.json` also names as the Vulkan ICD —
+carries `xcb_dri3_import_syncobj_checked`, `xcb_dri3_free_syncobj` and
+`xcb_present_pixmap_synced_checked` as strings, resolved through `dlsym` rather
+than linked (which is why an undefined-symbol scan misses them). `syncwatch`
+interposes `dlsym` and confirms the lookups fire at runtime: mpv on Vulkan X11
+WSI against Xwayland `:0` (verified at DRI3 1.4 / Present 1.4 by `dri3ver`)
+resolves the full triad three times, once per swapchain rather than once at
+init.
+
+Residual uncertainty: symbol resolution is not proof of invocation. The
+per-swapchain repetition and the completeness of the triad make use the
+overwhelmingly likely reading, and lifting the gate converts this to direct
+observation of `ImportSyncobj` arriving at the dispatcher.
+
+For contrast, no other installed client takes this path: Mesa 26.0.8
+(`libgallium`) uses `xcb_dri3_fence_from_fd`, the 1.3 route.
+
+## Root cause
+
+The Phase 4.2 design specified the Vulkan route deliberately
+(`2026-05-09-phase4-2-dri3-present-glx-design.md:385-392`):
+
+> `PresentPixmapSynced` (v1.4) `wait_value` / `idle_value` are 64-bit timeline
+> values fed into `VkTimelineSemaphoreSubmitInfo` on the submit.
+
+The point was to wait and signal *inside the queue submit*, keeping the CPU out
+of the loop — something Xorg cannot do and yserver, being a Vulkan compositor,
+could. Importing the client's syncobj into a `VkSemaphore` is what that plan
+required.
+
+**That plan did not survive hardware.** Commit `b92b3dd7` (2026-07-28, round 3
+of three) rewrote the acquire path to *"follow Xorg's non-blocking Copy-path
+ordering"*: a DRM timeline eventfd plus deferral of the copy, with Vulkan
+counter polling only as a fallback. Deferral is what fixed fullscreen mpv; a
+GPU-side wait was not the answer.
+
+The reason it was not the answer still holds. yserver has **one queue**
+(`crates/yserver/src/kms/vk/device.rs:299` — one family, one
+`get_device_queue`), shared between whole-screen compositing and every client.
+A GPU-side wait on a client's acquire point parks that single queue behind that
+client. `b92b3dd7` measured 473 of 2,221 synced presents (21.3%) arriving
+before their acquire point; under a queue wait each of those would have stalled
+the compositor instead of being deferred.
+
+So the imported `VkSemaphore` is left holding no architectural purpose. It
+enters no `queue_submit` anywhere — the only consumers of `.semaphore()` are
+`dri3_fd_from_fence` and two `PresentCompletionSignal` sites, a different type.
+Its one remaining job, the release signal, is `vkSignalSemaphore`, which is a
+**host** operation. It is already a CPU signal.
+
+## Fix
+
+Serve DRI3 syncobjs through the kernel interface that owns them, on every
+driver. Replace `vkSignalSemaphore` with `DRM_IOCTL_SYNCOBJ_TIMELINE_SIGNAL`
+and `vkGetSemaphoreCounterValue` with `DRM_IOCTL_SYNCOBJ_QUERY`, at the same
+call sites. Both replacements are host-side, exactly like what they replace, so
+no ordering guarantee changes.
+
+Everything needed already exists in the `drm` 0.15 crate —
+`syncobj_timeline_signal` (`control/mod.rs:947`), `syncobj_timeline_query`
+(:913), `syncobj_eventfd` (:957), `fd_to_syncobj` (:851). No new ioctl
+plumbing, so the AGENTS.md warning about `libc::Ioctl` typing across
+glibc/musl/FreeBSD does not come into play.
+
+### Components
+
+`dri3_sync_resources` (`crates/yserver/src/kms/render/backend.rs:805`) is today
+a single `HashMap<u32, Arc<OwnedSemaphore>>` serving two unrelated X resource
+types:
+
+| Resource | Registered by | What it actually needs |
+|---|---|---|
+| XSync `Fence` | `FenceFromFD` (:19264) | Vulkan — `FDFromFence` exports a sync_file from the `VkSemaphore` (:19308) |
+| DRI3 `Syncobj` | `ImportSyncobj` (:19373) | No Vulkan — signal, eventfd and query all have DRM ioctls |
+
+The fence half legitimately needs Vulkan, and works on NVIDIA already because
+those semaphores are Vulkan-created rather than imported. So `OwnedSemaphore`
+cannot simply be stripped. Split the types instead:
+
+- **`OwnedSemaphore`** keeps its Vulkan body and serves only
+  `FenceFromFD` / `FDFromFence`. Its `drm_syncobj` field, `signaled_eventfd()`
+  and `timeline_value()` are removed — they existed solely for the syncobj half.
+- **`ImportedSyncobj`** (new module) holds `Arc<crate::drm::Device>` plus a
+  `syncobj::Handle`, and nothing else. It implements `SyncobjHandle::signal`
+  over `syncobj_timeline_signal`, plus `timeline_value()` over
+  `syncobj_timeline_query` and `signaled_eventfd()` over `syncobj_eventfd`. No
+  `Arc<VkContext>`.
+- **`dri3_sync_resources` splits into two typed maps.** Beyond clarity this
+  removes a latent confusion: today `FDFromFence` on a syncobj xid resolves
+  into the same map and half-works.
+- **`present_source_wait.rs:22`** changes `syncobj_pin` from
+  `Arc<OwnedSemaphore>` to `Arc<ImportedSyncobj>`, and the readiness check at
+  :41 moves from `vkGetSemaphoreCounterValue` to `syncobj_timeline_query`.
+- **Deleted:** `import_drm_syncobj` (`vk/sync.rs:58`) and
+  `supports_dri3_syncobj` (`vk/device.rs:87`).
+
+### Capability derivation
+
+`Dri3Caps::syncobj` (`backend.rs:18967`) stops asking the Vulkan driver and
+asks the DRM device: `DriverCapability::TimelineSyncObj` (exposed by the `drm`
+crate at `lib.rs:309`). Version becomes `(1, 4)` when that capability is
+present and `(1, 3)` when it is not.
+
+This is what the Phase 4.2 design already listed as the correct gate — its
+fallback matrix names *"Kernel lacks `DRM_SYNCOBJ` ioctls"* (design:449) as the
+condition for dropping to 1.3. It was simply never implemented that way.
+
+The Present extension's syncobj capability mirrors `Dri3Caps::syncobj`
+(design:470), so it follows automatically — that bit is how a client learns
+`PresentPixmapSynced` is usable, and it must not be advertised without the DRI3
+half.
+
+### Data flow
+
+Unchanged in shape; only the executor of each step differs.
+
+| Step | Today | After |
+|---|---|---|
+| `ImportSyncobj` | `dup` + `fd_to_syncobj` + `import_drm_syncobj` | `fd_to_syncobj` on the borrowed fd |
+| acquire wait | `syncobj_eventfd` on the retained DRM handle | unchanged |
+| acquire fallback | `vkGetSemaphoreCounterValue` | `syncobj_timeline_query` |
+| release signal | `vkSignalSemaphore` | `syncobj_timeline_signal` |
+| `FreeSyncobj` | Arc drop → `destroy_syncobj` + `vkDestroySemaphore` | Arc drop → `destroy_syncobj` |
+
+The `dup` at `backend.rs:19329` disappears: it existed only because
+`vkImportSemaphoreFdKHR` consumes the fd, so a copy was needed for the DRM
+handle. `fd_to_syncobj` takes a `BorrowedFd`.
+
+### Error handling
+
+- Import failure returns `BadAlloc`, preserving current behaviour
+  (`process_request.rs:11500`).
+- Eventfd registration failure still falls through to polling, now via DRM
+  query.
+- A kernel without `TimelineSyncObj` degrades to `Dri3Caps.syncobj = false` and
+  version `(1, 3)` — the same degradation as today, keyed on the kernel rather
+  than on a driver list.
+- DRM timelines require strictly increasing points, as `vkSignalSemaphore`
+  does. Signalling a stale point fails on both. Semantics unchanged.
+
+## Alignment with the HLD
+
+The HLD lists as non-goals *"being a drop-in clone of Xorg internals"* and
+*"preserving behavior that exists only because of Xorg implementation
+accidents"*, and describes yserver as driving DRM/KMS *"via Vulkan"*. This
+change deserves to be checked against that, since it moves work out of Vulkan.
+
+It does not conflict, for three reasons.
+
+**The ioctl is not an Xorg internal.** A DRM syncobj is a kernel object and
+`DRM_IOCTL_SYNCOBJ_TIMELINE_SIGNAL` is its owner's interface. Vulkan's external
+semaphore import is an interop *bridge* to that object, and measurement 2 shows
+the bridge does not exist on this driver. Xorg, mutter and Mesa all use the
+kernel interface because it is the only one, not because of any Xorg
+convention.
+
+**There is precedent in this repo, for the same reason.** The GBM scanout spec
+(2026-07-20) states plainly: *"yserver allocates scanout the non-standard way
+(Vulkan), instead of via GBM like the whole ecosystem"*, and corrects an
+earlier belief it calls *"too hasty"*. Same decision shape, different object.
+The HLD's own phrasing is "DRM/KMS **and** Vulkan"; the server already speaks
+DRM directly for modeset, atomic commit, `AddFB2` and scanout allocation.
+
+**The CPU is not newly involved.** `vkSignalSemaphore` is already a host
+operation and the acquire path already waits on a kernel eventfd. The swap is
+CPU-to-CPU. The genuinely GPU-side design — waits inside the queue submit — was
+abandoned on measured evidence in `b92b3dd7`, and cannot be revived while the
+server has a single shared queue regardless of which sync primitive is used.
+
+Where this *would* conflict is if deferral were adopted by imitation of Xorg.
+It was not; it was adopted because one queue shared with every client cannot
+safely block on any of them.
+
+## Testing
+
+1. **Unit, no hardware.** `Dri3Caps` derivation from a capability value;
+   `FDFromFence` against a syncobj xid failing cleanly now that the maps are
+   separate.
+2. **Integration, `#[ignore]`** following the `dri3_fd_leak.rs` convention:
+   the full round trip against the real DRM node — create, export, import,
+   signal, query, eventfd. This is `syncobjprobe.c` as a Rust test, so it is
+   runnable on any machine rather than living only as a binary in a scratch
+   directory.
+3. **Hardware.** `PresentPixmapSynced` becomes exercisable for the first time.
+   Validation client must be Vulkan, not GL: `status.md:4084` records that
+   NVIDIA's libGL fails to bind DRI3 against yserver for unrelated reasons, so
+   a GL client cannot answer either way. Expected observations: `ImportSyncobj`
+   arriving at the dispatcher, deferred acquires in the `present_pace` log, and
+   releases signalling without warnings.
+
+## Risks / open questions
+
+- **The 2026-05-20 gate may have been hiding a second problem.** It was added
+  with no recorded reason, and measurement 2 explains only the import failure.
+  If something else was broken on the syncobj path in May, this change makes it
+  reachable again. Hardware validation is where that would surface.
+- **Pre-existing bookkeeping bug becomes reachable.** `status.md:567` records
+  *"1,676 failed idle-syncobj signals across several destroyed Vulkan child
+  surfaces"* — the scheduler retains completed frames and treats them as
+  pending after their syncobjs are freed. That bug is not fixed here, and it is
+  unreachable on this box today only because the gate suppresses the whole
+  path. After this change it becomes reachable, and will present as ioctl
+  `ENOENT` rather than a `VkResult`. A burst of failed-release warnings after
+  this lands is that bug surfacing, not a regression from it.
+- **Cross-driver validation needs other hardware.** The Mesa path changes from
+  a Vulkan host signal to a DRM host signal, and there is no AMD or Intel GPU
+  on this box. The bee (6900HX / RADV) is the machine that would confirm it.
+- **Symbol resolution is not invocation.** Measurement 3 shows NVIDIA resolving
+  the client-side entry points, not calling them. Direct confirmation arrives
+  with the hardware validation above.

--- a/docs/superpowers/specs/2026-08-08-dri3-syncobj-drm-signal-design.md
+++ b/docs/superpowers/specs/2026-08-08-dri3-syncobj-drm-signal-design.md
@@ -6,9 +6,12 @@ on the nvidia box, full-Mesa: yserver on the Raphael iGPU (**card1**, RADV,
 -> 1.4`, 6 `ImportSyncobj` imports, 192 synced presents with 1 acquire deferred
 and subsequently signalled, 0 `unknown syncobj`, 0 `DRM eventfd unavailable`
 fallback warnings — the spec's merge gate (non-zero deferrals, no fallback) is
-satisfied. IGT `syncobj_basic` 12/12 on nvidia-drm; `syncobj_eventfd/wait/timeline`
-skip because the 7.1 kernel compiles CONFIG_SW_SYNC but does not expose
-`/dev/sw_sync`.
+satisfied. IGT: the full `syncobj_*` suite passes **212/212 (0 SKIP)** on
+nvidia-drm (`syncobj_basic` 12, `syncobj_eventfd` 10, `syncobj_wait` 69,
+`syncobj_timeline` 121) with `CONFIG_SW_SYNC` exposed via
+`/sys/kernel/debug/sync/sw_sync` (symlinked to `/dev/sw_sync` for IGT 2.3);
+amdgpu coverage comes from the yserver `imported_syncobj` tests (3/3 on
+`renderD129`) — IGT's device filter does not match cards in this environment.
 
 **Related:** `2026-05-09-phase4-2-dri3-present-glx-design.md` (§3.3 defined the
 Vulkan route this supersedes), `2026-07-20-nvidia-gbm-scanout-allocation.md`

--- a/docs/superpowers/specs/2026-08-08-dri3-syncobj-drm-signal-design.md
+++ b/docs/superpowers/specs/2026-08-08-dri3-syncobj-drm-signal-design.md
@@ -291,53 +291,42 @@ Verified against the local Xorg checkout (`~/Projects/xserver`):
 
 | # | Contrato que debe cumplirse | Xorg | yserver (este cambio) |
 |---|---|---|---|
-| 1 | Un xid que no es legal para el cliente se rechaza (convención core X11 para todo recurso nuevo) | `LEGAL_NEW_RESOURCE(stuff->syncobj, client)` antes de cualquier trabajo → BadIDChoice (`dri3/dri3_request.c:609`) | `BadAlloc` — divergencia deliberada de códigos (ver "Divergence from Xorg") |
-| 2 | Un request sin fd se rechaza | `if (fd < 0) return BadValue` (`dri3/dri3_request.c:619-620`) | `BadAlloc` — divergencia deliberada |
-| 3 | Ningún cliente puede liberar el syncobj de otro | `FreeSyncobj` hace `dixLookupResourceByType(…, dri3_syncobj_type, client, DixWriteAccess)` y devuelve su status (`dri3/dri3_request.c:634-637`) | ownership enforced; un solo código `BadValue` — divergencia deliberada |
-| 4 | `PresentPixmapSynced`: syncobj None/no-importado o points ilegales → **Value error** (presentproto 1.4 §7) | `VERIFY_DRI3_SYNCOBJ` en ambos xids, luego `BadValue` si algún point es 0 o `acquire >= release` en el mismo syncobj (`present/present_request.c:296-302`) | `BadValue` — protocolo presentproto 1.4, sin divergencia |
+| 1 | Un xid que no es legal para el cliente se rechaza (convención core X11 para todo recurso nuevo) | `LEGAL_NEW_RESOURCE(stuff->syncobj, client)` antes de cualquier trabajo → BadIDChoice (`dri3/dri3_request.c:609`) | BadIDChoice — sigue a Xorg |
+| 2 | Un drawable que no existe se rechaza | `dixLookupDrawable(&drawable, stuff->drawable, …)` → BadDrawable (`dri3/dri3_request.c:615-618`) | BadDrawable — sigue a Xorg |
+| 3 | Un request sin fd se rechaza | `if (fd < 0) return BadValue` (`dri3/dri3_request.c:619-620`) | BadValue — sigue a Xorg |
+| 4 | Ningún cliente puede liberar el syncobj de otro | `FreeSyncobj` hace `dixLookupResourceByType(…, client, DixWriteAccess)` y devuelve su status (`dri3/dri3_request.c:634-637`): BadValue (unknown) / BadAccess (not owner) | BadValue / BadAccess — sigue a Xorg |
+| 5 | `PresentPixmapSynced`: syncobj None/no-importado o points ilegales → **Value error** (presentproto 1.4 §7) | `VERIFY_DRI3_SYNCOBJ` en ambos xids, luego `BadValue` si algún point es 0 o `acquire >= release` en el mismo syncobj (`present/present_request.c:296-302`) | BadValue — protocolo presentproto 1.4 |
 
-Symptom 4 is the worst of the four: an X client that gets no reply and no
-error has no recovery, and it is indistinguishable from a server hang.
+Symptom 5 (row 5) is the worst: an X client that gets no reply and no error
+has no recovery, and it is indistinguishable from a server hang.
 
 The same missing ownership causes the leak recorded under "Risks": Xorg's
 resource system frees a client's syncobjs on disconnect for free, whereas
 yserver's map is only ever pruned by an explicit `FreeSyncobj`.
 
-**Scope decision.** Give the registry an owning client and error semantics.
-That is the minimum that makes DRI3 1.4 safe to advertise: rows 3 and 4 are
-cross-client and denial-of-service shaped respectively, not cosmetic
-divergences. yserver does **not** adopt Xorg's resource-type machinery:
-syncobjs stay a backend `HashMap` with an owner field (HLD non-goal "being a
-drop-in clone of Xorg internals"). The exact error codes in rows 1-3 diverge
-from Xorg deliberately — see "Divergence from Xorg" below. Only row 4's Value
-errors are protocol-mandated (presentproto 1.4).
+**Scope decision.** Give the registry an owning client and error semantics
+matching Xorg. That is the minimum that makes DRI3 1.4 safe to advertise:
+rows 4 and 5 are cross-client and denial-of-service shaped respectively, not
+cosmetic divergences. **Error codes follow Xorg** (BadIDChoice, BadDrawable,
+BadValue, BadAccess) — desktop environments are tested for 40+ years against
+Xorg, so diverging in observable error codes is not worth the compatibility
+risk. The only retained divergence is internal: yserver does **not** adopt
+Xorg's resource-type machinery — syncobjs stay a backend `HashMap` with an
+owner field (HLD non-goal "being a drop-in clone of Xorg internals").
 
-### Divergence from Xorg — deliberate, and why it is not a spec violation
+### Divergence from Xorg — deliberate, internal only
 
 AGENTS.md's "follow Xorg" rule exists for behaviour real 40-year-old clients
-observe on the wire. It does not obligate yserver to replicate Xorg's error
-codes where the protocol is silent, nor Xorg's internal resource machinery.
-For DRI3 1.4 syncobjs this change deliberately diverges in two ways, both
-consistent with the HLD non-goals:
+observe on the wire. yserver follows Xorg for every observable error code in
+the conformance table above (rows 1-5). The one deliberate divergence is
+internal and not client-visible:
 
-1. **Resource model.** Xorg makes a syncobj a first-class X resource
-   (`dri3_syncobj_type = CreateNewResourceType(dri3_syncobj_free, "DRI3Syncobj")`).
-   yserver keeps syncobjs in a backend `HashMap<u32, (ClientId,
-   Arc<ImportedSyncobj>)>`. The owner field reproduces the observable
-   behaviour (ownership checks, disconnect purge) without cloning the dix
-   resource machinery — non-goal "being a drop-in clone of Xorg internals".
-2. **Error codes.** The protocol specifies exact error codes for
-   `PresentPixmapSynced` (presentproto 1.4: Value errors for None/not-imported
-   syncobjs, zero points, and `acquire >= release` on the same syncobj) —
-   those are kept verbatim (row 4). It does **not** specify codes for
-   `ImportSyncobj` / `FreeSyncobj` failures, so yserver uses its own,
-   consistent with the rest of its DRI3 surface: `BadAlloc` for any
-   `ImportSyncobj` failure (xid invalid, missing fd, import error) and
-   `BadValue` for `FreeSyncobj` failures (unknown, or not the owning client).
-   Xorg's BadIDChoice / BadAccess distinction is an implementation accident,
-   not a client contract — no modern DRI3 client branches on it — and
-   replicating it would be "preserving behavior that exists only because of
-   Xorg implementation accidents" (HLD non-goal).
+**Resource model.** Xorg makes a syncobj a first-class X resource
+(`dri3_syncobj_type = CreateNewResourceType(dri3_syncobj_free, "DRI3Syncobj")`).
+yserver keeps syncobjs in a backend `HashMap<u32, (ClientId,
+Arc<ImportedSyncobj>)>`. The owner field reproduces the observable behaviour
+(ownership checks, disconnect purge) without cloning the dix resource
+machinery — non-goal "being a drop-in clone of Xorg internals".
 
 What matters is the hang-free property, which both Xorg and this design
 satisfy: every failure path emits an X error rather than blocking with no

--- a/docs/superpowers/specs/2026-08-08-dri3-syncobj-drm-signal-design.md
+++ b/docs/superpowers/specs/2026-08-08-dri3-syncobj-drm-signal-design.md
@@ -25,8 +25,22 @@ The cap comes from `supports_dri3_syncobj()`
 
 Two costs follow. Clients that want explicit sync silently fall back to the
 1.3 fence path. And the `PresentPixmapSynced` branch of the merged
-deferred-Present design has never run on hardware — `docs/status.md:297`
+deferred-Present design has never run **on this box** — `docs/status.md:297`
 records it as *"structurally untestable on this box"*, naming this exact gate.
+
+**That qualifier carries the risk profile of this whole change and must not be
+dropped.** The path is not unvalidated. `docs/status.md:407-424` records it
+passing on bee **and** silence (Mesa/RADV) on 2026-07-28, across single- and
+dual-head and three desktop environments, on a run carrying 2,221 synced
+requests of which 473 (21.3%) arrived before their acquire point, were
+deferred, and all 473 subsequently signalled — 0.87 ms mean, 6 ms maximum, no
+fallback warning.
+
+So the direction of this change is the opposite of what "untested path" would
+suggest: it replaces the release signal *and* the readiness poll on the one
+stack where the path is **proven**, in order to reach a stack where it has
+never run. Validation planned only on NVIDIA cannot, by construction, detect a
+Mesa regression. See "Risks" for what now covers that.
 
 The gate arrived in commit `8c68a281` (2026-05-20) with a one-line message and
 an empty body, but its rationale **is** recorded — in a doc comment the same
@@ -190,16 +204,34 @@ Vulkan conjuncts is the actual change here, and it is justified by the same
 thing that justifies the rest of this spec: nothing imports the syncobj into
 Vulkan any more, so Vulkan's opinion of the fd stopped being relevant.
 
-**Which fd to ask.** The capability is read from `platform.device`, the
-primary/KMS node, while DRI3 hands clients the render node. On this box they
-are the same device. The project's own hardware matrix contains two split
-configurations — Raspberry Pi 4 (vc4 display, v3d render) and Asahi
-(`apple-drm` card, AGX render node) — where the display device's answer says
-nothing about the render device's. The failure mode there is quiet
-under-advertising: 1.3 on a box where the path would have worked. Prefer
-issuing both the capability query and the syncobj ioctls on `render_node_fd`
-so capability and use stay on one fd; if that turns out to be impractical,
-state the split-device gap explicitly rather than leaving it implied.
+**Which fd to ask — one device, decided, not preferred.** The capability query
+and every syncobj ioctl **must** issue on the same fd, and that fd is the
+render node, because the render node is what DRI3 hands the client. This is a
+requirement on the implementation, not a preference to be resolved during it.
+
+The failure mode of getting it wrong is not symmetric, which is why it needs
+deciding here rather than at the call site:
+
+| Cap read on | ioctls on | Result |
+|---|---|---|
+| render node | render node | correct |
+| KMS node | KMS node | quiet under-advertising on split boxes: 1.3 where 1.4 would have worked |
+| render node | KMS node | **advertises 1.4 on the strength of one device and then operates another** |
+
+The third row is the dangerous one and it is the easy one to write by
+accident, because `PlatformBackend` exposes the KMS node as a
+`crate::drm::Device` (ready to `clone()` into the new type) while the render
+node is only a bare `render_node_fd`. Reaching for the convenient field is
+exactly how capability and use end up on different devices. Whatever
+`ImportedSyncobj` holds must therefore be derived from the render node; if
+that means `PlatformBackend` has to retain a `Device` for the render node
+rather than an fd, that is part of this change, not an obstacle to it.
+
+On this box the two nodes are the same device, so no local test can catch the
+mismatch. The project's hardware matrix has two split configurations —
+Raspberry Pi 4 (vc4 display, v3d render) and Asahi (`apple-drm` card, AGX
+render node) — and neither is available here. The correctness argument has to
+carry it, which is why the rule is stated as an invariant.
 
 The Present extension's syncobj capability mirrors `Dri3Caps::syncobj`
 (design:470), so it follows automatically — that bit is how a client learns
@@ -237,6 +269,41 @@ handle. `fd_to_syncobj` takes a `BorrowedFd`.
 - A kernel without `TimelineSyncObj` degrades to `Dri3Caps.syncobj = false` and
   version `(1, 3)` — the same degradation as today, keyed on the kernel rather
   than on a driver list.
+
+### Protocol conformance: one root cause, four symptoms
+
+Today the syncobj registry is a bare `HashMap<u32, Arc<…>>` with **no owning
+client**. Xorg instead makes a syncobj a first-class X resource —
+`dri3_syncobj_type = CreateNewResourceType(dri3_syncobj_free, "DRI3Syncobj")`
+(`dri3/dri3.c:106`) — and every conformance property below falls out of that
+one decision. Lifting the 1.3 cap is what first makes these reachable by a
+real client, so they belong to this change even though the registry predates
+it.
+
+Verified against the local Xorg checkout (`~/Projects/xserver`):
+
+| # | Xorg does | Reference | yserver today |
+|---|---|---|---|
+| 1 | `LEGAL_NEW_RESOURCE(stuff->syncobj, client)` before any work | `dri3/dri3_request.c:609` | no XID validation; a duplicate or out-of-range xid is accepted |
+| 2 | `if (fd < 0) return BadValue` | `dri3/dri3_request.c:619-620` | no `BadValue` path |
+| 3 | `FreeSyncobj` does `dixLookupResourceByType(…, dri3_syncobj_type, client, DixWriteAccess)` and returns its status | `dri3/dri3_request.c:634-637` | map lookup with no client check; failure only warns (`process_request.rs:11532`), so **one client can free another client's syncobj** |
+| 4 | `PresentPixmapSynced` runs `VERIFY_DRI3_SYNCOBJ` on both xids, then `BadValue` if either point is 0 or `acquire >= release` on the same syncobj | `present/present_request.c:296-302` | unknown acquire syncobj produces **no X error and no reply** — the client blocks forever |
+
+Symptom 4 is the worst of the four: an X client that gets no reply and no
+error has no recovery, and it is indistinguishable from a server hang.
+
+The same missing ownership causes the leak recorded under "Risks": Xorg's
+resource system frees a client's syncobjs on disconnect for free, whereas
+yserver's map is only ever pruned by an explicit `FreeSyncobj`.
+
+**Scope decision.** Give the registry an owning client and error semantics
+matching the table. That is the minimum that makes DRI3 1.4 safe to
+advertise: rows 3 and 4 are cross-client and denial-of-service shaped
+respectively, not cosmetic divergences. Adopting Xorg's full resource-type
+machinery is not required — an owner field plus the four error paths gets the
+observable behaviour right — but if that turns out to fight the existing
+resource handling, model it as a real resource rather than weakening the
+table.
 
 ### Monotonicity: measured, and not what was first assumed
 
@@ -318,6 +385,25 @@ safely block on any of them.
    (`process_request.rs:11493`), so a healthy run is indistinguishable from a
    run where no client ever sent the request. A success-path `debug!` has to be
    added for this validation to mean anything.
+4. **Hardware, Mesa — a merge gate, not an extra.** NVIDIA validation proves
+   the change reaches a stack that never worked; it says nothing about the
+   stack the change puts at risk. A Mesa run must reproduce the 2026-07-28
+   result qualitatively: synced presents arriving before their acquire point,
+   deferred, and *all* subsequently signalled, with no fallback warning. A run
+   with zero deferrals proves nothing — it means the acquire points were
+   already met and the release path was never exercised under contention, so
+   the deferred count must be non-zero for the run to count.
+
+   Run it on the local RADV device — `card1` drives the display as of
+   2026-08-08, so this is available now; the bee is the fallback. Both env
+   overrides in "Risks" are mandatory, or the run silently renders on NVIDIA
+   and proves nothing about Mesa.
+
+   Compare against the recorded baseline (2,221 requests / 473 deferred /
+   0.87 ms mean) as a shape, not a threshold: the iGPU is 2 CUs against a
+   6900HX, so absolute timings will differ and a slower mean is not a
+   regression. What must match is the invariant — every deferred acquire
+   eventually signals, and no fallback warning appears.
 
 ## Risks / open questions
 
@@ -341,17 +427,81 @@ safely block on any of them.
   entries except `FreeSyncobj`, so a client that dies with syncobjs imported
   leaks them. Pre-existing in shape — today it leaks a `VkSemaphore` plus a DRM
   handle — but this change is what makes DRI3 1.4 reachable on the box where it
-  will actually be exercised, so the exposure is new in practice. Out of scope
-  here; recorded so it is not rediscovered as a regression.
+  will actually be exercised, so the exposure is new in practice. **No longer
+  out of scope:** it shares its root cause with the conformance table above
+  (the registry has no owning client), so the ownership work that fixes rows 3
+  and 4 is what closes this too. Fixing it separately would mean building the
+  same ownership twice.
 - **The polling fallback fails open.** `PendingPresentSourceWait::is_ready`
   treats a failed timeline query as ready and proceeds to copy. On NVIDIA that
   arm was unreachable (the import always failed, so no client got this far);
   after this change it is live, and failing open means copying a buffer whose
   producer may not have finished writing. The arm predates this change and is
   not altered by it, but it acquires teeth here.
-- **Cross-driver validation needs other hardware.** The Mesa path changes from
-  a Vulkan host signal to a DRM host signal, and there is no AMD or Intel GPU
-  on this box. The bee (6900HX / RADV) is the machine that would confirm it.
+- **Cross-driver validation is mandatory, and is now possible locally.** The
+  Mesa path changes from a Vulkan host signal to a DRM host signal on the one
+  stack where `PresentPixmapSynced` is proven (see "Problem"), so a Mesa run is
+  a merge gate, not a nice-to-have. As of 2026-08-08 this box has a second,
+  Mesa device: the Ryzen 7 7700 Raphael iGPU (`1002:164e`, gfx1036) on
+  `card1` / `renderD129`, with RADV built (Mesa 26.1.6,
+  `AMD Ryzen 7 7700 (RADV RAPHAEL_MENDOCINO)`). Measured the same day:
+  - `syncobjprobe /dev/dri/renderD129` passes 12/12, so the DRM path is viable
+    on amdgpu as well as nvidia-drm.
+  - Cross-device syncobj sharing works **both directions**
+    (`crosssyncobj.c`): create on one GPU, export the fd, `FDToHandle` on the
+    other, `TimelineSignal` there, and the creator's eventfd, `Query` and
+    `TimelineWait` all observe it. So a PRIME client on one GPU can be released
+    by a server on the other.
+
+  Two grades of coverage follow, and they are not equivalent:
+  - **Client-only Mesa** (yserver on NVIDIA, RADV client over PRIME) needs no
+    hardware change and exercises the interaction that matters — does a DRM
+    host signal wake a RADV waiter. It adds one untested variable: NVIDIA
+    importing an AMD-allocated dmabuf.
+  - **Full Mesa** (yserver and client both on RADV/card1) is the real
+    equivalent of the bee run. It needs a CRTC on `card1`, plus
+    `YSERVER_DRM_DEVICE=/dev/dri/card1` **and**
+    `VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/radeon_icd.x86_64.json` — the
+    second is not optional, see the device-selection defect below.
+
+  **Resolved 2026-08-08, and it inverted which side is blocked.** The display
+  now runs off the board's port: `card1-HDMI-A-1` is `connected`, 256-byte
+  EDID, 31 modes, top mode 1920x1080 — the same resolution as the existing
+  hardware-matrix entries, so timings stay comparable. The full-Mesa run is
+  therefore unblocked.
+
+  What is blocked now is the **NVIDIA** run: `card0` has no connected connector
+  at all, so `discover_outputs` will find nothing there. Restoring it means
+  either moving the cable back or a synthetic EDID on `card0-HDMI-A-2`
+  (`drm.edid_firmware=HDMI-A-2:edid/tv.bin video=HDMI-A-2:e`; kernel 7.1
+  removed the built-in EDID sets, so the blob must be supplied — copy it from
+  `/sys/class/drm/card1-HDMI-A-1/edid` while that connector is live). Plan the
+  two hardware runs as separate sessions rather than assuming both are
+  available at once.
+
+  Note the box is now a PRIME desktop — scanout on `card1` (amdgpu), every
+  client rendering on `renderD128` (nvidia-drm), `renderD129` unused. So
+  "there is an AMD GPU present" does not by itself mean a given process is
+  exercising Mesa; check which render node the client actually opened.
+- **Pre-existing defect, out of scope, newly reachable: the server can scan out
+  and render on different GPUs.** `resolve_drm_device` (`lib.rs:658`) picks the
+  KMS card by connected connector and `render_node::open_for_card` correctly
+  follows the sysfs sibling, but `pick_physical_device`
+  (`kms/vk/device.rs:588`) scores purely by
+  `DISCRETE_GPU=3 > INTEGRATED_GPU=2`, with no correlation to the chosen DRM
+  device. On a two-GPU box, pointing `YSERVER_DRM_DEVICE` at the iGPU yields
+  KMS on AMD and Vulkan on NVIDIA, silently. This is not caused by this change,
+  but this change's validation plan is what first depends on getting it right.
+
+  **As of 2026-08-08 this is the default path on the nvidia box, not an edge
+  case.** With the display moved to the board, `card1` is the only card with a
+  connected connector, so `pick_drm_candidate` selects it while
+  `pick_physical_device` still scores `DISCRETE_GPU` highest and selects the
+  NVIDIA device. Launching yserver here with no environment overrides now
+  produces the mismatched pair. Any hardware run for this change must set both
+  `YSERVER_DRM_DEVICE=/dev/dri/card1` and
+  `VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/radeon_icd.x86_64.json`, and a run
+  that omits them is not evidence about Mesa regardless of what it reports.
 - **Symbol resolution is not invocation.** Measurement 3 shows NVIDIA resolving
   the client-side entry points, not calling them. Direct confirmation arrives
   with the hardware validation above.

--- a/docs/superpowers/specs/2026-08-08-dri3-syncobj-drm-signal-design.md
+++ b/docs/superpowers/specs/2026-08-08-dri3-syncobj-drm-signal-design.md
@@ -25,12 +25,25 @@ The cap comes from `supports_dri3_syncobj()`
 
 Two costs follow. Clients that want explicit sync silently fall back to the
 1.3 fence path. And the `PresentPixmapSynced` branch of the merged
-deferred-Present design has never run on hardware — `docs/status.md:316`
+deferred-Present design has never run on hardware — `docs/status.md:297`
 records it as *"structurally untestable on this box"*, naming this exact gate.
 
-The gate arrived in commit `8c68a281` (2026-05-20). Its message is one line,
-`Disable DRI3 syncobj on NVIDIA`, with an empty body. No rationale was
-recorded anywhere, so the premise had to be re-measured rather than trusted.
+The gate arrived in commit `8c68a281` (2026-05-20) with a one-line message and
+an empty body, but its rationale **is** recorded — in a doc comment the same
+commit added directly above the function (`crates/yserver/src/kms/vk/device.rs:78-85`,
+restated at `docs/status.md:297`):
+
+> The implementation currently imports DRI3 syncobj fds as timeline semaphores
+> with `OPAQUE_FD`. That works on the Vulkan stacks we have used for
+> Venus/Mesa testing, but NVIDIA proprietary rejects the very first import with
+> `ERROR_INITIALIZATION_FAILED` […]. Advertising only DRI3 1.3 on that driver
+> lets clients fall back to the older fence-fd path instead of dying on
+> `ImportSyncobj`.
+
+So the gate was a correct, documented response to a real failure. What follows
+is not a discovery that it was wrong; it is that the *conclusion drawn from it*
+— cap the version — was one of two available responses, and the other one
+serves every driver.
 
 ## Evidence
 
@@ -47,9 +60,13 @@ the same payload, which is what makes a server-side signal reach the client.
 `import_drm_syncobj` (`crates/yserver/src/kms/vk/sync.rs:58`) byte for byte:
 timeline `VkSemaphore`, `vkImportSemaphoreFdKHR` with
 `VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT`, on a real DRM syncobj fd.
-Result: `VK_ERROR_INITIALIZATION_FAILED`.
+Result: `VK_ERROR_INITIALIZATION_FAILED` — the same error the 2026-05-20 doc
+comment already named. This measurement **corroborates** the recorded
+rationale rather than discovering it; its value is that the failure still
+reproduces on driver 610.57.04 three months later, so the constraint is
+structural and not a driver bug that has since been fixed.
 
-The gate's premise was correct. Note that
+Note that
 `vkGetPhysicalDeviceExternalSemaphoreProperties` reports
 `IMPORTABLE_BIT` set for timeline OPAQUE_FD on this driver — it advertises the
 capability and then rejects the fd. That is not a driver bug: `OPAQUE_FD` is a
@@ -163,9 +180,26 @@ asks the DRM device: `DriverCapability::TimelineSyncObj` (exposed by the `drm`
 crate at `lib.rs:309`). Version becomes `(1, 4)` when that capability is
 present and `(1, 3)` when it is not.
 
-This is what the Phase 4.2 design already listed as the correct gate — its
-fallback matrix names *"Kernel lacks `DRM_SYNCOBJ` ioctls"* (design:449) as the
-condition for dropping to 1.3. It was simply never implemented that way.
+**This is a departure from the Phase 4.2 design, not a restoration of it.** That
+design defined syncobj support conjunctively — `OPAQUE_FD` **and**
+`VK_KHR_timeline_semaphore` **and** DRM_SYNCOBJ ioctls (design:463-464, mirrored
+in the shipped `Dri3Caps` doc at `trait_def.rs:290-292`) — and its fallback
+matrix lists *"Kernel lacks `DRM_SYNCOBJ` ioctls"* (design:449) as one more
+condition on top of the Vulkan ones, not instead of them. Dropping the two
+Vulkan conjuncts is the actual change here, and it is justified by the same
+thing that justifies the rest of this spec: nothing imports the syncobj into
+Vulkan any more, so Vulkan's opinion of the fd stopped being relevant.
+
+**Which fd to ask.** The capability is read from `platform.device`, the
+primary/KMS node, while DRI3 hands clients the render node. On this box they
+are the same device. The project's own hardware matrix contains two split
+configurations — Raspberry Pi 4 (vc4 display, v3d render) and Asahi
+(`apple-drm` card, AGX render node) — where the display device's answer says
+nothing about the render device's. The failure mode there is quiet
+under-advertising: 1.3 on a box where the path would have worked. Prefer
+issuing both the capability query and the syncobj ioctls on `render_node_fd`
+so capability and use stay on one fd; if that turns out to be impractical,
+state the split-device gap explicitly rather than leaving it implied.
 
 The Present extension's syncobj capability mirrors `Dri3Caps::syncobj`
 (design:470), so it follows automatically — that bit is how a client learns
@@ -190,15 +224,45 @@ handle. `fd_to_syncobj` takes a `BorrowedFd`.
 
 ### Error handling
 
-- Import failure returns `BadAlloc`, preserving current behaviour
-  (`process_request.rs:11500`).
+- Import failure returns `BadAlloc` (`process_request.rs:11500`). This is a
+  **behaviour change, not a preservation**: today a `fd_to_syncobj` failure
+  only warns and falls back to the Vulkan-only path
+  (`backend.rs:19330-19339`), and just the Vulkan import failing yields
+  `BadAlloc`. With no Vulkan path left there is nothing to fall back to, and
+  the kernel-derived capability means a `fd_to_syncobj` failure on a device
+  that advertised `TimelineSyncObj` is a genuine error rather than an expected
+  driver gap.
 - Eventfd registration failure still falls through to polling, now via DRM
   query.
 - A kernel without `TimelineSyncObj` degrades to `Dri3Caps.syncobj = false` and
   version `(1, 3)` — the same degradation as today, keyed on the kernel rather
   than on a driver list.
-- DRM timelines require strictly increasing points, as `vkSignalSemaphore`
-  does. Signalling a stale point fails on both. Semantics unchanged.
+
+### Monotonicity: measured, and not what was first assumed
+
+An earlier draft of this spec claimed both primitives reject a stale point and
+called the swap semantically identical. That is **false**, measured on this
+kernel (`~/yserver-glx-probes/stalepoint.c`, both nodes):
+
+```
+signal point=10  rc=0  -> query reads 10
+signal point=5   rc=0  -> query reads 10   <- stale point SUCCEEDS, silently
+signal point=10  rc=0  -> query reads 10   <- duplicate SUCCEEDS
+signal point=20  rc=0  -> query reads 20
+```
+
+`DRM_IOCTL_SYNCOBJ_TIMELINE_SIGNAL` clamps to `max(current, point)` and
+returns success. On the Vulkan side, `value` exceeding the current counter is a
+VUID on `vkSignalSemaphore` — undefined behaviour, not an error return. So
+neither primitive reports an out-of-order signal, and the swap is **not**
+"unchanged".
+
+It is, however, safer. `signal_all_retained_present_wakes`
+(`backend.rs:6198-6203`) iterates `retained_present_wakes`, a `HashMap`, so
+shutdown flushes release points in arbitrary order. Under `vkSignalSemaphore`
+that is UB with a real risk of leaving a payload below its highest signalled
+point; under DRM the clamp guarantees the maximum wins. Out-of-order release
+signalling stops being a hazard and becomes merely silent.
 
 ## Alignment with the HLD
 
@@ -244,26 +308,47 @@ safely block on any of them.
    runnable on any machine rather than living only as a binary in a scratch
    directory.
 3. **Hardware.** `PresentPixmapSynced` becomes exercisable for the first time.
-   Validation client must be Vulkan, not GL: `status.md:4084` records that
+   Validation client must be Vulkan, not GL: `status.md:4063` records that
    NVIDIA's libGL fails to bind DRI3 against yserver for unrelated reasons, so
    a GL client cannot answer either way. Expected observations: `ImportSyncobj`
-   arriving at the dispatcher, deferred acquires in the `present_pace` log, and
-   releases signalling without warnings.
+   arriving at the dispatcher and deferred acquires in the `present_pace` log.
+
+   Note the success path of `ImportSyncobj` logs nothing today — the only
+   `DRI3::ImportSyncobj` line in the tree is the `BadAlloc` branch
+   (`process_request.rs:11493`), so a healthy run is indistinguishable from a
+   run where no client ever sent the request. A success-path `debug!` has to be
+   added for this validation to mean anything.
 
 ## Risks / open questions
 
-- **The 2026-05-20 gate may have been hiding a second problem.** It was added
-  with no recorded reason, and measurement 2 explains only the import failure.
-  If something else was broken on the syncobj path in May, this change makes it
-  reachable again. Hardware validation is where that would surface.
-- **Pre-existing bookkeeping bug becomes reachable.** `status.md:567` records
-  *"1,676 failed idle-syncobj signals across several destroyed Vulkan child
-  surfaces"* — the scheduler retains completed frames and treats them as
-  pending after their syncobjs are freed. That bug is not fixed here, and it is
-  unreachable on this box today only because the gate suppresses the whole
-  path. After this change it becomes reachable, and will present as ioctl
-  `ENOENT` rather than a `VkResult`. A burst of failed-release warnings after
-  this lands is that bug surfacing, not a regression from it.
+- **Pre-existing bookkeeping bug becomes reachable, and stays invisible.**
+  `status.md:548` records *"1,676 failed idle-syncobj signals across several
+  destroyed Vulkan child surfaces"* — the scheduler retains completed frames
+  and treats them as pending after their syncobjs are freed. Not fixed here.
+  Two sub-cases, and neither produces a new signal to watch for:
+  - Freed xid: `dri3_signal_syncobj` fails at its own registry miss
+    (`backend.rs:19384-19392`) with the same `unknown syncobj` text before and
+    after this change. It never reaches an ioctl.
+  - Pinned-handle replay (`signal_present_wake` →
+    `dri3_signal_syncobj_via_handle`, `backend.rs:19568-19576`): the object is
+    alive, and per the monotonicity measurement above a stale replayed release
+    point returns success silently. No warning in either world.
+
+  So this change makes the bug *reachable on this box* without making it more
+  observable. If it needs watching during validation, the string to grep is
+  `unknown syncobj`.
+- **No client-teardown purge for the syncobj registry.** Nothing removes
+  entries except `FreeSyncobj`, so a client that dies with syncobjs imported
+  leaks them. Pre-existing in shape — today it leaks a `VkSemaphore` plus a DRM
+  handle — but this change is what makes DRI3 1.4 reachable on the box where it
+  will actually be exercised, so the exposure is new in practice. Out of scope
+  here; recorded so it is not rediscovered as a regression.
+- **The polling fallback fails open.** `PendingPresentSourceWait::is_ready`
+  treats a failed timeline query as ready and proceeds to copy. On NVIDIA that
+  arm was unreachable (the import always failed, so no client got this far);
+  after this change it is live, and failing open means copying a buffer whose
+  producer may not have finished writing. The arm predates this change and is
+  not altered by it, but it acquires teeth here.
 - **Cross-driver validation needs other hardware.** The Mesa path changes from
   a Vulkan host signal to a DRM host signal, and there is no AMD or Intel GPU
   on this box. The bee (6900HX / RADV) is the machine that would confirm it.

--- a/docs/superpowers/specs/2026-08-08-dri3-syncobj-drm-signal-design.md
+++ b/docs/superpowers/specs/2026-08-08-dri3-syncobj-drm-signal-design.md
@@ -282,12 +282,12 @@ it.
 
 Verified against the local Xorg checkout (`~/Projects/xserver`):
 
-| # | Xorg does | Reference | yserver today |
+| # | Contrato que debe cumplirse | Xorg | yserver (este cambio) |
 |---|---|---|---|
-| 1 | `LEGAL_NEW_RESOURCE(stuff->syncobj, client)` before any work | `dri3/dri3_request.c:609` | no XID validation; a duplicate or out-of-range xid is accepted |
-| 2 | `if (fd < 0) return BadValue` | `dri3/dri3_request.c:619-620` | no `BadValue` path |
-| 3 | `FreeSyncobj` does `dixLookupResourceByType(…, dri3_syncobj_type, client, DixWriteAccess)` and returns its status | `dri3/dri3_request.c:634-637` | map lookup with no client check; failure only warns (`process_request.rs:11532`), so **one client can free another client's syncobj** |
-| 4 | `PresentPixmapSynced` runs `VERIFY_DRI3_SYNCOBJ` on both xids, then `BadValue` if either point is 0 or `acquire >= release` on the same syncobj | `present/present_request.c:296-302` | unknown acquire syncobj produces **no X error and no reply** — the client blocks forever |
+| 1 | Un xid que no es legal para el cliente se rechaza (convención core X11 para todo recurso nuevo) | `LEGAL_NEW_RESOURCE(stuff->syncobj, client)` antes de cualquier trabajo → BadIDChoice (`dri3/dri3_request.c:609`) | `BadAlloc` — divergencia deliberada de códigos (ver "Divergence from Xorg") |
+| 2 | Un request sin fd se rechaza | `if (fd < 0) return BadValue` (`dri3/dri3_request.c:619-620`) | `BadAlloc` — divergencia deliberada |
+| 3 | Ningún cliente puede liberar el syncobj de otro | `FreeSyncobj` hace `dixLookupResourceByType(…, dri3_syncobj_type, client, DixWriteAccess)` y devuelve su status (`dri3/dri3_request.c:634-637`) | ownership enforced; un solo código `BadValue` — divergencia deliberada |
+| 4 | `PresentPixmapSynced`: syncobj None/no-importado o points ilegales → **Value error** (presentproto 1.4 §7) | `VERIFY_DRI3_SYNCOBJ` en ambos xids, luego `BadValue` si algún point es 0 o `acquire >= release` en el mismo syncobj (`present/present_request.c:296-302`) | `BadValue` — protocolo presentproto 1.4, sin divergencia |
 
 Symptom 4 is the worst of the four: an X client that gets no reply and no
 error has no recovery, and it is indistinguishable from a server hang.
@@ -296,14 +296,45 @@ The same missing ownership causes the leak recorded under "Risks": Xorg's
 resource system frees a client's syncobjs on disconnect for free, whereas
 yserver's map is only ever pruned by an explicit `FreeSyncobj`.
 
-**Scope decision.** Give the registry an owning client and error semantics
-matching the table. That is the minimum that makes DRI3 1.4 safe to
-advertise: rows 3 and 4 are cross-client and denial-of-service shaped
-respectively, not cosmetic divergences. Adopting Xorg's full resource-type
-machinery is not required — an owner field plus the four error paths gets the
-observable behaviour right — but if that turns out to fight the existing
-resource handling, model it as a real resource rather than weakening the
-table.
+**Scope decision.** Give the registry an owning client and error semantics.
+That is the minimum that makes DRI3 1.4 safe to advertise: rows 3 and 4 are
+cross-client and denial-of-service shaped respectively, not cosmetic
+divergences. yserver does **not** adopt Xorg's resource-type machinery:
+syncobjs stay a backend `HashMap` with an owner field (HLD non-goal "being a
+drop-in clone of Xorg internals"). The exact error codes in rows 1-3 diverge
+from Xorg deliberately — see "Divergence from Xorg" below. Only row 4's Value
+errors are protocol-mandated (presentproto 1.4).
+
+### Divergence from Xorg — deliberate, and why it is not a spec violation
+
+AGENTS.md's "follow Xorg" rule exists for behaviour real 40-year-old clients
+observe on the wire. It does not obligate yserver to replicate Xorg's error
+codes where the protocol is silent, nor Xorg's internal resource machinery.
+For DRI3 1.4 syncobjs this change deliberately diverges in two ways, both
+consistent with the HLD non-goals:
+
+1. **Resource model.** Xorg makes a syncobj a first-class X resource
+   (`dri3_syncobj_type = CreateNewResourceType(dri3_syncobj_free, "DRI3Syncobj")`).
+   yserver keeps syncobjs in a backend `HashMap<u32, (ClientId,
+   Arc<ImportedSyncobj>)>`. The owner field reproduces the observable
+   behaviour (ownership checks, disconnect purge) without cloning the dix
+   resource machinery — non-goal "being a drop-in clone of Xorg internals".
+2. **Error codes.** The protocol specifies exact error codes for
+   `PresentPixmapSynced` (presentproto 1.4: Value errors for None/not-imported
+   syncobjs, zero points, and `acquire >= release` on the same syncobj) —
+   those are kept verbatim (row 4). It does **not** specify codes for
+   `ImportSyncobj` / `FreeSyncobj` failures, so yserver uses its own,
+   consistent with the rest of its DRI3 surface: `BadAlloc` for any
+   `ImportSyncobj` failure (xid invalid, missing fd, import error) and
+   `BadValue` for `FreeSyncobj` failures (unknown, or not the owning client).
+   Xorg's BadIDChoice / BadAccess distinction is an implementation accident,
+   not a client contract — no modern DRI3 client branches on it — and
+   replicating it would be "preserving behavior that exists only because of
+   Xorg implementation accidents" (HLD non-goal).
+
+What matters is the hang-free property, which both Xorg and this design
+satisfy: every failure path emits an X error rather than blocking with no
+reply.
 
 ### Monotonicity: measured, and not what was first assumed
 

--- a/docs/superpowers/specs/2026-08-08-dri3-syncobj-drm-signal-design.md
+++ b/docs/superpowers/specs/2026-08-08-dri3-syncobj-drm-signal-design.md
@@ -1,7 +1,14 @@
 # DRI3 1.4 syncobj: signal through DRM, not Vulkan
 
-**Status:** DESIGN (2026-08-08). Hardware evidence gathered on the nvidia box
-(RTX 5060 Ti, driver 610.57.04, kernel 7.1.6-gentoo-dist). Not yet implemented.
+**Status:** IMPLEMENTED (2026-08-10, branch `dri3-syncobj-drm-signal`). HW-verified
+on the nvidia box, full-Mesa: yserver on the Raphael iGPU (**card1**, RADV,
+`renderD129`) + mpv Vulkan X11 WSI reproduced a 15 s testsrc; `DRI3::QueryVersion
+-> 1.4`, 6 `ImportSyncobj` imports, 192 synced presents with 1 acquire deferred
+and subsequently signalled, 0 `unknown syncobj`, 0 `DRM eventfd unavailable`
+fallback warnings — the spec's merge gate (non-zero deferrals, no fallback) is
+satisfied. IGT `syncobj_basic` 12/12 on nvidia-drm; `syncobj_eventfd/wait/timeline`
+skip because the 7.1 kernel compiles CONFIG_SW_SYNC but does not expose
+`/dev/sw_sync`.
 
 **Related:** `2026-05-09-phase4-2-dri3-present-glx-design.md` (§3.3 defined the
 Vulkan route this supersedes), `2026-07-20-nvidia-gbm-scanout-allocation.md`


### PR DESCRIPTION
## DRI3 1.4 syncobj: signal through DRM, not Vulkan

Serves DRI3 1.4 syncobjs through the kernel's DRM syncobj interface on every driver, replacing the Vulkan timeline-semaphore path. The NVIDIA blacklist that capped DRI3 at 1.3 is deleted; `PresentPixmapSynced` is advertised whenever the kernel reports `DRM_CAP_SYNCOBJ_TIMELINE`.

### What changed

- **`ImportedSyncobj`** — a DRM-backed syncobj resource (`syncobj_timeline_signal`/`query`, `syncobj_eventfd`, `fd_to_syncobj`) plus `Device::open_render_node`.
- **One-device invariant** — every syncobj ioctl and the capability query run on the retained render-node `Device` (never the KMS node).
- **Split registry** — fences keep the Vulkan `OwnedSemaphore`; syncobjs move to `HashMap<u32, (ClientId, Arc<ImportedSyncobj>)>`.
- **Conformance** — owning client, `PresentPixmapSynced` Value errors, disconnect purge, duplicate-import and cross-client ownership checks. Error codes follow Xorg (BadIDChoice, BadDrawable, BadValue, BadAccess, BadAlloc).
- **Capability** — `Dri3Caps::syncobj` derives from `DRM_CAP_SYNCOBJ_TIMELINE` on the render node; `supports_dri3_syncobj()` blacklist removed.
- **OwnedSemaphore** reduced to the XSync fence half; the Vulkan syncobj import and `timeline_semaphore(true)` feature removed.

### Validation (nvidia box, 2026-08-10)

- **Full-Mesa**: yserver on the Raphael iGPU (card1, RADV) + mpv Vulkan X11 WSI. `DRI3::QueryVersion -> 1.4`, 6 `ImportSyncobj` imports, 192 synced presents with 1 acquire deferred and subsequently signalled, 0 `unknown syncobj`, 0 `DRM eventfd unavailable` fallback warnings — the spec's merge gate is satisfied.
- **IGT**: full `syncobj_*` suite passes 212/212 (0 SKIP) on nvidia-drm with `CONFIG_SW_SYNC` exposed via `/sys/kernel/debug/sync/sw_sync`.
- `cargo clippy --all-targets -- -D warnings` clean; yserver-core 1139 and yserver 780 tests pass (plus 62 DRM `#[ignore]` passing on real render nodes).

### Internal divergence from Xorg (not client-visible)

yserver does not clone Xorg's resource-type machinery for DRI3 syncobjs: they live in a backend `HashMap<u32, (ClientId, Arc<ImportedSyncobj>)>` with an owner field, instead of first-class X resources. This is internal only — error codes follow Xorg, and the observable behaviour (ownership checks, disconnect purge, protocol validation) is reproduced via the owner field. Justified by the HLD non-goal "being a drop-in clone of Xorg internals". See the spec's "Divergence from Xorg" section.

### `dri3_1.4/` is not part of this PR

A local reference-documentation directory (DRI3/Present protocols, kernel DRM docs) gathered during research. Excluded via `.gitignore` (`/dri3_1.4/`); the derived knowledge lives in the spec and plan in this repo.
