### PR TITLE
fix(dri3): scrambled hardware-decoded video in Chrome (#138)

### DIFF
--- a/crates/yserver-core/src/backend/mod.rs
+++ b/crates/yserver-core/src/backend/mod.rs
@@ -20,8 +20,8 @@ pub use params::{
 };
 pub use trait_def::{
     ActiveCursorImage, Backend, BackendFdKind, CompletedPresentEvent, CrtcConfigApply,
-    CrtcConfigToken, Dri3Caps, Dri3PixmapExport, HostSocketStatus, KeymapLoad, ModeSpec,
-    PresentCaps, PresentClockSample, PresentClockSource, PresentScanoutCandidate,
+    CrtcConfigToken, Dri3Caps, Dri3ImportModifier, Dri3PixmapExport, HostSocketStatus, KeymapLoad,
+    ModeSpec, PresentCaps, PresentClockSample, PresentClockSource, PresentScanoutCandidate,
     PresentSourceWait, PresentWake, SyncobjHandle, XkbNewKeyboardInfo, XshmfenceHandle,
 };
 

--- a/crates/yserver-core/src/backend/trait_def.rs
+++ b/crates/yserver-core/src/backend/trait_def.rs
@@ -325,6 +325,28 @@ mod present_caps_tests {
 /// DRI3 capability surface. Phase 4.2 design §4. `version == (0, 0)`
 /// is the "DRI3 unsupported" sentinel; any other value advertises
 /// DRI3 to clients. The other booleans gate individual request types
+/// How the layout of a client-supplied dma-buf is known.
+///
+/// The two DRI3 import requests differ in exactly this, and conflating
+/// them is #138: `PixmapFromBuffers` (DRI3 1.2) carries an explicit
+/// modifier on the wire, while the legacy `PixmapFromBuffer` (DRI3 1.0)
+/// carries none. "No modifier on the wire" means the layout is
+/// **implicit** and must be resolved from the buffer itself. It does
+/// **not** mean linear, and assuming linear makes the server re-export
+/// false metadata that a client then samples by — scrambling its own
+/// output with no bad pixel ever passing through us.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Dri3ImportModifier {
+    /// The client named the layout (`PixmapFromBuffers`). `0` here is a
+    /// real, explicit `DRM_FORMAT_MOD_LINEAR` and must stay meaningful.
+    Explicit(u64),
+    /// The client did not name it (`PixmapFromBuffer`). The backend must
+    /// resolve the concrete modifier from the dma-buf, and must fail the
+    /// import if it cannot — a wrong successful import is worse than a
+    /// refused one.
+    Implicit,
+}
+
 /// rather than the whole extension.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct Dri3Caps {
@@ -2124,6 +2146,12 @@ pub trait Backend {
     /// Phase 4.2 only handles single-plane (RGB) imports; the
     /// multi-plane variant of `PixmapFromBuffers` is rejected at the
     /// dispatcher.
+    ///
+    /// `modifier` distinguishes a layout the client named from one it
+    /// did not; see [`Dri3ImportModifier`]. Whatever concrete modifier
+    /// an implicit import resolves to is what `BuffersFromPixmap` must
+    /// later report back — that round trip is the contract clients
+    /// sample by.
     #[allow(clippy::too_many_arguments)]
     fn dri3_import_pixmap(
         &mut self,
@@ -2132,7 +2160,7 @@ pub trait Backend {
         _height: u16,
         _stride: u32,
         _offset: u32,
-        _modifier: u64,
+        _modifier: Dri3ImportModifier,
         _depth: u8,
         _bpp: u8,
     ) -> io::Result<PixmapHandle> {

--- a/crates/yserver-core/src/backend/trait_def.rs
+++ b/crates/yserver-core/src/backend/trait_def.rs
@@ -340,11 +340,22 @@ pub enum Dri3ImportModifier {
     /// The client named the layout (`PixmapFromBuffers`). `0` here is a
     /// real, explicit `DRM_FORMAT_MOD_LINEAR` and must stay meaningful.
     Explicit(u64),
-    /// The client did not name it (`PixmapFromBuffer`). The backend must
-    /// resolve the concrete modifier from the dma-buf, and must fail the
-    /// import if it cannot — a wrong successful import is worse than a
-    /// refused one.
-    Implicit,
+    /// The client did not name it (`PixmapFromBuffer`), and carried a
+    /// buffer `size` on the wire that an export must report verbatim.
+    ///
+    /// **The backend cannot currently resolve the real layout**, and does
+    /// not pretend to: it builds its own Vulkan view as if the buffer
+    /// were linear, records the layout as unknown, and reports
+    /// `DRM_FORMAT_MOD_INVALID` to anyone who asks — so a client can
+    /// resolve the layout itself, which is what fixes #138. The
+    /// consequence is that the *server's* view of such a pixmap is
+    /// wrong whenever the buffer is not in fact linear, so anything
+    /// that would sample or scan it out server-side must refuse it
+    /// rather than render garbage. Making the view itself correct needs
+    /// an EGL implicit-import path or a driver-specific layout
+    /// resolver; gbm cannot do it on amdgpu (measured: it answers
+    /// `DRM_FORMAT_MOD_INVALID` even for its own fresh allocation).
+    Implicit { size: u32 },
 }
 
 /// rather than the whole extension.

--- a/crates/yserver-core/src/core_loop/process_request.rs
+++ b/crates/yserver-core/src/core_loop/process_request.rs
@@ -12303,7 +12303,7 @@ fn handle_dri3_request(
                 // TILED VA-API decode buffer here, we recorded it as
                 // linear, and `BuffersFromPixmap` then handed that lie
                 // back so Chrome sampled its own frame wrong.
-                crate::backend::Dri3ImportModifier::Implicit,
+                crate::backend::Dri3ImportModifier::Implicit { size: req.size },
                 req.depth,
                 req.bpp,
             ) {

--- a/crates/yserver-core/src/core_loop/process_request.rs
+++ b/crates/yserver-core/src/core_loop/process_request.rs
@@ -12296,7 +12296,14 @@ fn handle_dri3_request(
                 req.height,
                 u32::from(req.stride),
                 0,
-                0, // PixmapFromBuffer always implies LINEAR (no modifier).
+                // DRI3 1.0 carries no modifier. That means the layout is
+                // IMPLICIT, to be resolved from the buffer -- not linear.
+                // This line used to pass `0`, i.e. an explicit
+                // DRM_FORMAT_MOD_LINEAR, which is #138: Chrome hands us a
+                // TILED VA-API decode buffer here, we recorded it as
+                // linear, and `BuffersFromPixmap` then handed that lie
+                // back so Chrome sampled its own frame wrong.
+                crate::backend::Dri3ImportModifier::Implicit,
                 req.depth,
                 req.bpp,
             ) {
@@ -12401,7 +12408,7 @@ fn handle_dri3_request(
                 req.height,
                 req.strides[0],
                 req.offsets[0],
-                req.modifier,
+                crate::backend::Dri3ImportModifier::Explicit(req.modifier),
                 req.depth,
                 req.bpp,
             ) {

--- a/crates/yserver/src/kms/render/backend.rs
+++ b/crates/yserver/src/kms/render/backend.rs
@@ -2928,6 +2928,15 @@ impl KmsBackend {
 
         let import = self.store.get(source_id).and_then(|drawable| {
             let metadata = drawable.storage.imported_dmabuf.as_ref()?;
+            // An unresolved layout must never reach KMS. The client never
+            // named it (legacy `PixmapFromBuffer`), so `metadata.modifier`
+            // is our linear guess; scanning a tiled buffer out as linear
+            // puts garbage on the display, and `add_fb2` may well accept
+            // it. Refuse the direct path and let the ordinary composite
+            // handle the pixmap instead.
+            if metadata.implicit_layout {
+                return None;
+            }
             let plane = metadata.planes.first()?;
             let fd = drawable
                 .storage
@@ -24323,15 +24332,17 @@ impl Backend for KmsBackend {
         // allocation -- so there is nothing to resolve against. i915 does
         // report a concrete modifier, but a fix that only works on Intel
         // is not a fix.
-        let (vk_modifier, reported_modifier) = match modifier {
-            Dri3ImportModifier::Explicit(m) => (m, Some(m)),
+        let (vk_modifier, reported_modifier, client_size, implicit_layout) = match modifier {
+            Dri3ImportModifier::Explicit(m) => (m, Some(m), None, false),
             // LINEAR is a best-effort for OUR OWN Vulkan view of the
             // buffer, which is only ever sampled if the server itself
             // composites this pixmap. It is deliberately NOT what we
             // report back.
-            Dri3ImportModifier::Implicit => (
+            Dri3ImportModifier::Implicit { size } => (
                 crate::kms::vk::dri3::DRM_FORMAT_MOD_LINEAR,
                 Some(crate::kms::vk::dri3::DRM_FORMAT_MOD_INVALID),
+                Some(size),
+                true,
             ),
         };
         let modifier = vk_modifier;
@@ -24343,6 +24354,7 @@ impl Backend for KmsBackend {
             format,
             modifier,
             reported_modifier,
+            client_size,
             &[crate::kms::vk::dri3::DmabufPlane {
                 offset: u64::from(offset),
                 pitch: stride,
@@ -24375,6 +24387,7 @@ impl Backend for KmsBackend {
                 fourcc,
                 vk_format: format,
                 modifier,
+                implicit_layout,
                 planes: vec![ImportedDmabufPlane {
                     offset: u64::from(offset),
                     pitch: stride,
@@ -37040,6 +37053,95 @@ mod tests {
     /// (depth, bpp) combinations with a non-empty error before
     /// touching the dma-buf fd. Exercises the guard above the
     /// `import_dmabuf` call. Vk-attached so we hit the second
+    /// #138 regression, at the metadata boundary that actually broke.
+    ///
+    /// An imported pixmap must be handed back to the client **as the
+    /// client described it**. Two separate lies used to live here:
+    /// a legacy `PixmapFromBuffer` was recorded as explicit LINEAR, and
+    /// every export re-derived its answer from our own VkImage rather
+    /// than from the client's buffer. Chrome imports a TILED VA-API
+    /// frame through the legacy request and then asks for it straight
+    /// back, so both lies reached it and it sampled its own frame wrong.
+    ///
+    /// The contract asserted here:
+    ///   - an implicit import reports `DRM_FORMAT_MOD_INVALID`, never
+    ///     LINEAR -- "I was not told" is the honest answer, and it is
+    ///     what lets the client resolve the layout itself;
+    ///   - an explicit import reports back that same modifier;
+    ///   - stride and offset survive the round trip unchanged.
+    #[test]
+    #[ignore = "needs live Vulkan ICD and a render node"]
+    fn dri3_imported_pixmap_exports_the_clients_own_description() {
+        use yserver_core::backend::Dri3ImportModifier;
+        const INVALID: u64 = crate::kms::vk::dri3::DRM_FORMAT_MOD_INVALID;
+
+        let mut b = match KmsBackend::for_tests_with_vk() {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("skip: no Vk: {e}");
+                return;
+            }
+        };
+        // A real dma-buf from the SAME device the backend renders on:
+        // create a server pixmap and export it. Sourcing one from a
+        // /dev/dri node instead risks allocating on the wrong GPU on a
+        // dual-GPU host, and skipping when a node is missing made an
+        // earlier version of this test pass vacuously.
+        let (w, h) = (256u16, 64u16);
+        let seed = match b.create_pixmap(None, 32, w, h) {
+            Ok(handle) => handle,
+            Err(e) => {
+                eprintln!("skip: create_pixmap: {e}");
+                return;
+            }
+        };
+        let seed_export = match b.dri3_export_pixmap_buffers(seed.as_raw()) {
+            Ok(e) => e,
+            Err(e) => {
+                eprintln!("skip: seed export: {e}");
+                return;
+            }
+        };
+        let stride = seed_export.stride;
+        let seed_modifier = seed_export.modifier;
+
+        for (case, requested, expected) in [
+            (
+                "implicit",
+                Dri3ImportModifier::Implicit {
+                    size: seed_export.size,
+                },
+                INVALID,
+            ),
+            (
+                "explicit",
+                Dri3ImportModifier::Explicit(seed_modifier),
+                seed_modifier,
+            ),
+        ] {
+            let fd = seed_export.fd.try_clone().expect("dup the seed dma-buf");
+            let handle = b
+                .dri3_import_pixmap(fd, w, h, stride, 0, requested, 32, 32)
+                .unwrap_or_else(|e| panic!("{case}: import failed: {e}"));
+            let export = b
+                .dri3_export_pixmap_buffers(handle.as_raw())
+                .unwrap_or_else(|e| panic!("{case}: export failed: {e}"));
+
+            assert_eq!(
+                export.modifier, expected,
+                "{case}: exported modifier must be what the client's buffer is described by. \
+                 Reporting LINEAR (0) for an unnamed layout is #138 -- the client believes it \
+                 and samples a tiled buffer as linear",
+            );
+            assert_eq!(
+                export.stride, stride,
+                "{case}: the client's own stride must survive the round trip, not be \
+                 re-derived from our VkImage",
+            );
+            assert_eq!(export.offset, 0, "{case}: offset must round trip");
+        }
+    }
+
     /// arm (the Vk branch).
     #[test]
     #[ignore = "needs live Vulkan ICD"]

--- a/crates/yserver/src/kms/render/backend.rs
+++ b/crates/yserver/src/kms/render/backend.rs
@@ -37088,35 +37088,50 @@ mod tests {
         // dual-GPU host, and skipping when a node is missing made an
         // earlier version of this test pass vacuously.
         let (w, h) = (256u16, 64u16);
-        let seed = match b.create_pixmap(None, 32, w, h) {
-            Ok(handle) => handle,
-            Err(e) => {
-                eprintln!("skip: create_pixmap: {e}");
-                return;
-            }
-        };
-        let seed_export = match b.dri3_export_pixmap_buffers(seed.as_raw()) {
-            Ok(e) => e,
-            Err(e) => {
-                eprintln!("skip: seed export: {e}");
-                return;
-            }
-        };
+        // Past this point nothing may "skip". A missing Vulkan ICD is a
+        // legitimate skip and is handled above; a fixture that cannot
+        // build once Vulkan IS up is a broken test, and letting it
+        // return green is how the first version of this test passed
+        // vacuously.
+        let seed = b
+            .create_pixmap(None, 32, w, h)
+            .expect("fixture: create_pixmap with a live Vk context");
+        let seed_export = b
+            .dri3_export_pixmap_buffers(seed.as_raw())
+            .expect("fixture: export the seed pixmap");
+        assert!(
+            seed_export.size > 0 && seed_export.stride > 0,
+            "fixture: seed export must describe a real buffer, got size={} stride={}",
+            seed_export.size,
+            seed_export.stride,
+        );
         let stride = seed_export.stride;
         let seed_modifier = seed_export.modifier;
 
-        for (case, requested, expected) in [
+        // The legacy request states a size on the wire; an export must
+        // report that number back verbatim.
+        //
+        // Deliberately NOT the seed's own size: the fallback path derives
+        // the same number from the Vulkan layout, so reusing it makes the
+        // assertion pass whether or not the stated size is honoured. A
+        // distinguishable value is what gives it teeth. A client would not
+        // normally overstate its buffer, but the contract is "report what
+        // the client said", and nothing here consumes the buffer.
+        let stated_size = seed_export.size + 4096;
+        for (case, requested, expected, expected_size) in [
             (
                 "implicit",
-                Dri3ImportModifier::Implicit {
-                    size: seed_export.size,
-                },
+                Dri3ImportModifier::Implicit { size: stated_size },
                 INVALID,
+                stated_size,
             ),
             (
+                // No size on the PixmapFromBuffers wire, so this one
+                // legitimately falls back to the Vulkan layout.
                 "explicit",
                 Dri3ImportModifier::Explicit(seed_modifier),
                 seed_modifier,
+                seed_export.size,
             ),
         ] {
             let fd = seed_export.fd.try_clone().expect("dup the seed dma-buf");
@@ -37139,6 +37154,13 @@ mod tests {
                  re-derived from our VkImage",
             );
             assert_eq!(export.offset, 0, "{case}: offset must round trip");
+            assert_eq!(
+                export.size, expected_size,
+                "{case}: the client's stated buffer size must be reported verbatim. \
+                 Measuring it from the fd instead reports 0 on a failed seek, and moves \
+                 the client's file offset, since a dup'd SCM_RIGHTS fd shares its \
+                 open-file description",
+            );
         }
     }
 

--- a/crates/yserver/src/kms/render/backend.rs
+++ b/crates/yserver/src/kms/render/backend.rs
@@ -28,9 +28,10 @@ use ash::vk;
 use yserver_core::{
     backend::{
         AnyHandle, Backend, BackendFdKind, ClipState, CrtcConfigApply, CrtcConfigToken,
-        CursorHandle, DrawState, Dri3Caps, Dri3PixmapExport, FillState, FontHandle, GlyphSetHandle,
-        KeymapLoad, OriginContext, PictureHandle, PixmapHandle, PresentCaps,
-        PresentScanoutCandidate, PresentSourceWait, WindowHandle, identity_ramp, resample_channel,
+        CursorHandle, DrawState, Dri3Caps, Dri3ImportModifier, Dri3PixmapExport, FillState,
+        FontHandle, GlyphSetHandle, KeymapLoad, OriginContext, PictureHandle, PixmapHandle,
+        PresentCaps, PresentScanoutCandidate, PresentSourceWait, WindowHandle, identity_ramp,
+        resample_channel,
     },
     core_loop::HostInputEvent,
     host_x11::{
@@ -24279,7 +24280,7 @@ impl Backend for KmsBackend {
         height: u16,
         stride: u32,
         offset: u32,
-        modifier: u64,
+        modifier: Dri3ImportModifier,
         depth: u8,
         bpp: u8,
     ) -> io::Result<PixmapHandle> {
@@ -24299,13 +24300,49 @@ impl Backend for KmsBackend {
                 )));
             }
         };
-        let drawable = crate::kms::vk::dri3::import_dmabuf(
+        // Vulkan's modifier import is explicit-only, so an implicit
+        // layout has to be resolved to a concrete modifier first. gbm
+        // does that the way glamor does it for the same request
+        // (`gbm_bo_import(GBM_BO_IMPORT_FD)` then `gbm_bo_get_modifier`,
+        // ../xserver/glamor/glamor_egl.c:572 and :450).
+        //
+        // On failure this returns Err rather than falling back to
+        // LINEAR. Guessing is what #138 was: a wrong *successful*
+        // import corrupts the client's own output and reports success,
+        // where a refused one is visible and debuggable.
+        // What we tell clients later, which is the half that matters:
+        // `DRM_FORMAT_MOD_INVALID` means "layout not named", and a client
+        // re-importing on that answer resolves it itself (EGL and GL have
+        // an implicit dma-buf import path; Vulkan does not). Claiming
+        // LINEAR instead is #138 -- the client believes us and samples a
+        // tiled buffer as linear.
+        //
+        // We cannot do better than "unknown" here: gbm reports
+        // DRM_FORMAT_MOD_INVALID for an implicitly imported buffer on
+        // amdgpu -- measured, and it does so even for gbm's own fresh
+        // allocation -- so there is nothing to resolve against. i915 does
+        // report a concrete modifier, but a fix that only works on Intel
+        // is not a fix.
+        let (vk_modifier, reported_modifier) = match modifier {
+            Dri3ImportModifier::Explicit(m) => (m, Some(m)),
+            // LINEAR is a best-effort for OUR OWN Vulkan view of the
+            // buffer, which is only ever sampled if the server itself
+            // composites this pixmap. It is deliberately NOT what we
+            // report back.
+            Dri3ImportModifier::Implicit => (
+                crate::kms::vk::dri3::DRM_FORMAT_MOD_LINEAR,
+                Some(crate::kms::vk::dri3::DRM_FORMAT_MOD_INVALID),
+            ),
+        };
+        let modifier = vk_modifier;
+        let drawable = crate::kms::vk::dri3::import_dmabuf_reporting(
             vk.clone(),
             fd,
             u32::from(width),
             u32::from(height),
             format,
             modifier,
+            reported_modifier,
             &[crate::kms::vk::dri3::DmabufPlane {
                 offset: u64::from(offset),
                 pitch: stride,
@@ -24374,17 +24411,41 @@ impl Backend for KmsBackend {
         // Client pixmaps are composited as sampled window textures, so
         // probe with the sampled client-import usage (keeps SAMPLED, which
         // correctly steers v3dv clients to a tiled modifier).
-        let screen = crate::kms::vk::dri3::supported_modifiers(
+        let probed = crate::kms::vk::dri3::supported_modifiers_with_planes(
             vk,
             format,
             crate::kms::vk::dri3::CLIENT_IMPORT_USAGE,
         );
-        // Window-modifier list is the subset that the window's
-        // output can flip-scanout. Phase 4.1 always uses LINEAR
-        // for scanout, so the window list collapses to LINEAR
-        // here. A follow-up populates `output.scanout_format_set`
-        // from the real add_fb2 probe and widens this.
-        let window: Vec<u64> = screen.iter().copied().filter(|&m| m == 0).collect();
+        let screen: Vec<u64> = probed.iter().map(|(m, _)| *m).collect();
+        // The window list is the SINGLE-PLANE subset, not just LINEAR.
+        //
+        // `PixmapFromBuffers` import handles one plane today, so a
+        // multi-plane layout offered here is one we then refuse with
+        // BadAlloc: Mesa logs `dri3_alloc_render_buffer ... failed` and
+        // the window renders nothing at all. On this AMD part three of
+        // the six tiled modifiers carry DCC and need two planes (three
+        // when retiled), which is what makes the naive "advertise
+        // everything" version blank every GL client.
+        //
+        // Collapsing to LINEAR is wrong in the other direction: it is
+        // not what the question means once a window is composited
+        // rather than flipped, and composited is our default. Xorg
+        // answers with the tiled set here too.
+        //
+        // This is NOT a fix for #138, and was briefly believed to be.
+        // Offering the tiled single-plane set left that bug exactly as
+        // it was: Chrome's hardware-decoded video arrives over
+        // EGL/dma-buf from VA-API and never travels this path. Do not
+        // reintroduce that claim.
+        //
+        // Plane count comes from `drmFormatModifierPlaneCount`, not from
+        // decoding modifier bits, so the filter tracks whatever the
+        // driver actually reports.
+        let window: Vec<u64> = probed
+            .iter()
+            .filter(|(_, planes)| *planes == 1)
+            .map(|(m, _)| *m)
+            .collect();
         (window, screen)
     }
 
@@ -36999,7 +37060,16 @@ mod tests {
             .expect("open /dev/null");
         let raw = f.into_raw_fd();
         let fd = unsafe { OwnedFd::from_raw_fd(raw) };
-        let res = b.dri3_import_pixmap(fd, 16, 16, 64, 0, 0, 8, 8);
+        let res = b.dri3_import_pixmap(
+            fd,
+            16,
+            16,
+            64,
+            0,
+            yserver_core::backend::Dri3ImportModifier::Explicit(0),
+            8,
+            8,
+        );
         assert!(
             res.is_err(),
             "depth=8 bpp=8 is outside Phase 4.2 RGB single-plane scope",

--- a/crates/yserver/src/kms/render/backend.rs
+++ b/crates/yserver/src/kms/render/backend.rs
@@ -37070,7 +37070,7 @@ mod tests {
     ///   - an explicit import reports back that same modifier;
     ///   - stride and offset survive the round trip unchanged.
     #[test]
-    #[ignore = "needs live Vulkan ICD and a render node"]
+    #[ignore = "needs a Vulkan ICD that can export dma-bufs (not lavapipe)"]
     fn dri3_imported_pixmap_exports_the_clients_own_description() {
         use yserver_core::backend::Dri3ImportModifier;
         const INVALID: u64 = crate::kms::vk::dri3::DRM_FORMAT_MOD_INVALID;
@@ -37088,17 +37088,26 @@ mod tests {
         // dual-GPU host, and skipping when a node is missing made an
         // earlier version of this test pass vacuously.
         let (w, h) = (256u16, 64u16);
-        // Past this point nothing may "skip". A missing Vulkan ICD is a
-        // legitimate skip and is handled above; a fixture that cannot
-        // build once Vulkan IS up is a broken test, and letting it
-        // return green is how the first version of this test passed
-        // vacuously.
         let seed = b
             .create_pixmap(None, 32, w, h)
             .expect("fixture: create_pixmap with a live Vk context");
-        let seed_export = b
-            .dri3_export_pixmap_buffers(seed.as_raw())
-            .expect("fixture: export the seed pixmap");
+        // The real precondition is not "Vulkan initialised" but "this
+        // device can hand out an exportable dma-buf". CI runs the
+        // ignored tests on lavapipe, which initialises fine and then
+        // cannot allocate exportable storage -- that is a legitimate
+        // "not here", not a failure.
+        //
+        // Everything else IS a failure. Skipping on any error is how an
+        // earlier version of this test passed vacuously, and the point of
+        // the narrow match is to keep that door shut.
+        let seed_export = match b.dri3_export_pixmap_buffers(seed.as_raw()) {
+            Ok(e) => e,
+            Err(e) if e.to_string().contains("ERROR_FORMAT_NOT_SUPPORTED") => {
+                eprintln!("skip: ICD cannot export dma-bufs (lavapipe on CI): {e}");
+                return;
+            }
+            Err(e) => panic!("fixture: export the seed pixmap: {e}"),
+        };
         assert!(
             seed_export.size > 0 && seed_export.stride > 0,
             "fixture: seed export must describe a real buffer, got size={} stride={}",

--- a/crates/yserver/src/kms/render/store.rs
+++ b/crates/yserver/src/kms/render/store.rs
@@ -91,6 +91,13 @@ pub(crate) struct ImportedDmabufMetadata {
     pub(crate) fourcc: u32,
     pub(crate) vk_format: vk::Format,
     pub(crate) modifier: u64,
+    /// True when the client never named the layout (legacy
+    /// `PixmapFromBuffer`), so `modifier` above is **our guess**, not a
+    /// fact. Any consumer that acts on the layout -- notably the M1
+    /// direct-scanout probe, which would hand the buffer to KMS
+    /// described as linear -- must refuse such a pixmap rather than
+    /// trust the field.
+    pub(crate) implicit_layout: bool,
     pub(crate) planes: Vec<ImportedDmabufPlane>,
     pub(crate) width: u16,
     pub(crate) height: u16,
@@ -2194,6 +2201,7 @@ mod tests {
     #[test]
     fn imported_dmabuf_metadata_preserves_layout_exactly() {
         let metadata = ImportedDmabufMetadata {
+            implicit_layout: false,
             fourcc: u32::from_le_bytes(*b"XR24"),
             vk_format: vk::Format::B8G8R8A8_UNORM,
             modifier: 0x0100_0000_0000_0002,

--- a/crates/yserver/src/kms/vk/dri3.rs
+++ b/crates/yserver/src/kms/vk/dri3.rs
@@ -322,13 +322,23 @@ pub fn export_dmabuf(
         let fd = dma_buf_fd
             .try_clone()
             .map_err(|_| vk::Result::ERROR_OUT_OF_HOST_MEMORY)?;
-        // dma-buf size via lseek(SEEK_END); the fd's offset is not used
-        // by anything else here, and libc is already a dependency.
-        let size = {
-            use std::os::fd::AsRawFd as _;
-            let end = unsafe { libc::lseek(fd.as_raw_fd(), 0, libc::SEEK_END) };
-            u32::try_from(end.max(0)).unwrap_or(u32::MAX)
-        };
+        // The client's own stated size when the request carried one.
+        // Never measured with lseek: this fd shares its open-file
+        // description with the client's, so seeking it would move the
+        // client's offset, and a failed seek would silently report 0.
+        let size = drawable.import_size.unwrap_or_else(|| {
+            let layout = unsafe {
+                vk.device.get_image_subresource_layout(
+                    drawable.vk_image,
+                    vk::ImageSubresource {
+                        aspect_mask: vk::ImageAspectFlags::COLOR,
+                        mip_level: 0,
+                        array_layer: 0,
+                    },
+                )
+            };
+            u32::try_from(layout.size).unwrap_or(u32::MAX)
+        });
         return Ok(DmabufExport {
             fd,
             size,
@@ -471,10 +481,12 @@ pub fn import_dmabuf_reporting(
     format: vk::Format,
     modifier: u64,
     reported_modifier: Option<u64>,
+    client_size: Option<u32>,
     planes: &[DmabufPlane],
 ) -> Result<DrawableImage, DrawableImageError> {
     let mut image = import_dmabuf(vk, dma_buf_fd, width, height, format, modifier, planes)?;
     image.drm_modifier = reported_modifier;
+    image.import_size = client_size;
     Ok(image)
 }
 

--- a/crates/yserver/src/kms/vk/dri3.rs
+++ b/crates/yserver/src/kms/vk/dri3.rs
@@ -13,6 +13,10 @@ use super::{
 
 /// Linear, untagged DRM format modifier (`DRM_FORMAT_MOD_LINEAR`).
 pub const DRM_FORMAT_MOD_LINEAR: u64 = 0;
+/// "Layout not named." What DRI3 1.0 `PixmapFromBuffer` conveys, and
+/// what we must report back for such a pixmap rather than inventing a
+/// concrete modifier -- see `Dri3ImportModifier` and #138.
+pub const DRM_FORMAT_MOD_INVALID: u64 = 0x00ff_ffff_ffff_ffff;
 
 /// All DRM format modifiers the driver advertises as importable for
 /// `format` as DMA_BUF (single-plane, EXCLUSIVE sharing).
@@ -51,8 +55,27 @@ pub fn supported_modifiers(
     format: vk::Format,
     usage: vk::ImageUsageFlags,
 ) -> Vec<u64> {
+    supported_modifiers_with_planes(vk, format, usage)
+        .into_iter()
+        .map(|(modifier, _planes)| modifier)
+        .collect()
+}
+
+/// [`supported_modifiers`], but each entry carries the number of memory
+/// planes the layout needs (`drmFormatModifierPlaneCount`).
+///
+/// Callers that can only handle a single plane must filter on it rather
+/// than guess from the modifier bits: AMD's DCC layouts need two planes
+/// (three when retiled), and advertising one we then refuse makes the
+/// client render nothing at all rather than fall back.
+#[must_use]
+pub fn supported_modifiers_with_planes(
+    vk: &VkContext,
+    format: vk::Format,
+    usage: vk::ImageUsageFlags,
+) -> Vec<(u64, u32)> {
     if !vk.image_drm_format_modifier {
-        return vec![DRM_FORMAT_MOD_LINEAR];
+        return vec![(DRM_FORMAT_MOD_LINEAR, 1)];
     }
 
     let modifier_count = match list_modifier_count(vk, format) {
@@ -77,7 +100,10 @@ pub fn supported_modifiers(
     let mut accepted = Vec::with_capacity(entries);
     for prop in props_storage.iter().take(entries) {
         if can_import_modifier(vk, format, prop.drm_format_modifier, usage) {
-            accepted.push(prop.drm_format_modifier);
+            accepted.push((
+                prop.drm_format_modifier,
+                prop.drm_format_modifier_plane_count,
+            ));
         }
     }
 
@@ -281,6 +307,37 @@ pub fn export_dmabuf(
         .external_memory_fd
         .as_ref()
         .ok_or(vk::Result::ERROR_EXTENSION_NOT_PRESENT)?;
+    // An imported pixmap is the CLIENT's buffer. Hand back that same
+    // buffer, with the client's own plane description -- do not launder
+    // it through `vkGetMemoryFdKHR` on our VkImage.
+    //
+    // #138: for a legacy `PixmapFromBuffer` we had to guess a modifier to
+    // build that VkImage at all, so re-exporting from it describes the
+    // buffer by our guess rather than by what it is. Returning the
+    // original fd keeps the buffer's own layout metadata intact, which is
+    // what lets the client resolve the layout itself.
+    if let super::target::ImageBacking::Imported { dma_buf_fd, .. } = &drawable.backing
+        && let Some((stride, offset)) = drawable.import_plane0
+    {
+        let fd = dma_buf_fd
+            .try_clone()
+            .map_err(|_| vk::Result::ERROR_OUT_OF_HOST_MEMORY)?;
+        // dma-buf size via lseek(SEEK_END); the fd's offset is not used
+        // by anything else here, and libc is already a dependency.
+        let size = {
+            use std::os::fd::AsRawFd as _;
+            let end = unsafe { libc::lseek(fd.as_raw_fd(), 0, libc::SEEK_END) };
+            u32::try_from(end.max(0)).unwrap_or(u32::MAX)
+        };
+        return Ok(DmabufExport {
+            fd,
+            size,
+            stride,
+            offset,
+            modifier: drawable.drm_modifier.unwrap_or(DRM_FORMAT_MOD_LINEAR),
+        });
+    }
+
     let memory = drawable.backing_memory();
     let layout = unsafe {
         vk.device.get_image_subresource_layout(
@@ -304,10 +361,16 @@ pub fn export_dmabuf(
         size,
         stride: pitch,
         offset: u32::try_from(layout.offset).unwrap_or(0),
-        // DrawableImage (imported client buffers) does not currently
-        // track its DRM modifier; report LINEAR. The TFP export path uses
-        // export_promoted/export_backing, which carry the real modifier.
-        modifier: DRM_FORMAT_MOD_LINEAR,
+        // Report the modifier the image was actually imported with.
+        //
+        // This used to hardcode LINEAR "because DrawableImage does not
+        // track its modifier", which is the export half of #138: a
+        // client that imported a TILED buffer through the legacy
+        // PixmapFromBuffer asked for it back, was told LINEAR, and
+        // sampled its own frame as linear. Server-owned images have no
+        // client modifier and still answer LINEAR here; they export
+        // through export_promoted, which carries the real one.
+        modifier: drawable.drm_modifier.unwrap_or(DRM_FORMAT_MOD_LINEAR),
     })
 }
 
@@ -394,6 +457,27 @@ pub fn export_promoted(
 /// §3.2. Takes ownership of `dma_buf_fd`. On success the fd lifetime
 /// is owned by the resulting `DrawableImage`; on failure the OwnedFd
 /// drops and closes the fd.
+/// [`import_dmabuf`], but recording a *reported* modifier that may differ
+/// from the one Vulkan was given.
+///
+/// They diverge for a legacy `PixmapFromBuffer`: Vulkan needs some
+/// concrete modifier to build an image at all, while the honest answer to
+/// give a client asking about that pixmap is `DRM_FORMAT_MOD_INVALID`.
+pub fn import_dmabuf_reporting(
+    vk: Arc<VkContext>,
+    dma_buf_fd: std::os::fd::OwnedFd,
+    width: u32,
+    height: u32,
+    format: vk::Format,
+    modifier: u64,
+    reported_modifier: Option<u64>,
+    planes: &[DmabufPlane],
+) -> Result<DrawableImage, DrawableImageError> {
+    let mut image = import_dmabuf(vk, dma_buf_fd, width, height, format, modifier, planes)?;
+    image.drm_modifier = reported_modifier;
+    Ok(image)
+}
+
 pub fn import_dmabuf(
     vk: Arc<VkContext>,
     dma_buf_fd: std::os::fd::OwnedFd,

--- a/crates/yserver/src/kms/vk/target.rs
+++ b/crates/yserver/src/kms/vk/target.rs
@@ -51,6 +51,19 @@ pub struct DrawableImage {
     pub extent: vk::Extent2D,
     pub format: vk::Format,
     pub backing: ImageBacking,
+    /// DRM format modifier this image was imported with, for images
+    /// that came from a client dma-buf. `BuffersFromPixmap` must report
+    /// it back verbatim: answering LINEAR for a tiled import is #138 --
+    /// the client re-imports by our answer and samples its own buffer
+    /// wrong. `None` for server-owned images, which export through
+    /// `export_promoted` and carry their modifier on the storage.
+    pub drm_modifier: Option<u64>,
+    /// Plane-0 `(stride, offset)` exactly as the client described it at
+    /// import. An export of an imported pixmap hands back the client's
+    /// own buffer and its own description, rather than re-deriving one
+    /// from our Vulkan view -- which for an implicit import is a view we
+    /// had to guess at.
+    pub import_plane0: Option<(u32, u32)>,
     /// Damage accumulated since the last successful upload. Updated
     /// at every drawing-op call site (Task 3.3 marks whole-image
     /// damage; 4.1.4 family ports tighten to per-op rects).
@@ -587,6 +600,11 @@ impl DrawableImage {
                 dma_buf_fd,
                 vk_memory: memory,
             },
+            drm_modifier: Some(modifier),
+            import_plane0: Some((
+                plane_pitches.first().copied().unwrap_or(0),
+                u32::try_from(plane_offsets.first().copied().unwrap_or(0)).unwrap_or(0),
+            )),
             damage: MirrorDamage::default(),
             current_layout: vk::ImageLayout::UNDEFINED,
             vk,
@@ -681,6 +699,10 @@ impl DrawableImage {
         };
 
         Ok(Self {
+            // Server-owned: exported via export_promoted, which carries
+            // the modifier on the storage instead.
+            drm_modifier: None,
+            import_plane0: None,
             vk_image: image,
             vk_image_view: view,
             mask_view: None,
@@ -1035,6 +1057,10 @@ impl DrawableImage {
         extent: vk::Extent2D,
     ) -> Self {
         Self {
+            // Server-owned: exported via export_promoted, which carries
+            // the modifier on the storage instead.
+            drm_modifier: None,
+            import_plane0: None,
             vk_image: entry.image,
             vk_image_view: entry.view,
             mask_view: None,

--- a/crates/yserver/src/kms/vk/target.rs
+++ b/crates/yserver/src/kms/vk/target.rs
@@ -64,6 +64,12 @@ pub struct DrawableImage {
     /// from our Vulkan view -- which for an implicit import is a view we
     /// had to guess at.
     pub import_plane0: Option<(u32, u32)>,
+    /// Buffer size the client stated at import, where the request
+    /// carried one (legacy `PixmapFromBuffer` does; `PixmapFromBuffers`
+    /// does not). Reported verbatim on export rather than measured:
+    /// an `lseek` on a dup'd SCM_RIGHTS fd shares its open-file
+    /// description, so probing it moves the client's file offset.
+    pub import_size: Option<u32>,
     /// Damage accumulated since the last successful upload. Updated
     /// at every drawing-op call site (Task 3.3 marks whole-image
     /// damage; 4.1.4 family ports tighten to per-op rects).
@@ -601,6 +607,7 @@ impl DrawableImage {
                 vk_memory: memory,
             },
             drm_modifier: Some(modifier),
+            import_size: None,
             import_plane0: Some((
                 plane_pitches.first().copied().unwrap_or(0),
                 u32::try_from(plane_offsets.first().copied().unwrap_or(0)).unwrap_or(0),
@@ -702,6 +709,7 @@ impl DrawableImage {
             // Server-owned: exported via export_promoted, which carries
             // the modifier on the storage instead.
             drm_modifier: None,
+            import_size: None,
             import_plane0: None,
             vk_image: image,
             vk_image_view: view,
@@ -1060,6 +1068,7 @@ impl DrawableImage {
             // Server-owned: exported via export_promoted, which carries
             // the modifier on the storage instead.
             drm_modifier: None,
+            import_size: None,
             import_plane0: None,
             vk_image: entry.image,
             vk_image_view: entry.view,

--- a/docs/status.md
+++ b/docs/status.md
@@ -620,6 +620,63 @@ lives in [`code-quality-audit-2026-07-26.md`](code-quality-audit-2026-07-26.md).
 
 ## Where we are
 
+- **2026-09-10 #138 Chrome hardware-decoded video scrambled — FIXED, hardware
+  confirmed:** ads, video and fullscreen all correct on silence (RX 6800,
+  Mesa 26.2.2, Chromium, AV1 via `VaapiVideoDecoder`). Two server-side lies,
+  both ours, on the legacy `DRI3::PixmapFromBuffer` path.
+
+  *The layout claim.* DRI3 1.0 carries no modifier, which means the layout is
+  **implicit**, not linear. We passed a hardcoded `0` — an explicit
+  `DRM_FORMAT_MOD_LINEAR` — for every such import. `Dri3ImportModifier` now
+  makes the two requests structurally distinct: `Explicit(m)` for
+  `PixmapFromBuffers`, `Implicit` for the legacy request, so they cannot be
+  conflated again.
+
+  *The export.* `export_dmabuf` re-exported via `vkGetMemoryFdKHR` from a
+  VkImage we had to *describe* as LINEAR in order to create at all, so the
+  client got back a re-export of our wrong description of its own buffer. An
+  imported pixmap now exports a dup of the **client's original fd** with the
+  client's own stride/offset, never routed through our Vulkan view. The
+  buffer keeps its own layout metadata, which is what lets the client resolve
+  the real tiling — the thing glamor gets for free by staying implicit end to
+  end. This is more correct independently of #138: an imported pixmap *is* the
+  client's buffer.
+
+  *Why the obvious repairs do not work, measured so nobody retries them.*
+  gbm cannot resolve an implicit layout on amdgpu: `gbm_bo_get_modifier`
+  returns `DRM_FORMAT_MOD_INVALID` for an implicitly imported buffer **and for
+  gbm's own fresh allocation**. i915 does report a concrete modifier, so a
+  probe run against the wrong render node looks like success — silence is
+  dual-GPU and `renderD128` is the i915, `renderD129` the RX 6800. Vulkan has
+  no implicit-import path, unlike EGL. Reporting `DRM_FORMAT_MOD_INVALID`
+  instead of LINEAR is *not* sufficient on its own — tried, still garbled;
+  the fd is the part that matters.
+
+  *Diagnosis path, since inference from the corruption pattern failed three
+  times:* an `LD_PRELOAD` interposer on `vaExportSurfaceHandle` read the real
+  descriptor — tiled `0x0200000020801b03`, NV12/ARGB. It has to interpose
+  `dlsym`, because Chromium `dlopen`s libva and a plain symbol override never
+  fires. Kept at `target/diag138/va_trace.c` (gitignored); needs
+  `chromium --disable-gpu-sandbox`.
+
+  *Also fixed on the way, separate contract bug:* `dri3_supported_modifiers`
+  returned a LINEAR-only **window** list. Widening it to the full screen list
+  blanks every GL client — Mesa picks a DCC modifier needing 2–3 planes, our
+  dispatcher rejects `num_buffers != 1`, and Mesa logs
+  `dri3_alloc_render_buffer ... failed`. The window list is now the
+  single-plane subset, filtered on `drmFormatModifierPlaneCount` rather than
+  on decoded modifier bits. Verified NOT to be the #138 fix: Chrome then took
+  tiled `0x200000020801b03` for its window pixmap and the video was still
+  scrambled.
+
+  *Still open.* Our own Vulkan view of an implicitly imported pixmap is still
+  described as LINEAR when it is not, so a server-side composite of one would
+  render garbage; in Chrome's flow nothing does — the log shows zero
+  server-side draw ops against those pixmaps — but a screenshot or a
+  compositor redirecting one would. Fixing that needs amdgpu BO-metadata
+  decoding or an EGL import path. Multi-plane `PixmapFromBuffers` also remains
+  unimplemented.
+
 - **2026-09-10 composite overlay claim ownership validated on hardware:**
   awesome + picom on silence, **A/B against master on the same hardware**:
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -669,13 +669,30 @@ lives in [`code-quality-audit-2026-07-26.md`](code-quality-audit-2026-07-26.md).
   tiled `0x200000020801b03` for its window pixmap and the video was still
   scrambled.
 
-  *Still open.* Our own Vulkan view of an implicitly imported pixmap is still
-  described as LINEAR when it is not, so a server-side composite of one would
-  render garbage; in Chrome's flow nothing does — the log shows zero
-  server-side draw ops against those pixmaps — but a screenshot or a
-  compositor redirecting one would. Fixing that needs amdgpu BO-metadata
-  decoding or an EGL import path. Multi-plane `PixmapFromBuffers` also remains
-  unimplemented.
+  *Scope, stated precisely (codex, and it is the right framing):* this fixes
+  **Chrome's round trip**, not "legacy implicit DRI3 imports". Our own Vulkan
+  view of such a pixmap is still built as if the buffer were linear, because
+  Vulkan cannot import implicitly and gbm cannot resolve the layout on
+  amdgpu. Chrome never makes the server sample those pixmaps — the log shows
+  zero server-side draw ops against them — but `CopyArea`, RENDER, a
+  compositor redirect or a screenshot involving one would still render
+  garbage. Making the view itself right needs an EGL implicit-import path or
+  a driver-specific layout resolver.
+
+  Two consequences of that are now handled rather than left latent, both
+  found by codex on review:
+  - The legacy request carries `size` on the wire and it is now preserved and
+    reported verbatim. The first version measured it with `lseek(SEEK_END)`,
+    which is wrong twice over: a failure silently reports 0, and the fd
+    shares its open-file description with the client's, so probing it moves
+    the client's file offset.
+  - `ImportedDmabufMetadata::implicit_layout` marks a guessed layout, and the
+    **M1 direct-scanout probe refuses such a pixmap**. Without that, a tiled
+    buffer described as linear could be handed to `add_fb2`, which may well
+    accept it and put garbage on the display. The refusal accounts as
+    `m1_gate_reject_import`, so it is visible in telemetry.
+
+  Multi-plane `PixmapFromBuffers` also remains unimplemented.
 
 - **2026-09-10 composite overlay claim ownership validated on hardware:**
   awesome + picom on silence, **A/B against master on the same hardware**:


### PR DESCRIPTION
Closes #138.

Chrome with hardware acceleration played YouTube video as scrambled
horizontal lines, while the rest of the page rendered correctly. Firefox was
unaffected, and so was Chrome with hardware acceleration turned off.

yserver was describing Chrome's own video buffer back to it incorrectly: on
the older DRI3 import path, a buffer whose layout the client never specified
was assumed to be laid out linearly, and that assumption was then reported
back as fact. Chrome trusted it and sampled its own frames wrong.

Verified on AMD RX 6800 — advert, video and fullscreen playback all correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
