### PR TITLE
fix(render): Java text was invisible, and subpixel text rendered as solid blocks

### DIFF
--- a/crates/yserver-core/src/core_loop/process_request.rs
+++ b/crates/yserver-core/src/core_loop/process_request.rs
@@ -2010,6 +2010,16 @@ fn handle_render_request(
         }
         23..=25 => {
             let Some(req) = x11::render_composite_glyphs_request(body) else {
+                // Silently dropping this draws nothing and reports no
+                // error, which looks exactly like "the text is invisible"
+                // (#137). Say so.
+                debug!(
+                    "client {} #{} RENDER::CompositeGlyphs{} -> DROPPED (body not parsed, {} bytes)",
+                    client_id.0,
+                    sequence.0,
+                    8u16 << (u16::from(minor) - 23),
+                    body.len(),
+                );
                 return Ok(RequestOutcome::Handled);
             };
             if dst_picture_is_sourceless(state, req.dst) {
@@ -2035,6 +2045,20 @@ fn handle_render_request(
                 .resources
                 .glyphset(req.glyphset)
                 .map(|g| g.host_glyphset_xid.as_raw());
+            if host_src.is_none() || host_dst.is_none() || host_gs.is_none() {
+                debug!(
+                    "client {} #{} RENDER::CompositeGlyphs src=0x{:x}{} dst=0x{:x}{} glyphset=0x{:x}{} \
+                     -> DROPPED (unresolved resource)",
+                    client_id.0,
+                    sequence.0,
+                    req.src.0,
+                    if host_src.is_none() { " MISSING" } else { "" },
+                    req.dst.0,
+                    if host_dst.is_none() { " MISSING" } else { "" },
+                    req.glyphset.0,
+                    if host_gs.is_none() { " MISSING" } else { "" },
+                );
+            }
             if let (Some(host_src), Some(host_dst), Some(host_gs)) = (host_src, host_dst, host_gs) {
                 let mask_fmt = if req.mask_format == 0 {
                     0
@@ -2049,6 +2073,23 @@ fn handle_render_request(
                         req.src_y, &req.items, 0, 0,
                     )
                     .unwrap_or_default();
+                debug!(
+                    "client {} #{} RENDER::CompositeGlyphs{} op={} src=0x{:x} dst=0x{:x} gs=0x{:x} \
+                     mask_format={}->{} items={} src_xy=({},{}) -> painted {} rect(s)",
+                    client_id.0,
+                    sequence.0,
+                    8u16 << (u16::from(minor) - 23),
+                    req.op,
+                    req.src.0,
+                    req.dst.0,
+                    req.glyphset.0,
+                    req.mask_format,
+                    mask_fmt,
+                    req.items.len(),
+                    req.src_x,
+                    req.src_y,
+                    painted.len(),
+                );
                 if let Some(dst_drawable) =
                     state.resources.picture(req.dst).and_then(|p| p.drawable)
                 {

--- a/crates/yserver/src/kms/backend.rs
+++ b/crates/yserver/src/kms/backend.rs
@@ -189,6 +189,159 @@ impl Depth1MaskCache {
     }
 }
 
+/// CPU cache of #137 tier-1 uniform glyph-source colours: the
+/// premultiplied `[f32; 4]` a 1x1 drawable source collapsed to, keyed by
+/// the drawable it was read from.
+///
+/// **The read is not what costs.** Measured on a deliberately worst-case
+/// synthetic churn workload (32 strings recoloured every 10ms), the
+/// pixel copy-out itself is 1.5 ms/s — noise. What costs is that
+/// [`RenderEngine::get_image`](crate::kms::render::engine::RenderEngine::get_image)
+/// must close any open frame
+/// ([`CloseReason::SyncWait`](crate::kms::render::frame_builder::CloseReason::SyncWait))
+/// before it can wait on its readback fence, and that close destroys the
+/// batching `composite_glyphs_via_frame_builder` exists to provide:
+/// `frame_builder_opens=237 closes=238` per second with
+/// `close_reasons[sync_wait=179]` — ~75% of ALL frame closes were this
+/// one readback — and `ops/frame_avg` collapsed to 1.6.
+///
+/// A hit skips `get_image` entirely and therefore skips the frame close.
+/// That, not the copy, is what this buys.
+///
+/// # Keying — all three components of the spec's invariant 6
+///
+/// A hit requires `(DrawableId, content_version, offset)` to match, and
+/// each component is load-bearing:
+///
+/// - **`DrawableId`** — minted monotonically and never recycled, so a
+///   freed-and-reallocated pixmap always gets a fresh id and cannot
+///   alias a stale entry. `content_version` alone would collide across
+///   drawables: it is local to an allocation, so two unrelated 1x1
+///   sources both sitting at version 3 would share one colour.
+/// - **`content_version`** (`store.rs`, bumped by every pixel write) —
+///   this is the staleness guard, and it is the whole reason population
+///   happens only AFTER the ordered read. Java's `XRSolidSrcPict`
+///   repaints the SAME 1x1 pixmap to change text colour and then reuses
+///   the picture, so a value cached at `CreatePicture` time — or keyed
+///   on anything that does not move when the pixels do — renders every
+///   later run of text in the PREVIOUS colour. That converts a total,
+///   obvious failure into an intermittent wrong-colour one, which is
+///   strictly worse than the bug being fixed (spec invariant 4).
+/// - **`offset`** — one backing can legitimately be sampled at several
+///   content offsets at the same version (a redirected window's 1x1
+///   content domain inside a larger allocation), and those are different
+///   pixels.
+///
+/// Following [`Depth1MaskCache`]'s shape, the map key carries identity +
+/// offset while `content_version` is validated inside the entry. That is
+/// the same triple, and it has one property a three-part map key does
+/// not: only ONE version of a given `(id, offset)` is ever live, so an
+/// insert REPLACES its predecessor instead of stranding it. Keying the
+/// map on a monotonically increasing version would accumulate a dead
+/// entry per repaint — a leak in all but name, and exactly the shape
+/// Java's recolour-per-string pattern produces fastest.
+///
+/// Bounded LRU on top of that, so sources of long-gone pixmaps cannot
+/// accumulate and no free-path hook is needed.
+pub(crate) struct UniformGlyphSourceCache {
+    entries: std::collections::HashMap<UniformGlyphSourceKey, UniformGlyphSourceEntry>,
+    /// LRU order, back = most-recently-used. `touch` removes any prior
+    /// occurrence before pushing, so this stays duplicate-free and
+    /// `entries.len() == order.len()` holds.
+    order: std::collections::VecDeque<UniformGlyphSourceKey>,
+    cap: usize,
+}
+
+/// Identity + sampled origin. The version lives in the entry; see
+/// [`UniformGlyphSourceCache`] for why it is not part of the map key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct UniformGlyphSourceKey {
+    id: crate::kms::render::store::DrawableId,
+    /// `SourceDrawable::offset()`, already resolved into backing space.
+    offset: (i32, i32),
+}
+
+struct UniformGlyphSourceEntry {
+    content_version: u64,
+    premul: [f32; 4],
+}
+
+impl UniformGlyphSourceCache {
+    /// `cap` = max distinct `(drawable, offset)` sources retained
+    /// (clamped to >= 1). A client typically holds exactly one such
+    /// pixmap (Java's per-`GraphicsConfiguration` `XRSolidSrcPict`), and
+    /// each entry is a key plus four floats, so this is generous.
+    pub(crate) fn new(cap: usize) -> Self {
+        Self {
+            entries: std::collections::HashMap::new(),
+            order: std::collections::VecDeque::new(),
+            cap: cap.max(1),
+        }
+    }
+
+    /// Hit iff we hold this `(id, offset)` at the SAME `content_version`.
+    /// A hit lets the caller skip the ordered readback, and with it the
+    /// frame close that readback forces.
+    pub(crate) fn get(
+        &mut self,
+        id: crate::kms::render::store::DrawableId,
+        content_version: u64,
+        offset: (i32, i32),
+    ) -> Option<[f32; 4]> {
+        let key = UniformGlyphSourceKey { id, offset };
+        let premul = match self.entries.get(&key) {
+            Some(e) if e.content_version == content_version => e.premul,
+            _ => return None,
+        };
+        self.touch(key);
+        Some(premul)
+    }
+
+    /// Insert (or replace) this source's colour and evict LRU victims
+    /// past `cap`. Called ONLY after the ordered read has returned the
+    /// pixel — never at picture-create time.
+    pub(crate) fn insert(
+        &mut self,
+        id: crate::kms::render::store::DrawableId,
+        content_version: u64,
+        offset: (i32, i32),
+        premul: [f32; 4],
+    ) {
+        let key = UniformGlyphSourceKey { id, offset };
+        self.entries.insert(
+            key,
+            UniformGlyphSourceEntry {
+                content_version,
+                premul,
+            },
+        );
+        self.touch(key);
+        while self.entries.len() > self.cap {
+            match self.order.pop_front() {
+                Some(victim) => {
+                    self.entries.remove(&victim);
+                }
+                None => break,
+            }
+        }
+    }
+
+    /// Move `key` to the MRU end, removing any stale position first so
+    /// `order` never holds duplicates.
+    fn touch(&mut self, key: UniformGlyphSourceKey) {
+        if let Some(pos) = self.order.iter().position(|&x| x == key) {
+            self.order.remove(pos);
+        }
+        self.order.push_back(key);
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        debug_assert_eq!(self.entries.len(), self.order.len());
+        self.entries.len()
+    }
+}
+
 /// Rasterise an X11 pixmap clip-mask against a paint-rect list.
 ///
 /// X11 GC clip-mask: a pixel paints iff the mask bit at
@@ -1141,5 +1294,107 @@ mod depth1_mask_cache_tests {
         assert!(c.get(b, 1, 1, 1).is_none(), "LRU entry b evicted");
         assert!(c.get(a, 1, 1, 1).is_some(), "recently-used a survives");
         assert!(c.get(d, 1, 1, 1).is_some(), "newest d survives");
+    }
+}
+
+/// #137 step 5 — the collision cases the `(DrawableId, content_version,
+/// offset)` key exists to prevent. None of them is visible without an
+/// explicit test: every one of them looks like a working cache until the
+/// wrong colour comes out.
+#[cfg(test)]
+mod uniform_glyph_source_cache_tests {
+    use super::UniformGlyphSourceCache;
+    use crate::kms::render::store::DrawableId;
+
+    const RED: [f32; 4] = [1.0, 0.0, 0.0, 1.0];
+    const BLUE: [f32; 4] = [0.0, 0.0, 1.0, 1.0];
+
+    /// Spec invariant 4: a repaint bumps `content_version`, and the
+    /// entry stored at the old version must NOT satisfy the new read.
+    /// This is the staleness trap — Java repaints this very pixmap to
+    /// change text colour and reuses the picture.
+    #[test]
+    fn a_bumped_content_version_misses() {
+        let mut c = UniformGlyphSourceCache::new(8);
+        let id = DrawableId::for_tests(1);
+        assert_eq!(c.get(id, 0, (0, 0)), None, "empty cache misses");
+
+        c.insert(id, 5, (0, 0), RED);
+        assert_eq!(c.get(id, 5, (0, 0)), Some(RED), "same version hits");
+        assert_eq!(
+            c.get(id, 6, (0, 0)),
+            None,
+            "a repainted source must force a fresh ordered read"
+        );
+    }
+
+    /// `content_version` is local to an allocation, so two unrelated
+    /// drawables routinely sit at the same version. Keying on the
+    /// version alone would hand drawable 2 drawable 1's colour.
+    #[test]
+    fn two_drawables_at_the_same_content_version_do_not_share_an_entry() {
+        let mut c = UniformGlyphSourceCache::new(8);
+        let (a, b) = (DrawableId::for_tests(1), DrawableId::for_tests(2));
+        c.insert(a, 3, (0, 0), RED);
+        assert_eq!(
+            c.get(b, 3, (0, 0)),
+            None,
+            "a different drawable at the same version must not hit"
+        );
+        c.insert(b, 3, (0, 0), BLUE);
+        assert_eq!(c.get(a, 3, (0, 0)), Some(RED));
+        assert_eq!(c.get(b, 3, (0, 0)), Some(BLUE));
+    }
+
+    /// One backing can legitimately be sampled at several content
+    /// offsets at the same version — a redirected window's 1x1 content
+    /// domain inside a larger allocation. Those are different pixels.
+    #[test]
+    fn two_offsets_into_one_backing_do_not_share_an_entry() {
+        let mut c = UniformGlyphSourceCache::new(8);
+        let id = DrawableId::for_tests(1);
+        c.insert(id, 7, (0, 0), RED);
+        assert_eq!(
+            c.get(id, 7, (4, 2)),
+            None,
+            "a different sampled offset must not hit"
+        );
+        c.insert(id, 7, (4, 2), BLUE);
+        assert_eq!(c.get(id, 7, (0, 0)), Some(RED));
+        assert_eq!(c.get(id, 7, (4, 2)), Some(BLUE));
+    }
+
+    /// Only one version of a given `(id, offset)` is ever live, so a
+    /// repaint REPLACES its predecessor rather than stranding it. A map
+    /// keyed on the monotonically increasing version would leave a dead
+    /// entry per repaint — a leak, and Java's recolour-per-string
+    /// pattern produces it fastest.
+    #[test]
+    fn a_repaint_replaces_rather_than_accumulates() {
+        let mut c = UniformGlyphSourceCache::new(8);
+        let id = DrawableId::for_tests(1);
+        for v in 1..=100 {
+            c.insert(id, v, (0, 0), RED);
+        }
+        assert_eq!(c.len(), 1, "100 repaints must leave one entry");
+    }
+
+    #[test]
+    fn bounded_lru_evicts_least_recently_used() {
+        let mut c = UniformGlyphSourceCache::new(2);
+        let (a, b, d) = (
+            DrawableId::for_tests(1),
+            DrawableId::for_tests(2),
+            DrawableId::for_tests(3),
+        );
+        c.insert(a, 1, (0, 0), RED);
+        c.insert(b, 1, (0, 0), BLUE);
+        // Touch `a` so `b` becomes the LRU victim.
+        assert_eq!(c.get(a, 1, (0, 0)), Some(RED));
+        c.insert(d, 1, (0, 0), RED);
+        assert_eq!(c.len(), 2, "cap enforced");
+        assert_eq!(c.get(b, 1, (0, 0)), None, "LRU entry b evicted");
+        assert_eq!(c.get(a, 1, (0, 0)), Some(RED), "recently-used a survives");
+        assert_eq!(c.get(d, 1, (0, 0)), Some(RED), "newest d survives");
     }
 }

--- a/crates/yserver/src/kms/backend.rs
+++ b/crates/yserver/src/kms/backend.rs
@@ -1199,10 +1199,20 @@ pub(crate) fn parse_add_glyphs(gs: &mut GlyphSetState, body_tail: &[u8]) {
             break;
         }
         let wire = &body_tail[data_off..data_off + nbytes];
-        // For ARGB32 we extract the alpha byte from each pixel into a
-        // densely-packed A8 buffer and record the stored glyph as A8.
-        // The downstream atlas + text pipeline path then handles it
-        // identically to a real A8 upload.
+        // Store each glyph in the format it arrived in. A8 is
+        // densified (its wire rows are padded to 4 bytes); A1 and
+        // ARGB32 keep their wire bytes verbatim, and the conversion
+        // to the atlas's A8 coverage plane happens on an atlas MISS
+        // in the engine (`GlyphPixels::to_a8`), so a resident glyph
+        // is never converted twice.
+        //
+        // ARGB32 in particular must NOT be reduced here: it used to
+        // be flattened to its alpha byte and recorded as A8, which is
+        // what made subpixel-antialiased text render as solid blocks
+        // (a subpixel-AA client leaves alpha at 255 across the whole
+        // glyph box and puts the coverage in R, G and B). Keeping the
+        // four channels also leaves the component-alpha path able to
+        // pack all of them later.
         let (pixels, stored_format) = match gs.format {
             GlyphSetFormat::A8 => {
                 let mut pixels = vec![0u8; w * h];
@@ -1213,18 +1223,11 @@ pub(crate) fn parse_add_glyphs(gs: &mut GlyphSetState, body_tail: &[u8]) {
                 (pixels, GlyphSetFormat::A8)
             }
             GlyphSetFormat::A1 => (wire.to_vec(), GlyphSetFormat::A1),
-            GlyphSetFormat::Argb32 => {
-                // Pixel bytes per X RENDER ARGB32 = little-endian
-                // CARD32 with alpha-shift=24 → memory order [B, G, R, A].
-                let mut pixels = vec![0u8; w * h];
-                for row in 0..h {
-                    let row_off = row * stride;
-                    for col in 0..w {
-                        pixels[row * w + col] = wire[row_off + col * 4 + 3];
-                    }
-                }
-                (pixels, GlyphSetFormat::A8)
-            }
+            // Memory order per pixel is [B, G, R, A] — X RENDER
+            // `PICT_a8r8g8b8` is a little-endian CARD32 with
+            // alpha-shift 24, so blue is the LOW byte. Rows are
+            // dense at `4 * w`, which is already 4-aligned.
+            GlyphSetFormat::Argb32 => (wire.to_vec(), GlyphSetFormat::Argb32),
             GlyphSetFormat::Other => return,
         };
         data_off += nbytes;
@@ -1240,6 +1243,95 @@ pub(crate) fn parse_add_glyphs(gs: &mut GlyphSetState, body_tail: &[u8]) {
                 pixels,
                 format: stored_format,
             },
+        );
+    }
+}
+
+#[cfg(test)]
+mod parse_add_glyphs_tests {
+    use super::parse_add_glyphs;
+    use crate::kms::{
+        core::{GlyphSetFormat, GlyphSetState},
+        render::glyph_pixels::reduce_argb32_glyph_to_a8_coverage,
+    };
+    use std::collections::HashMap;
+
+    /// Build an `AddGlyphs` `body_tail` for a single glyph: the
+    /// bytes after the 4-byte glyphset XID.
+    fn one_glyph_body(w: u16, h: u16, pixels: &[u8]) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(&1u32.to_le_bytes()); // n = 1
+        body.extend_from_slice(&7u32.to_le_bytes()); // glyph id
+        body.extend_from_slice(&w.to_le_bytes());
+        body.extend_from_slice(&h.to_le_bytes());
+        body.extend_from_slice(&0i16.to_le_bytes()); // x bearing
+        body.extend_from_slice(&0i16.to_le_bytes()); // y bearing
+        body.extend_from_slice(&i16::try_from(w).unwrap_or(0).to_le_bytes()); // x_off
+        body.extend_from_slice(&0i16.to_le_bytes()); // y_off
+        body.extend_from_slice(pixels);
+        body
+    }
+
+    fn ingest(format: GlyphSetFormat, w: u16, h: u16, pixels: &[u8]) -> GlyphSetState {
+        let mut gs = GlyphSetState {
+            format,
+            glyphs: HashMap::new(),
+        };
+        parse_add_glyphs(&mut gs, &one_glyph_body(w, h, pixels));
+        gs
+    }
+
+    #[test]
+    fn a8_glyphs_are_densified_and_stay_a8() {
+        // Invariant 1: the common path must not move. A8 wire rows
+        // are padded to 4 bytes; ingest strips the pad and nothing
+        // else.
+        let wire = [1u8, 2, 3, 0xEE, 4, 5, 6, 0xEE];
+        let gs = ingest(GlyphSetFormat::A8, 3, 2, &wire);
+        let g = gs.glyphs.get(&7).expect("glyph stored");
+        assert_eq!(g.format, GlyphSetFormat::A8);
+        assert_eq!(g.pixels, vec![1, 2, 3, 4, 5, 6], "row pad stripped");
+    }
+
+    #[test]
+    fn a1_glyphs_keep_their_wire_bytes_and_stay_a1() {
+        // Invariant 1 again: A1 is forwarded verbatim, expanded
+        // later on atlas miss.
+        let wire = [0b0101_0011u8, 0, 0, 0, 0b1000_0001, 0, 0, 0];
+        let gs = ingest(GlyphSetFormat::A1, 8, 2, &wire);
+        let g = gs.glyphs.get(&7).expect("glyph stored");
+        assert_eq!(g.format, GlyphSetFormat::A1);
+        assert_eq!(g.pixels, wire.to_vec(), "A1 wire bytes untouched");
+    }
+
+    #[test]
+    fn argb32_glyphs_keep_all_four_channels_and_stay_argb32() {
+        // The defect: ingest used to keep only the alpha byte and
+        // record the glyph as A8. On a subpixel-AA glyph alpha is
+        // 255 over the whole box, so the stored glyph was a solid
+        // block. Wire memory order is [B, G, R, A].
+        let wire = [
+            0x20u8, 0x60, 0xA0, 0xE0, // (0,0) B,G,R,A
+            0x10, 0x40, 0x50, 0xFF, // (1,0)
+            0x00, 0x00, 0x00, 0xFF, // (0,1)
+            0xFF, 0xFF, 0xFF, 0xFF, // (1,1)
+        ];
+        let gs = ingest(GlyphSetFormat::Argb32, 2, 2, &wire);
+        let g = gs.glyphs.get(&7).expect("glyph stored");
+        assert_eq!(
+            g.format,
+            GlyphSetFormat::Argb32,
+            "the stored format must stay ARGB32; rewriting it to A8 \
+             is what discarded the colour channels"
+        );
+        assert_eq!(g.pixels, wire.to_vec(), "all four channels retained");
+
+        // And the deferred reduction turns those bytes into real
+        // coverage rather than the alpha byte's solid 0xFF.
+        assert_eq!(
+            reduce_argb32_glyph_to_a8_coverage(&g.pixels, 2, 2),
+            vec![96u8, 53, 0, 255],
+            "coverage = mean of logical R, G, B"
         );
     }
 }

--- a/crates/yserver/src/kms/core.rs
+++ b/crates/yserver/src/kms/core.rs
@@ -1485,13 +1485,20 @@ pub(crate) fn build_font_catalog(fc: &fontconfig::Fontconfig) -> Vec<String> {
 pub(crate) enum GlyphSetFormat {
     A8,
     A1,
-    /// ARGB32 source glyphs (Cairo's default for modern GTK3 themes
-    /// using subpixel / colour-emoji rendering). On `AddGlyphs` we
-    /// extract the alpha channel into a densely-packed A8 buffer and
-    /// store the glyph as if it had been uploaded in A8 format — the
-    /// downstream atlas + text pipeline path is identical from there
-    /// on. Subpixel coverage detail and emoji colour are lost; glyph
-    /// shape is preserved, which is enough for grayscale text.
+    /// ARGB32 source glyphs — every toolkit asking for subpixel
+    /// (LCD) antialiasing, which is the default on MATE, GNOME and
+    /// KDE, plus colour emoji. `AddGlyphs` stores the wire bytes
+    /// verbatim (dense CARD32 rows, memory order `[B, G, R, A]`);
+    /// the engine reduces them to one A8 coverage plane — the mean
+    /// of logical R, G and B — on atlas miss.
+    ///
+    /// It used to keep the **alpha** byte instead and record the
+    /// glyph as `A8`. A subpixel-AA client puts one coverage value
+    /// per LCD subpixel in R, G and B and leaves alpha at 255 over
+    /// the whole glyph box, so that produced a solid `0xFF`
+    /// rectangle per glyph — text as blocks. Real per-channel
+    /// coverage (and emoji colour) still awaits the component-alpha
+    /// path; grayscale-antialiased letterforms are what this yields.
     Argb32,
     Other,
 }
@@ -1509,7 +1516,11 @@ pub(crate) struct StoredGlyph {
     /// horizontal-text rendering only advances the x pen between glyphs.
     #[allow(dead_code)]
     pub(crate) y_off: i16,
-    /// Row-major A8 bytes, densely packed (no per-row padding).
+    /// Glyph pixels as they arrived, in `format`: row-major A8
+    /// bytes densely packed (no per-row padding) for `A8`, the raw
+    /// wire bitmap for `A1`, and the raw `[B, G, R, A]` CARD32 wire
+    /// bytes for `Argb32`. Conversion to the atlas's A8 coverage
+    /// plane happens on atlas miss (`GlyphPixels::to_a8`).
     pub(crate) pixels: Vec<u8>,
     pub(crate) format: GlyphSetFormat,
 }

--- a/crates/yserver/src/kms/render/backend.rs
+++ b/crates/yserver/src/kms/render/backend.rs
@@ -6232,6 +6232,108 @@ impl KmsBackend {
         }
     }
 
+    /// #137 visibility note — record a `CompositeGlyphs` this server
+    /// cannot serve: bump the counter, and log the FIRST occurrence at
+    /// `warn!` with every later one at `debug!`.
+    ///
+    /// A drop here draws nothing and returns no error, so the client
+    /// cannot tell — and neither could we. #137 was an entire class of
+    /// application (every Java/AWT one) rendering no text at all while
+    /// the server's own telemetry knew, because the only evidence sat
+    /// at `debug` in a module the usual `RUST_LOG` filters exclude.
+    /// Warning once means a silently-unsupported paint path announces
+    /// itself rather than never; reverting to `debug` after that means
+    /// a pathological client cannot flood the log.
+    ///
+    /// **Once per process**, deliberately and literally — not once per
+    /// server generation. A bare flag does not reset itself at a
+    /// generation boundary, and wiring one into the reset lifecycle
+    /// would depend on the #121 reset work, which is unmerged and
+    /// parked. Revisit if and when reset lands.
+    ///
+    /// The counter is NOT rate-limited: it advances on every drop.
+    fn record_composite_glyphs_drop(&mut self, reason: std::fmt::Arguments<'_>) {
+        self.telemetry.record_composite_glyphs_dropped_unsupported();
+        if take_first_occurrence(&COMPOSITE_GLYPHS_DROP_WARNED) {
+            log::warn!(
+                "render composite_glyphs UNSUPPORTED: {reason} — this request drew \
+                 NOTHING and returned no error. Further occurrences log at debug; \
+                 the composite_glyphs_dropped_unsupported counter keeps counting."
+            );
+        } else {
+            log::debug!("render composite_glyphs gap: {reason}");
+        }
+    }
+
+    /// #137 tier 1 — collapse a uniform drawable glyph source to the
+    /// premultiplied colour it is, by reading its single pixel.
+    ///
+    /// `Err` carries the reason the caller must log: every way this can
+    /// decline draws no text, and a client whose text silently vanishes
+    /// cannot tell.
+    ///
+    /// Two things about the read are load-bearing:
+    ///
+    /// - It goes through [`RenderEngine::get_image`], the synchronous
+    ///   readback, for its flush / close-frame / fence-wait ordering. A
+    ///   direct image map offers no such guarantee and would race the
+    ///   client's own recolouring — Java repaints this very pixmap to
+    ///   change text colour and then reuses the picture, so an unordered
+    ///   read renders the *previous* colour.
+    /// - It goes through [`Src::server_internal`], the privileged
+    ///   unclipped backing-space handle. `SourceDrawable::offset()` is
+    ///   already resolved into backing space, so a client-bounded `Src`
+    ///   would reapply a coordinate space on top of it and sample the
+    ///   wrong pixel of a redirected window's backing — precisely the
+    ///   case the domain-not-storage rule exists to get right.
+    fn uniform_glyph_source_premul(
+        &mut self,
+        host_src: u32,
+        src: crate::kms::render::engine::SourceDrawable,
+        repeat: Repeat,
+        mask_fmt: u32,
+    ) -> Result<[f32; 4], &'static str> {
+        use crate::kms::render::{
+            engine::{premul_from_wire_pixel, uniform_pixel_glyph_source},
+            telemetry::GetImageSite,
+        };
+        let (depth, extent) = self
+            .store
+            .get(src.id())
+            .map(|d| (d.depth, d.storage.extent))
+            .ok_or("source drawable is not in the store")?;
+        let rect = uniform_pixel_glyph_source(src, repeat, extent, mask_fmt)
+            .ok_or("not a one-pixel sampled domain under a plane-covering repeat (tier 1 only)")?;
+        // The picture's DECLARED format, which overrides storage depth
+        // when it says the alpha byte is padding — the same precedence
+        // `resolve_force_opaque_pict_format` applies on the sampling
+        // path. Absent (a synthesized source) falls back to depth.
+        let pict_format = match self.core.pictures.get(&host_src) {
+            Some(PictureRecord::Drawable { pict_format, .. }) => *pict_format,
+            _ => 0,
+        };
+        self.telemetry
+            .record_get_image_site(GetImageSite::GlyphSource);
+        let wire = self
+            .engine
+            .get_image(
+                &mut self.store,
+                &mut self.platform,
+                Src::server_internal(src.id()),
+                rect,
+                depth,
+            )
+            .map_err(|e| {
+                log::warn!(
+                    "render composite_glyphs: uniform source readback failed for \
+                     0x{host_src:x} at {rect:?} d{depth}: {e:?}"
+                );
+                "uniform source readback failed"
+            })?;
+        premul_from_wire_pixel(&wire, depth, pict_format)
+            .ok_or("source depth has no RENDER pixel decode, or the read came back short")
+    }
+
     /// Resolve an accumulated content clip against the storage it will be
     /// applied in. `None` (no bordered level) keeps the target on the
     /// pre-#133 arithmetic.
@@ -14797,6 +14899,20 @@ fn parse_gradient_stops(body: &[u8], stops_offset: usize) -> Option<Vec<Gradient
 /// the v2 record's type and `KmsCore.pictures` as the map.
 /// `body` is the full request body shape:
 /// `picture(4) + value_mask(4) + values[…]`.
+/// Has the once-per-process `CompositeGlyphs` unsupported-drop warning
+/// been said yet? See `KmsBackend::record_composite_glyphs_drop` for
+/// why this is once per PROCESS and not once per generation.
+static COMPOSITE_GLYPHS_DROP_WARNED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Claim a one-shot: `true` exactly once per flag, for the caller that
+/// got there first. Split out from its call site so the rate limiting
+/// is testable without capturing log output, and without a test having
+/// to consume a process-wide one-shot that another test may need.
+fn take_first_occurrence(flag: &std::sync::atomic::AtomicBool) -> bool {
+    !flag.swap(true, std::sync::atomic::Ordering::Relaxed)
+}
+
 fn change_picture_apply_mask(core: &mut KmsCore, host_pic: u32, body: &[u8]) {
     if body.len() < 8 {
         return;
@@ -22963,7 +23079,7 @@ impl Backend for KmsBackend {
         op: u8,
         host_src: u32,
         host_dst: u32,
-        _mask_fmt: u32,
+        mask_fmt: u32,
         host_gs: u32,
         src_x: i16,
         src_y: i16,
@@ -23000,13 +23116,12 @@ impl Backend for KmsBackend {
         // protocol errors, not unsupported features; they log a gap
         // and return Ok without bumping the counter.
         if crate::kms::vk::render_pipeline::StdPictOp::from_u8(op).is_none() || op > 12 {
-            log::debug!(
-                "render composite_glyphs gap: op={op} (standard fixed-function ops 0..=12)"
-            );
-            self.telemetry.record_composite_glyphs_dropped_unsupported();
+            self.record_composite_glyphs_drop(format_args!(
+                "op={op} is outside the standard fixed-function family (0..=12)"
+            ));
             return Ok(Vec::new());
         }
-        let Some((src_resolved, _src_repeat, _src_xform, _src_ca)) =
+        let Some((src_resolved, src_repeat, _src_xform, _src_ca)) =
             self.resolve_picture_for_render(host_src)
         else {
             log::debug!("render composite_glyphs gap: src 0x{host_src:x} not resolvable");
@@ -23030,12 +23145,28 @@ impl Backend for KmsBackend {
                     [0.0, 0.0, 0.0, 0.0]
                 })
             }
-            ResolvedSource::Drawable(_) | ResolvedSource::None => {
-                log::debug!(
-                    "render composite_glyphs gap: src 0x{host_src:x} is not SolidFill / Gradient \
-                     (plan §3d v1-parity scope)"
-                );
-                self.telemetry.record_composite_glyphs_dropped_unsupported();
+            // #137 tier 1 — a source whose sampled domain is one pixel
+            // under a covering repeat IS a colour, so read it and take
+            // the same route as `CreateSolidFill`. Anything else stays
+            // dropped: tier 2 (general drawable sources) needs its own
+            // spec, and asserting otherwise here would assert tier 2.
+            ResolvedSource::Drawable(src_drawable) => {
+                match self.uniform_glyph_source_premul(host_src, src_drawable, src_repeat, mask_fmt)
+                {
+                    Ok(premul) => premul,
+                    Err(why) => {
+                        self.record_composite_glyphs_drop(format_args!(
+                            "src 0x{host_src:x} is a drawable ({src_drawable:?} \
+                             repeat={src_repeat:?} mask_fmt={mask_fmt}) — {why}"
+                        ));
+                        return Ok(Vec::new());
+                    }
+                }
+            }
+            ResolvedSource::None => {
+                self.record_composite_glyphs_drop(format_args!(
+                    "src 0x{host_src:x} resolved to no source picture at all"
+                ));
                 return Ok(Vec::new());
             }
         };
@@ -30552,6 +30683,105 @@ mod tests {
             },
         );
         (src_pic.as_raw(), gs_xid)
+    }
+
+    /// #137 visibility note, the rate limiter itself: a one-shot is
+    /// claimed exactly once, by whoever gets there first. Tested on a
+    /// LOCAL flag rather than the process-wide one, so it neither
+    /// depends on test order nor consumes the real one-shot.
+    #[test]
+    fn the_first_occurrence_of_a_one_shot_is_claimed_once() {
+        use super::take_first_occurrence;
+        use std::sync::atomic::AtomicBool;
+        let flag = AtomicBool::new(false);
+        assert!(
+            take_first_occurrence(&flag),
+            "the first caller must get the one-shot"
+        );
+        for i in 0..100 {
+            assert!(
+                !take_first_occurrence(&flag),
+                "occurrence {i} must not warn again — a pathological client \
+                 would otherwise flood the log"
+            );
+        }
+    }
+
+    /// #137 visibility note: the LOG is rate-limited, the COUNTER is
+    /// not. A hundred unsupported requests bump the counter a hundred
+    /// times, so telemetry still measures how bad a gap is even after
+    /// the log has gone quiet.
+    ///
+    /// The source here is a drawable whose sampled domain is 4x4 —
+    /// admissible under tier 2, not tier 1 — so the drop is the real
+    /// remaining one, reached without a live Vk (the read is never
+    /// attempted).
+    #[test]
+    fn composite_glyphs_counts_every_unsupported_drop_not_just_the_first() {
+        use crate::kms::render::store::{DrawableKind, Storage};
+        use ash::vk;
+        use yserver_core::backend::{AnyHandle, PixmapHandle};
+
+        let mut b = KmsBackend::for_tests();
+        let (_unused_solidfill, gs_xid) = install_solidfill_and_glyphset(&mut b, 1);
+
+        // A real store entry, so the picture resolves to
+        // `ResolvedSource::Drawable` rather than failing to resolve at
+        // all (which is a protocol error, not an unsupported feature,
+        // and deliberately does NOT bump the counter).
+        let src_xid = 0x5137_0001u32;
+        b.store
+            .allocate(
+                src_xid,
+                DrawableKind::Pixmap,
+                32,
+                false,
+                Storage::for_tests_null(
+                    vk::Extent2D {
+                        width: 4,
+                        height: 4,
+                    },
+                    vk::Format::B8G8R8A8_UNORM,
+                ),
+            )
+            .expect("allocate the source pixmap");
+        let src_pic = b
+            .render_create_picture(
+                None,
+                AnyHandle::Pixmap(PixmapHandle::from_raw(src_xid).expect("PixmapHandle")),
+                yserver_protocol::x11::RENDER_FMT_ARGB32,
+                0x0001,              // CPRepeat
+                &1u32.to_le_bytes(), // Normal
+            )
+            .expect("render_create_picture")
+            .expect("Some")
+            .as_raw();
+
+        for _ in 0..100 {
+            b.render_composite_glyphs(
+                None,
+                23, // CompositeGlyphs8
+                3,  // Over
+                src_pic,
+                0xDEAD, // host_dst — the source gate fires first
+                0,      // mask_fmt
+                gs_xid,
+                0,
+                0,
+                &[1u8, 0, 0, 0, 0, 0, 0, 0],
+                0,
+                0,
+            )
+            .expect("ok");
+        }
+        assert_eq!(
+            b.telemetry.lifetime.composite_glyphs_dropped_unsupported, 100,
+            "the counter is not rate-limited: every unsupported drop must advance it",
+        );
+        assert_eq!(
+            b.telemetry.lifetime.paint_submits, 0,
+            "no paint submit on the drop path",
+        );
     }
 
     /// Ops outside the standard fixed-function family (0..=12) —

--- a/crates/yserver/src/kms/render/backend.rs
+++ b/crates/yserver/src/kms/render/backend.rs
@@ -1219,6 +1219,15 @@ pub struct KmsBackend {
     /// `DrawableId` + validated by `content_version`. See
     /// [`crate::kms::backend::Depth1MaskCache`].
     pub(crate) depth1_mask_cache: crate::kms::backend::Depth1MaskCache,
+    /// #137 step 5 — CPU cache of tier-1 uniform glyph-source colours.
+    /// A hit skips the ordered `get_image` of
+    /// [`Self::uniform_glyph_source_premul`] and, with it, the
+    /// `CloseReason::SyncWait` frame close that readback forces — which
+    /// measured as ~75% of ALL frame closes on a text-heavy workload.
+    /// Keyed by never-recycled `DrawableId` + sampled offset and
+    /// validated by `content_version`; populated only AFTER the read.
+    /// See [`crate::kms::backend::UniformGlyphSourceCache`].
+    pub(crate) uniform_glyph_source_cache: crate::kms::backend::UniformGlyphSourceCache,
     /// GPU snapshot of the current clip-mask pixmap for the masked CopyArea
     /// path (Task 14). Single current-clip carrier, mirroring
     /// `clip_mask_cache`'s ownership: created + eagerly populated on install,
@@ -4801,6 +4810,7 @@ impl KmsBackend {
             crtc_queue_sequence_unsupported_devices: HashSet::new(),
             clip_mask_cache: None,
             depth1_mask_cache: crate::kms::backend::Depth1MaskCache::new(256),
+            uniform_glyph_source_cache: crate::kms::backend::UniformGlyphSourceCache::new(64),
             clip_mask_snapshot: None,
             fill_pattern_cache: None,
             kms_outputs_active,
@@ -5750,6 +5760,7 @@ impl KmsBackend {
             crtc_queue_sequence_unsupported_devices: HashSet::new(),
             clip_mask_cache: None,
             depth1_mask_cache: crate::kms::backend::Depth1MaskCache::new(256),
+            uniform_glyph_source_cache: crate::kms::backend::UniformGlyphSourceCache::new(64),
             clip_mask_snapshot: None,
             fill_pattern_cache: None,
             kms_outputs_active: true,
@@ -6286,6 +6297,21 @@ impl KmsBackend {
     ///   would reapply a coordinate space on top of it and sample the
     ///   wrong pixel of a redirected window's backing — precisely the
     ///   case the domain-not-storage rule exists to get right.
+    ///
+    /// Step 5 puts [`Self::uniform_glyph_source_cache`] in front of the
+    /// read. That is not a copy-cost optimisation: the copy-out measured
+    /// at 1.5 ms/s. It is there because `get_image` must
+    /// `close_open_frame(CloseReason::SyncWait)` before it can wait, and
+    /// that close measured as ~75% of ALL frame closes on a text-heavy
+    /// workload (`opens=237 closes=238`, `sync_wait=179`), collapsing
+    /// `ops/frame_avg` to 1.6 and destroying the batching
+    /// `composite_glyphs_via_frame_builder` exists to provide. A hit
+    /// skips the read and therefore skips the close.
+    ///
+    /// The cache is populated only on the way OUT, after the pixel has
+    /// been read, and a hit requires the source's `content_version` to
+    /// be unchanged — so a client that repaints the 1x1 pixmap to
+    /// recolour its text (Java, every string) misses and re-reads.
     fn uniform_glyph_source_premul(
         &mut self,
         host_src: u32,
@@ -6297,13 +6323,25 @@ impl KmsBackend {
             engine::{premul_from_wire_pixel, uniform_pixel_glyph_source},
             telemetry::GetImageSite,
         };
-        let (depth, extent) = self
+        let (depth, extent, content_version) = self
             .store
             .get(src.id())
-            .map(|d| (d.depth, d.storage.extent))
+            .map(|d| (d.depth, d.storage.extent, d.content_version))
             .ok_or("source drawable is not in the store")?;
         let rect = uniform_pixel_glyph_source(src, repeat, extent, mask_fmt)
             .ok_or("not a one-pixel sampled domain under a plane-covering repeat (tier 1 only)")?;
+        // Step 5 — the cache lookup, and the ONLY thing that can skip
+        // the readback below. `rect.offset` is the pixel actually read,
+        // which is `src.offset()` resolved into backing space.
+        let key_offset = (rect.offset.x, rect.offset.y);
+        if let Some(premul) =
+            self.uniform_glyph_source_cache
+                .get(src.id(), content_version, key_offset)
+        {
+            self.telemetry.record_uniform_glyph_source_cache(true);
+            return Ok(premul);
+        }
+        self.telemetry.record_uniform_glyph_source_cache(false);
         // The picture's DECLARED format, which overrides storage depth
         // when it says the alpha byte is padding — the same precedence
         // `resolve_force_opaque_pict_format` applies on the sampling
@@ -6330,8 +6368,16 @@ impl KmsBackend {
                 );
                 "uniform source readback failed"
             })?;
-        premul_from_wire_pixel(&wire, depth, pict_format)
-            .ok_or("source depth has no RENDER pixel decode, or the read came back short")
+        let premul = premul_from_wire_pixel(&wire, depth, pict_format)
+            .ok_or("source depth has no RENDER pixel decode, or the read came back short")?;
+        // Populate AFTER the ordered read, never before — see spec
+        // invariant 4 and [`UniformGlyphSourceCache`]. The version read
+        // above is the one the bytes just returned belong to: nothing
+        // between it and here can write the source, because this thread
+        // IS the request loop and the read is fence-waited.
+        self.uniform_glyph_source_cache
+            .insert(src.id(), content_version, key_offset, premul);
+        Ok(premul)
     }
 
     /// Resolve an accumulated content clip against the storage it will be
@@ -9555,6 +9601,31 @@ impl KmsBackend {
         self.telemetry
             .lifetime
             .frame_builder_close_reason_non_ported_paint_op
+    }
+
+    /// #137 step 5: read the lifetime
+    /// `frame_builder_close_reason_sync_wait` counter after draining
+    /// pending flush outcomes and frame-close events. Same drain shape
+    /// as [`Self::telemetry_close_reason_non_ported_for_tests`].
+    ///
+    /// This is the oracle for the whole justification of the
+    /// uniform-glyph-source cache: the readback's value is not the copy
+    /// it avoids but the `CloseReason::SyncWait` frame close it avoids,
+    /// so a cache hit must leave this counter unmoved.
+    pub fn telemetry_close_reason_sync_wait_for_tests(&mut self) -> u64 {
+        for outcome in self.engine.drain_flush_outcomes() {
+            if outcome.aborted {
+                self.telemetry.record_submit_group_abort();
+            } else {
+                self.telemetry
+                    .record_submit_group_flush(outcome.flushed_entries, outcome.reason);
+            }
+        }
+        // Close-REASON counters accumulate from frame-builder close
+        // EVENTS, not flush outcomes — without this drain the counter
+        // stays 0 no matter how many closes fired in the engine.
+        self.drain_frame_builder_telemetry();
+        self.telemetry.lifetime.frame_builder_close_reason_sync_wait
     }
 
     /// Phase B.3 Task 2 (N1, N8, N9): drive `engine.copy_area` directly

--- a/crates/yserver/src/kms/render/backend.rs
+++ b/crates/yserver/src/kms/render/backend.rs
@@ -23282,15 +23282,17 @@ impl Backend for KmsBackend {
         // Two-pass parse: pass 1 fills `parsed` with per-glyph
         // metadata + the glyph's stored format; pass 2 resolves each
         // to a `CompositeGlyphInput` borrowing the glyphset's stored
-        // pixel bytes as-is (dense A8 or raw A1 wire). A1→A8 expansion
-        // is deferred to the engine's atlas-miss branch
-        // (`GlyphPixels::to_a8`) so a resident glyph is never
-        // re-expanded (#2, 2026-07-08 render-optimization gaps). The
-        // split keeps the immutable `self.core.glyphsets` borrow off
-        // the mutable `self.engine` call below.
+        // pixel bytes as-is (dense A8, raw A1 wire or raw ARGB32
+        // wire). Conversion to A8 is deferred to the engine's
+        // atlas-miss branch (`GlyphPixels::to_a8`) so a resident
+        // glyph is never re-converted (#2, 2026-07-08
+        // render-optimization gaps). The split keeps the immutable
+        // `self.core.glyphsets` borrow off the mutable
+        // `self.engine` call below.
         enum GlyphFmt {
             A8,
             A1,
+            Argb32,
         }
         struct Parsed {
             gs_xid: u32,
@@ -23377,12 +23379,18 @@ impl Backend for KmsBackend {
                         // Forwarded raw; expanded on atlas miss by
                         // `GlyphPixels::to_a8`.
                         GlyphSetFormat::A1 => GlyphFmt::A1,
-                        // ARGB32-source glyphs are pre-converted to
-                        // A8 in `parse_add_glyphs`, so this branch
-                        // is unreachable in practice. Defensive:
-                        // skip the glyph if the stored format
-                        // somehow ended up as ARGB32 / Other.
-                        GlyphSetFormat::Argb32 | GlyphSetFormat::Other => {
+                        // Wire ARGB32: dense CARD32 rows, memory
+                        // order [B, G, R, A]. Forwarded raw; reduced
+                        // to one A8 coverage plane (the mean of
+                        // logical R, G, B) on atlas miss by
+                        // `GlyphPixels::to_a8`. Reducing here instead
+                        // would throw away the colour channels a
+                        // subpixel-AA client puts the coverage in.
+                        GlyphSetFormat::Argb32 => GlyphFmt::Argb32,
+                        // A glyphset whose picture format we never
+                        // accepted; `parse_add_glyphs` refuses to
+                        // store glyphs for it, so this is defensive.
+                        GlyphSetFormat::Other => {
                             log::warn!(
                                 "render composite_glyphs: unexpected stored format {:?} for \
                                  glyph 0x{glyph_id:x} — skipping",
@@ -23480,6 +23488,7 @@ impl Backend for KmsBackend {
                 let pixels = match p.fmt {
                     GlyphFmt::A8 => GlyphPixels::A8(stored),
                     GlyphFmt::A1 => GlyphPixels::A1Wire(stored),
+                    GlyphFmt::Argb32 => GlyphPixels::Argb32Wire(stored),
                 };
                 Some(CompositeGlyphInput {
                     gs_xid: p.gs_xid,

--- a/crates/yserver/src/kms/render/backend.rs
+++ b/crates/yserver/src/kms/render/backend.rs
@@ -55,6 +55,7 @@ use crate::{
         cpu_types::{PictTransform, Rectangle16, Repeat},
         render::{
             engine::{RenderEngine, decode_x11_pixel_for_storage},
+            glyph_pixels::GlyphSourceFormat,
             platform::{
                 ConnectorSnapshot, CrtcKey, PlatformBackend, QualifiedScanoutPlan,
                 is_terminal_disposable_probe_error,
@@ -16112,6 +16113,186 @@ fn default_window_init_color(depth: u8) -> [f32; 4] {
     }
 }
 
+/// One glyph resolved out of a `CompositeGlyphs` items stream: the
+/// glyphset it came from, its id, its size, the picture format it is
+/// **stored** in, and its dst-space top-left. Holds no borrow of the
+/// glyphset map, so the caller can drop the immutable
+/// `core.glyphsets` borrow before the `&mut self.engine` call that
+/// consumes pass 2's output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ParsedGlyph {
+    pub(super) gs_xid: u32,
+    pub(super) glyph_id: u32,
+    pub(super) w: u32,
+    pub(super) h: u32,
+    /// The glyphset's picture format — protocol state, read here
+    /// from the glyphset record. The engine turns it into an
+    /// effective `GlyphLayout`
+    /// (`RenderEngine::effective_glyph_layout`), because that mapping
+    /// depends on device state the parse must not consult.
+    pub(super) source_format: GlyphSourceFormat,
+    pub(super) dst_x: i32,
+    pub(super) dst_y: i32,
+}
+
+/// What pass 1 of the items parse produced, plus the counters the
+/// caller's "nothing parsed" diagnostic reports.
+#[derive(Debug, Default)]
+pub(super) struct ParsedGlyphItems {
+    /// Every drawable glyph the stream named, **in request order**.
+    pub(super) glyphs: Vec<ParsedGlyph>,
+    pub(super) elements: usize,
+    pub(super) found: usize,
+    pub(super) missing: usize,
+}
+
+/// Pass 1 of the `CompositeGlyphs` items parse — mirrors v1's
+/// `try_vk_render_composite_glyphs` shape.
+///
+/// Element size depends on the minor opcode: `CompositeGlyphs8` (23)
+/// → 1-byte ids, 16 (24) → 2, 32 (25) → 4. Each element starts with
+/// `count(u8) pad pad pad dx(i16) dy(i16)`; if `count == 255` the
+/// same 8 bytes instead carry an inline **glyphset change**, with the
+/// new glyphset xid in the trailing u32. `x_off` / `y_off` seed the
+/// pen and each element's `dx` / `dy` accumulates onto it.
+///
+/// That inline form is why one request can mix glyph source formats:
+/// different glyphsets may have different picture formats, so the
+/// returned sequence can interleave A8 and ARGB32 glyphs — which the
+/// engine then has to record as several contiguous draw runs
+/// (`RenderEngine::split_glyph_runs`).
+///
+/// Split out of `render_composite_glyphs` for two reasons: it keeps
+/// the immutable `glyphsets` borrow off the `&mut self.engine` call
+/// that consumes the result, and it is the seam a test drives to
+/// assert that the glyphs — and their source-format tags — come out
+/// in request order across an inline glyphset change.
+pub(super) fn parse_composite_glyph_items(
+    glyphsets: &HashMap<u32, crate::kms::core::GlyphSetState>,
+    minor: u8,
+    host_gs: u32,
+    x_off: i16,
+    y_off: i16,
+    items: &[u8],
+) -> ParsedGlyphItems {
+    use crate::kms::core::GlyphSetFormat;
+
+    let id_size: usize = match minor {
+        23 => 1,
+        24 => 2,
+        _ => 4,
+    };
+    let mut out = ParsedGlyphItems::default();
+    let mut pen_x = i32::from(x_off);
+    let mut pen_y = i32::from(y_off);
+    let mut pos: usize = 0;
+    let mut active_gs_xid = host_gs;
+    while pos + 8 <= items.len() {
+        let count = items[pos] as usize;
+        if count == 255 {
+            let new_xid = u32::from_le_bytes([
+                items[pos + 4],
+                items[pos + 5],
+                items[pos + 6],
+                items[pos + 7],
+            ]);
+            if new_xid != 0 && glyphsets.contains_key(&new_xid) {
+                active_gs_xid = new_xid;
+            }
+            pos += 8;
+            continue;
+        }
+        out.elements += 1;
+        let dx = i32::from(i16::from_le_bytes([items[pos + 4], items[pos + 5]]));
+        let dy = i32::from(i16::from_le_bytes([items[pos + 6], items[pos + 7]]));
+        pen_x += dx;
+        pen_y += dy;
+
+        let payload_start = pos + 8;
+        let payload_bytes = count * id_size;
+        let padded = (payload_bytes + 3) & !3;
+        if payload_start + padded > items.len() {
+            break;
+        }
+
+        let Some(active_gs) = glyphsets.get(&active_gs_xid) else {
+            pos += 8 + padded;
+            continue;
+        };
+        let active_gs_xid_for_key = active_gs_xid;
+
+        for i in 0..count {
+            let id_off = payload_start + i * id_size;
+            let glyph_id: u32 = match id_size {
+                1 => u32::from(items[id_off]),
+                2 => u32::from(u16::from_le_bytes([items[id_off], items[id_off + 1]])),
+                _ => u32::from_le_bytes([
+                    items[id_off],
+                    items[id_off + 1],
+                    items[id_off + 2],
+                    items[id_off + 3],
+                ]),
+            };
+            let Some(glyph) = active_gs.glyphs.get(&glyph_id) else {
+                out.missing += 1;
+                continue;
+            };
+            out.found += 1;
+
+            let gw = u32::from(glyph.width);
+            let gh = u32::from(glyph.height);
+            let dst_x = pen_x - i32::from(glyph.x);
+            let dst_y = pen_y - i32::from(glyph.y);
+
+            if gw > 0 && gh > 0 {
+                let source_format = match glyph.format {
+                    GlyphSetFormat::A8 => GlyphSourceFormat::A8,
+                    // Wire A1: rows padded to a 32-bit scanline
+                    // unit, bit order = advertised `bitmap-bit-order`
+                    // (LSBFirst for the common little-endian client).
+                    // Forwarded raw; expanded on atlas miss by
+                    // `GlyphPixels::to_a8`.
+                    GlyphSetFormat::A1 => GlyphSourceFormat::A1,
+                    // Wire ARGB32: dense CARD32 rows, memory order
+                    // [B, G, R, A]. Forwarded raw; reduced to one A8
+                    // coverage plane on atlas miss by
+                    // `GlyphPixels::to_a8`. Reducing here instead
+                    // would throw away the colour channels a
+                    // subpixel-AA client puts the coverage in.
+                    GlyphSetFormat::Argb32 => GlyphSourceFormat::Argb32,
+                    // A glyphset whose picture format we never
+                    // accepted; `parse_add_glyphs` refuses to store
+                    // glyphs for it, so this is defensive.
+                    GlyphSetFormat::Other => {
+                        log::warn!(
+                            "render composite_glyphs: unexpected stored format {:?} for \
+                             glyph 0x{glyph_id:x} — skipping",
+                            glyph.format,
+                        );
+                        continue;
+                    }
+                };
+
+                out.glyphs.push(ParsedGlyph {
+                    gs_xid: active_gs_xid_for_key,
+                    glyph_id,
+                    w: gw,
+                    h: gh,
+                    source_format,
+                    dst_x,
+                    dst_y,
+                });
+            }
+
+            pen_x += i32::from(glyph.x_off);
+            pen_y += i32::from(glyph.y_off);
+        }
+
+        pos += 8 + padded;
+    }
+    out
+}
+
 /// Stage 3f.13 glyph fallback: pull the first stop's premultiplied
 /// RGBA from a gradient picture record. Returns `None` if `host_pic`
 /// isn't a gradient or has zero stops. Used by `composite_glyphs`
@@ -23158,12 +23339,9 @@ impl Backend for KmsBackend {
         x_off: i16,
         y_off: i16,
     ) -> io::Result<Vec<xfixes::RegionRect>> {
-        use crate::kms::{
-            core::GlyphSetFormat,
-            render::{
-                engine::{CompositeGlyphInput, ResolvedSource},
-                glyph_pixels::GlyphPixels,
-            },
+        use crate::kms::render::{
+            engine::{CompositeGlyphInput, ResolvedSource},
+            glyph_pixels::GlyphPixels,
         };
 
         // Gating: op must be a standard fixed-function PictOp
@@ -23258,165 +23436,30 @@ impl Backend for KmsBackend {
             return Ok(Vec::new());
         }
 
-        // Items parser — mirrors v1's `try_vk_render_composite_glyphs`
-        // shape. Element size depends on the minor opcode:
-        // CompositeGlyphs8 (23) → 1 byte ids, 16 (24) → 2, 32 (25)
-        // → 4. Each element starts with `count(u8) pad pad pad
-        // dx(i16) dy(i16)`; if `count == 255` the same 8 bytes
-        // carry an inline glyphset change with the new gs xid in
-        // the trailing u32.
-        let id_size: usize = match minor {
-            23 => 1,
-            24 => 2,
-            _ => 4,
-        };
+        // Items parser. Pass 1 (`parse_composite_glyph_items`) walks
+        // the wire stream and resolves every glyph it names, tagging
+        // each with the picture format its glyphset stores it in;
+        // pass 2 below resolves each of those to a
+        // `CompositeGlyphInput` borrowing the glyphset's stored pixel
+        // bytes as-is (dense A8, raw A1 wire or raw ARGB32 wire).
+        // Conversion to A8 is deferred to the engine's atlas-miss
+        // branch (`GlyphPixels::to_a8`) so a resident glyph is never
+        // re-converted (#2, 2026-07-08 render-optimization gaps).
+        // The two passes also keep the immutable
+        // `self.core.glyphsets` borrow off the mutable `self.engine`
+        // call below.
+        //
         // Per X RENDER protocol, `src_x`/`src_y` are the SOURCE
-        // picture sampling origin, not the dst pen — same as v1.
-        // The first glyph-element's `dx` / `dy` sets the absolute
-        // pen position; subsequent elements accumulate.
+        // picture sampling origin, not the dst pen — same as v1. The
+        // first glyph-element's `dx` / `dy` sets the absolute pen
+        // position; subsequent elements accumulate.
         let _ = (src_x, src_y);
-        let mut pen_x = i32::from(x_off);
-        let mut pen_y = i32::from(y_off);
-        let mut pos: usize = 0;
-        let mut active_gs_xid = host_gs;
-        // Two-pass parse: pass 1 fills `parsed` with per-glyph
-        // metadata + the glyph's stored format; pass 2 resolves each
-        // to a `CompositeGlyphInput` borrowing the glyphset's stored
-        // pixel bytes as-is (dense A8, raw A1 wire or raw ARGB32
-        // wire). Conversion to A8 is deferred to the engine's
-        // atlas-miss branch (`GlyphPixels::to_a8`) so a resident
-        // glyph is never re-converted (#2, 2026-07-08
-        // render-optimization gaps). The split keeps the immutable
-        // `self.core.glyphsets` borrow off the mutable
-        // `self.engine` call below.
-        enum GlyphFmt {
-            A8,
-            A1,
-            Argb32,
-        }
-        struct Parsed {
-            gs_xid: u32,
-            glyph_id: u32,
-            w: u32,
-            h: u32,
-            fmt: GlyphFmt,
-            dst_x: i32,
-            dst_y: i32,
-        }
-        let mut parsed: Vec<Parsed> = Vec::new();
-        let mut missing_glyphs = 0usize;
-        let mut found_glyphs = 0usize;
-        let mut elements = 0usize;
-        // Borrow the glyphsets map immutably for the whole parse.
-        // The engine call below takes `&mut self.engine` /
-        // `&mut self.store` but not `&self.core.glyphsets`, so a
-        // single borrow scope here is sound.
-        while pos + 8 <= items.len() {
-            let count = items[pos] as usize;
-            if count == 255 {
-                if pos + 8 <= items.len() {
-                    let new_xid = u32::from_le_bytes([
-                        items[pos + 4],
-                        items[pos + 5],
-                        items[pos + 6],
-                        items[pos + 7],
-                    ]);
-                    if new_xid != 0 && self.core.glyphsets.contains_key(&new_xid) {
-                        active_gs_xid = new_xid;
-                    }
-                }
-                pos += 8;
-                continue;
-            }
-            elements += 1;
-            let dx = i32::from(i16::from_le_bytes([items[pos + 4], items[pos + 5]]));
-            let dy = i32::from(i16::from_le_bytes([items[pos + 6], items[pos + 7]]));
-            pen_x += dx;
-            pen_y += dy;
-
-            let payload_start = pos + 8;
-            let payload_bytes = count * id_size;
-            let padded = (payload_bytes + 3) & !3;
-            if payload_start + padded > items.len() {
-                break;
-            }
-
-            let Some(active_gs) = self.core.glyphsets.get(&active_gs_xid) else {
-                pos += 8 + padded;
-                continue;
-            };
-            let active_gs_xid_for_key = active_gs_xid;
-
-            for i in 0..count {
-                let id_off = payload_start + i * id_size;
-                let glyph_id: u32 = match id_size {
-                    1 => u32::from(items[id_off]),
-                    2 => u32::from(u16::from_le_bytes([items[id_off], items[id_off + 1]])),
-                    _ => u32::from_le_bytes([
-                        items[id_off],
-                        items[id_off + 1],
-                        items[id_off + 2],
-                        items[id_off + 3],
-                    ]),
-                };
-                let Some(glyph) = active_gs.glyphs.get(&glyph_id) else {
-                    missing_glyphs += 1;
-                    continue;
-                };
-                found_glyphs += 1;
-
-                let gw = u32::from(glyph.width);
-                let gh = u32::from(glyph.height);
-                let dst_x = pen_x - i32::from(glyph.x);
-                let dst_y = pen_y - i32::from(glyph.y);
-
-                if gw > 0 && gh > 0 {
-                    let fmt = match glyph.format {
-                        GlyphSetFormat::A8 => GlyphFmt::A8,
-                        // Wire A1: rows padded to a 32-bit scanline
-                        // unit, bit order = advertised `bitmap-bit-order`
-                        // (LSBFirst for the common little-endian client).
-                        // Forwarded raw; expanded on atlas miss by
-                        // `GlyphPixels::to_a8`.
-                        GlyphSetFormat::A1 => GlyphFmt::A1,
-                        // Wire ARGB32: dense CARD32 rows, memory
-                        // order [B, G, R, A]. Forwarded raw; reduced
-                        // to one A8 coverage plane (the mean of
-                        // logical R, G, B) on atlas miss by
-                        // `GlyphPixels::to_a8`. Reducing here instead
-                        // would throw away the colour channels a
-                        // subpixel-AA client puts the coverage in.
-                        GlyphSetFormat::Argb32 => GlyphFmt::Argb32,
-                        // A glyphset whose picture format we never
-                        // accepted; `parse_add_glyphs` refuses to
-                        // store glyphs for it, so this is defensive.
-                        GlyphSetFormat::Other => {
-                            log::warn!(
-                                "render composite_glyphs: unexpected stored format {:?} for \
-                                 glyph 0x{glyph_id:x} — skipping",
-                                glyph.format,
-                            );
-                            continue;
-                        }
-                    };
-
-                    parsed.push(Parsed {
-                        gs_xid: active_gs_xid_for_key,
-                        glyph_id,
-                        w: gw,
-                        h: gh,
-                        fmt,
-                        dst_x,
-                        dst_y,
-                    });
-                }
-
-                pen_x += i32::from(glyph.x_off);
-                pen_y += i32::from(glyph.y_off);
-            }
-
-            pos += 8 + padded;
-        }
+        let ParsedGlyphItems {
+            glyphs: parsed,
+            elements,
+            found: found_glyphs,
+            missing: missing_glyphs,
+        } = parse_composite_glyph_items(&self.core.glyphsets, minor, host_gs, x_off, y_off, items);
 
         if parsed.is_empty() {
             // No drawable glyphs (every entry was zero-size or
@@ -23485,10 +23528,14 @@ impl Backend for KmsBackend {
                     .get(&p.gs_xid)
                     .and_then(|gs| gs.glyphs.get(&p.glyph_id))
                     .map(|g| g.pixels.as_slice())?;
-                let pixels = match p.fmt {
-                    GlyphFmt::A8 => GlyphPixels::A8(stored),
-                    GlyphFmt::A1 => GlyphPixels::A1Wire(stored),
-                    GlyphFmt::Argb32 => GlyphPixels::Argb32Wire(stored),
+                // The byte encoding IS the format tag: the engine
+                // reads it back with `GlyphPixels::source_format()`,
+                // so it can never be told "these bytes are ARGB32"
+                // and "this glyph is A8" at the same time.
+                let pixels = match p.source_format {
+                    GlyphSourceFormat::A8 => GlyphPixels::A8(stored),
+                    GlyphSourceFormat::A1 => GlyphPixels::A1Wire(stored),
+                    GlyphSourceFormat::Argb32 => GlyphPixels::Argb32Wire(stored),
                 };
                 Some(CompositeGlyphInput {
                     gs_xid: p.gs_xid,
@@ -31010,18 +31057,25 @@ mod tests {
 
     /// Per plan §3d items-parse spec: the items stream's inline
     /// `0xFF 0 0 0 new_gs_xid` element rotates the active glyphset
-    /// for subsequent glyph lookups. The test installs two
-    /// glyphsets with distinct codepoint→pixel mappings, feeds an
-    /// items stream that draws one glyph from each, and asserts
-    /// that both glyphsets contributed to the engine call — the
-    /// parser must have honoured the inline change. We can't hit
-    /// the Vk engine in this fixture (no live Vk under
-    /// `for_tests`), so the gate is "no unsupported drop fired"
-    /// AND "both glyphset lookups succeeded" (verified by reaching
-    /// the engine, which returns `NoVk` on the stub but does NOT
-    /// bump the unsupported counter).
+    /// for subsequent glyph lookups.
+    ///
+    /// **This test used to assert nothing of the sort.** Its only
+    /// gate was `composite_glyphs_dropped_unsupported == 0`, which
+    /// holds whether the inline element is honoured or silently
+    /// skipped — a parse that ignored it would resolve one glyph
+    /// instead of two and still pass. (Reported honestly by #137 step
+    /// 4b, whose own tests do catch it; fixed here rather than left
+    /// as a name that promises coverage it does not have.)
+    ///
+    /// It now drives `parse_composite_glyph_items` — the seam step 4b
+    /// factored out — and asserts the resolved glyph SEQUENCE:
+    /// glyphset, id and pen position, in request order. The negative
+    /// control at the end is what gives it teeth: point the inline
+    /// change at an unknown xid and the second glyph becomes a MISS,
+    /// because the initial glyphset does not contain its id.
     #[test]
     fn composite_glyphs_inline_glyphset_change_parsed() {
+        use super::parse_composite_glyph_items;
         use crate::kms::core::{GlyphSetFormat, GlyphSetState, StoredGlyph};
 
         let mut b = KmsBackend::for_tests();
@@ -31092,17 +31146,61 @@ mod tests {
         )
         .expect("ok");
         // Op + source were Over + SolidFill, so the unsupported
-        // counter must NOT have fired.
+        // counter must NOT have fired. (dst resolution fails — no
+        // Drawable backing for 0x4242_4242 in the store — so the
+        // engine is never reached; engine reachability is covered by
+        // the Vk-backed acceptance tests.)
         assert_eq!(
             b.telemetry.lifetime.composite_glyphs_dropped_unsupported, 0,
             "Over + SolidFill must not hit the unsupported gate",
         );
-        // dst resolution failed (no Drawable backing for 0x4242_4242
-        // in the store), so the engine wasn't called — but the parse
-        // still walked both glyphsets without bumping the gap. The
-        // load-bearing assertion is that the inline change keeps the
-        // call in the Over+SolidFill envelope; engine reachability
-        // is covered by the Vk-backed acceptance test.
+
+        // ── what the test's name actually claims ──
+        //
+        // Element 1 draws 0x10 from gs_a at pen 0; the glyph advances
+        // the pen by its x_off of 1; element 3's dx of 1 takes it to
+        // 2, where 0x20 comes from gs_b. Two glyphs, TWO glyphsets,
+        // in request order.
+        let parsed = parse_composite_glyph_items(&b.core.glyphsets, 23, gs_a, 0, 0, &items);
+        assert_eq!(
+            parsed
+                .glyphs
+                .iter()
+                .map(|g| (g.gs_xid, g.glyph_id, g.dst_x))
+                .collect::<Vec<_>>(),
+            vec![(gs_a, 0x10, 0), (gs_b, 0x20, 2)],
+            "the inline `count == 255` element must rotate the active glyphset \
+             for every later glyph, in request order",
+        );
+        assert_eq!(
+            parsed.missing, 0,
+            "both ids must resolve in their own glyphset"
+        );
+
+        // Teeth: point the inline change at an xid no glyphset holds.
+        // The active glyphset then stays gs_a, which has no 0x20, so
+        // the second glyph is a MISS — i.e. this stream really does
+        // depend on the inline element being honoured, and a parse
+        // that skipped it would produce exactly this.
+        let mut ignored = items.clone();
+        let change_at = 12; // element 1 is 8 + 4 bytes
+        assert_eq!(
+            ignored[change_at], 255,
+            "fixture: the change element is here"
+        );
+        ignored[change_at + 4..change_at + 8].copy_from_slice(&0xDEAD_BEEF_u32.to_le_bytes());
+        let parsed_ignored =
+            parse_composite_glyph_items(&b.core.glyphsets, 23, gs_a, 0, 0, &ignored);
+        assert_eq!(
+            parsed_ignored
+                .glyphs
+                .iter()
+                .map(|g| (g.gs_xid, g.glyph_id))
+                .collect::<Vec<_>>(),
+            vec![(gs_a, 0x10)],
+            "with the change unresolvable, only the first glyph can be found",
+        );
+        assert_eq!(parsed_ignored.missing, 1, "0x20 is not in gs_a");
     }
 
     // ─── Stage 3f.1: poly_* + fill_poly logic tests ────────────

--- a/crates/yserver/src/kms/render/backend.rs
+++ b/crates/yserver/src/kms/render/backend.rs
@@ -23100,6 +23100,9 @@ impl Backend for KmsBackend {
             dst_y: i32,
         }
         let mut parsed: Vec<Parsed> = Vec::new();
+        let mut missing_glyphs = 0usize;
+        let mut found_glyphs = 0usize;
+        let mut elements = 0usize;
         // Borrow the glyphsets map immutably for the whole parse.
         // The engine call below takes `&mut self.engine` /
         // `&mut self.store` but not `&self.core.glyphsets`, so a
@@ -23121,6 +23124,7 @@ impl Backend for KmsBackend {
                 pos += 8;
                 continue;
             }
+            elements += 1;
             let dx = i32::from(i16::from_le_bytes([items[pos + 4], items[pos + 5]]));
             let dy = i32::from(i16::from_le_bytes([items[pos + 6], items[pos + 7]]));
             pen_x += dx;
@@ -23152,8 +23156,10 @@ impl Backend for KmsBackend {
                     ]),
                 };
                 let Some(glyph) = active_gs.glyphs.get(&glyph_id) else {
+                    missing_glyphs += 1;
                     continue;
                 };
+                found_glyphs += 1;
 
                 let gw = u32::from(glyph.width);
                 let gh = u32::from(glyph.height);
@@ -23206,6 +23212,16 @@ impl Backend for KmsBackend {
             // No drawable glyphs (every entry was zero-size or
             // missing from the glyphset). Not a gap; just nothing
             // to record.
+            log::debug!(
+                "render composite_glyphs: NOTHING PARSED minor={minor} gs=0x{host_gs:x} \
+                 items={} elements={elements} found={found_glyphs} missing={missing_glyphs} \
+                 glyphs_in_set={}",
+                items.len(),
+                self.core
+                    .glyphsets
+                    .get(&host_gs)
+                    .map_or(0, |g| g.glyphs.len()),
+            );
             return Ok(Vec::new());
         }
         let mut min_x = i32::MAX;
@@ -23234,6 +23250,12 @@ impl Backend for KmsBackend {
             glyph_union_local,
         );
         if cliplist_local.is_empty() {
+            log::debug!(
+                "render composite_glyphs: CLIPPED OUT minor={minor} dst=0x{host_dst:x} glyphs={} union={:?} extent={:?} clip_by_children={clip_by_children}",
+                parsed.len(),
+                glyph_union_local,
+                dst_local_extent,
+            );
             return Ok(Vec::new());
         }
         let dst_clip =
@@ -23270,6 +23292,10 @@ impl Backend for KmsBackend {
             .collect();
 
         if inputs.is_empty() {
+            log::debug!(
+                "render composite_glyphs: NO PIXELS minor={minor} dst=0x{host_dst:x} parsed={}",
+                parsed.len(),
+            );
             return Ok(Vec::new());
         }
 

--- a/crates/yserver/src/kms/render/engine.rs
+++ b/crates/yserver/src/kms/render/engine.rs
@@ -5950,8 +5950,13 @@ impl RenderEngine {
                     continue;
                 }
                 // Pin-ceiling enforcement: check BEFORE pack() so dropped
-                // glyphs don't leak atlas slots (mirror B.1 pattern).
-                if new_uploads.len() + 1 + pending_pins_before_call > ceiling {
+                // glyphs don't leak atlas slots (mirror B.1 pattern). The
+                // trailing `+ 1` reserves the instance buffer's pin,
+                // pinned unconditionally after this loop: when uploads
+                // and the draw buffer cannot both fit, drop uploads to
+                // leave room for the draw — losing a glyph loses one
+                // glyph, losing the draw loses the whole run.
+                if new_uploads.len() + 1 + pending_pins_before_call + 1 > ceiling {
                     stats.glyphs_dropped += 1;
                     continue;
                 }
@@ -6427,13 +6432,21 @@ impl RenderEngine {
             prospective_miss_keys.insert(key);
         }
         let prospective_misses = prospective_miss_keys.len();
-        let needs_close_reopen = pending_pins_before_call + prospective_misses > ceiling;
+        // Reserve one pin for the instance buffer that this call pins
+        // unconditionally after the per-glyph walk (engine.rs:6768):
+        // the pre-pass budgets prospective *uploads* only, so without
+        // this `+ 1` a call whose uploads exactly fill `ceiling` ends
+        // the frame at `ceiling + 1` pins (#137 step 1 / stage 2c).
+        let needs_close_reopen = pending_pins_before_call + prospective_misses + 1 > ceiling;
         if needs_close_reopen {
             // Force a close+reopen NOW (pre-allocation). Log the
             // ceiling hit once per process via note_pin_ceiling_hit_once.
+            // Report the same reserved total: this argument is the
+            // attempted pin count, and the unreserved sum would
+            // understate it.
             inner
                 .frame_builder
-                .note_pin_ceiling_hit_once(pending_pins_before_call + prospective_misses);
+                .note_pin_ceiling_hit_once(pending_pins_before_call + prospective_misses + 1);
             // Release the inner borrow before calling close_open_frame
             // (which itself reborrows self). Conventional cue without
             // invoking `drop()` on a reference.
@@ -6484,8 +6497,9 @@ impl RenderEngine {
             // If the SINGLE call still exceeds the ceiling — drop
             // excess glyphs. The spec accepts atlas-slot leakage in
             // the rare-failure regime; we extend that to "pathological
-            // single call".
-            if prospective_misses > ceiling {
+            // single call". Same reservation as above: the unconditional
+            // instance-buffer pin still needs its slot.
+            if prospective_misses + 1 > ceiling {
                 log::warn!(
                     "render composite_glyphs (frame_builder): single call requested {} \
                      atlas misses but per-frame ceiling is {}; will drop excess",
@@ -6563,8 +6577,12 @@ impl RenderEngine {
                 // Pin-ceiling enforcement: check BEFORE calling
                 // `pack()` so dropped glyphs don't leak atlas slots
                 // (codex R4: pack consumes a shelf advance regardless
-                // of whether the glyph ends up uploaded).
-                if new_uploads.len() + 1 + pending_pins_before_call > ceiling {
+                // of whether the glyph ends up uploaded). The trailing
+                // `+ 1` reserves the instance buffer's pin: when uploads
+                // and the draw buffer cannot both fit, drop uploads to
+                // leave room for the draw — losing a glyph loses one
+                // glyph, losing the draw loses the whole run.
+                if new_uploads.len() + 1 + pending_pins_before_call + 1 > ceiling {
                     stats.glyphs_dropped += 1;
                     continue;
                 }
@@ -16455,5 +16473,153 @@ mod tests {
             "must expose an IDENTITY view"
         );
         assert!(s.size_bytes > 0);
+    }
+
+    // ── #137 step 1: pin-ceiling reservation for the instance buffer ──
+    //
+    // The pre-pass / per-glyph admission rules budget prospective glyph
+    // *uploads* only; the instance buffer is then pinned unconditionally
+    // afterwards. A call whose uploads exactly fill the declared ceiling
+    // therefore ends the frame at `ceiling + 1` pins. These assert the
+    // actual pin COUNT, never "it rendered" — the off-by-one renders
+    // fine, so an outcome-based test would pass on the broken code.
+
+    /// `composite_glyphs_via_frame_builder`'s half of the hole
+    /// (`render/engine.rs`, pre-pass / single-call-overflow / per-glyph
+    /// admission). Ceiling of 2, two never-before-seen glyphs in ONE
+    /// call: pre-fix, both upload (2 pins) and the instance buffer pins
+    /// unconditionally after (1 more) = 3 pins against a ceiling of 2.
+    #[test]
+    #[ignore = "needs live Vulkan ICD"]
+    fn composite_glyphs_pin_ceiling_reserves_instance_buffer_pin() {
+        let Some(mut platform) = live_platform() else {
+            eprintln!("no Vk — skipping");
+            return;
+        };
+        let mut store = DrawableStore::new();
+        let mut engine = RenderEngine::new(&platform).expect("engine");
+        let target = alloc_drawable_3a(&platform, &mut store, 0x1, 32, 32);
+
+        {
+            let inner = engine.inner.as_mut().expect("inner");
+            inner.frame_builder.set_max_pinned_resources_per_frame(2);
+        }
+
+        let pixels_a = [0xFFu8; 4];
+        let pixels_b = [0xFFu8; 4];
+        let glyphs = [
+            CompositeGlyphInput {
+                gs_xid: 0x7001,
+                glyph_id: 1,
+                w: 2,
+                h: 2,
+                pixels: GlyphPixels::A8(&pixels_a),
+                dst_x: 1,
+                dst_y: 1,
+            },
+            CompositeGlyphInput {
+                gs_xid: 0x7001,
+                glyph_id: 2,
+                w: 2,
+                h: 2,
+                pixels: GlyphPixels::A8(&pixels_b),
+                dst_x: 10,
+                dst_y: 1,
+            },
+        ];
+
+        let stats = engine
+            .composite_glyphs(
+                &mut store,
+                &mut platform,
+                Dst::server_internal(target),
+                3, // Over
+                0, // pict_format unknown → depth heuristic
+                [1.0, 1.0, 1.0, 1.0],
+                &glyphs,
+                None,
+            )
+            .expect("composite_glyphs");
+
+        let inner = engine.inner.as_ref().expect("inner");
+        let ceiling = inner.frame_builder.max_pinned_resources_per_frame();
+        let open = inner
+            .frame_builder
+            .open
+            .as_ref()
+            .expect("frame stays open after composite_glyphs");
+        assert!(
+            open.pins.len() <= ceiling,
+            "pin set must never exceed the declared ceiling: {} pins against a \
+             ceiling of {} (glyphs_dropped={})",
+            open.pins.len(),
+            ceiling,
+            stats.glyphs_dropped,
+        );
+
+        engine.drain_all(&mut platform);
+    }
+
+    /// `image_text`'s identical hole (`render/engine.rs:5954`'s
+    /// per-glyph admission rule, same unconditional instance pin
+    /// afterwards). Same shape as the `composite_glyphs` case above,
+    /// through the core-font path instead of the glyphset path.
+    #[test]
+    #[ignore = "needs live Vulkan ICD"]
+    fn image_text_pin_ceiling_reserves_instance_buffer_pin() {
+        let Some(mut platform) = live_platform() else {
+            eprintln!("no Vk — skipping");
+            return;
+        };
+        let mut store = DrawableStore::new();
+        let mut engine = RenderEngine::new(&platform).expect("engine");
+        let target = alloc_drawable_3a_with_kind(
+            &platform,
+            &mut store,
+            0x1,
+            32,
+            32,
+            super::super::store::DrawableKind::Window,
+            true,
+        );
+
+        {
+            let inner = engine.inner.as_mut().expect("inner");
+            inner.frame_builder.set_max_pinned_resources_per_frame(2);
+        }
+
+        let glyphs = vec![
+            build_glyph(u32::from(b'A'), 1, 1, 2, 2),
+            build_glyph(u32::from(b'B'), 10, 1, 2, 2),
+        ];
+
+        let stats = engine
+            .image_text(
+                &mut store,
+                &mut platform,
+                Dst::server_internal(target),
+                7,
+                [1.0, 1.0, 1.0, 1.0],
+                &glyphs,
+            )
+            .expect("image_text");
+
+        let inner = engine.inner.as_ref().expect("inner");
+        let ceiling = inner.frame_builder.max_pinned_resources_per_frame();
+        let open = inner
+            .frame_builder
+            .open
+            .as_ref()
+            .expect("frame stays open after image_text");
+        assert!(
+            open.pins.len() <= ceiling,
+            "pin set must never exceed the declared ceiling: {} pins against a \
+             ceiling of {} (glyphs_dropped={})",
+            open.pins.len(),
+            ceiling,
+            stats.glyphs_dropped,
+        );
+
+        engine.drain_all(&mut platform);
     }
 }

--- a/crates/yserver/src/kms/render/engine.rs
+++ b/crates/yserver/src/kms/render/engine.rs
@@ -57,7 +57,7 @@ use crate::kms::{
     vk::{
         device::VkContext,
         dst_readback::DstReadback,
-        glyph::{AtlasEntry, GlyphKey},
+        glyph::{AtlasEntry, GlyphKey, GlyphLayout},
         ops::{render::CompositeTarget, text::TextRunTarget},
         render_pipeline::{RenderPipelineCache, SolidColorImage},
         text_pipeline::TextPipeline,
@@ -5941,10 +5941,12 @@ impl RenderEngine {
                     let e = AtlasEntry {
                         atlas_x: 0,
                         atlas_y: 0,
-                        w: 0,
+                        packed_w: 0,
+                        logical_w: 0,
                         h: 0,
                         pen_left: 0,
                         pen_top: 0,
+                        layout: GlyphLayout::A8,
                     };
                     new_zero_inserts.push((key, e));
                     continue;
@@ -5998,24 +6000,26 @@ impl RenderEngine {
                 let new_entry = AtlasEntry {
                     atlas_x,
                     atlas_y,
-                    w: w_u,
+                    packed_w: w_u,
+                    logical_w: w_u,
                     h: h_u,
                     pen_left: 0,
                     pen_top: 0,
+                    layout: GlyphLayout::A8,
                 };
                 new_uploads.push((key, new_entry, staging));
                 stats.glyph_uploads += 1;
                 new_entry
             };
 
-            if entry.w == 0 || entry.h == 0 {
+            if entry.logical_w == 0 || entry.h == 0 {
                 continue;
             }
             // Project glyph bbox into damage tracker.
             damage_min_x = damage_min_x.min(g.dst_x);
             damage_min_y = damage_min_y.min(g.dst_y);
             #[allow(clippy::cast_possible_wrap)]
-            let max_x = g.dst_x.saturating_add(entry.w as i32);
+            let max_x = g.dst_x.saturating_add(entry.logical_w as i32);
             #[allow(clippy::cast_possible_wrap)]
             let max_y = g.dst_y.saturating_add(entry.h as i32);
             damage_max_x = damage_max_x.max(max_x);
@@ -6023,7 +6027,7 @@ impl RenderEngine {
             glyphs_to_draw.push(super::frame_builder::RecordedTextGlyph {
                 atlas_x: entry.atlas_x,
                 atlas_y: entry.atlas_y,
-                w: entry.w,
+                logical_w: entry.logical_w,
                 h: entry.h,
                 dst_x: g.dst_x,
                 dst_y: g.dst_y,
@@ -6040,7 +6044,7 @@ impl RenderEngine {
                         staging_pin_idx,
                         atlas_x: entry.atlas_x,
                         atlas_y: entry.atlas_y,
-                        w: entry.w,
+                        packed_w: entry.packed_w,
                         h: entry.h,
                         insert_key: key,
                         insert_entry: entry,
@@ -6094,7 +6098,12 @@ impl RenderEngine {
         );
         for g in &glyphs_to_draw {
             if let Some(inst) = crate::kms::vk::text_pipeline::GlyphInstanceData::from_glyph(
-                g.dst_x, g.dst_y, g.atlas_x, g.atlas_y, g.w, g.h,
+                g.dst_x,
+                g.dst_y,
+                g.atlas_x,
+                g.atlas_y,
+                g.logical_w,
+                g.h,
             ) {
                 instance_data.extend_from_slice(inst.as_bytes());
             }
@@ -6566,10 +6575,12 @@ impl RenderEngine {
                     let e = AtlasEntry {
                         atlas_x: 0,
                         atlas_y: 0,
-                        w: 0,
+                        packed_w: 0,
+                        logical_w: 0,
                         h: 0,
                         pen_left: 0,
                         pen_top: 0,
+                        layout: GlyphLayout::A8,
                     };
                     new_zero_inserts.push((key, e));
                     continue;
@@ -6629,22 +6640,24 @@ impl RenderEngine {
                 let new_entry = AtlasEntry {
                     atlas_x,
                     atlas_y,
-                    w: g.w,
+                    packed_w: g.w,
+                    logical_w: g.w,
                     h: g.h,
                     pen_left: 0,
                     pen_top: 0,
+                    layout: GlyphLayout::A8,
                 };
                 new_uploads.push((key, new_entry, staging));
                 stats.glyph_uploads += 1;
                 new_entry
             };
-            if entry.w == 0 || entry.h == 0 {
+            if entry.logical_w == 0 || entry.h == 0 {
                 continue;
             }
             damage_min_x = damage_min_x.min(g.dst_x);
             damage_min_y = damage_min_y.min(g.dst_y);
             #[allow(clippy::cast_possible_wrap)]
-            let max_x = g.dst_x.saturating_add(entry.w as i32);
+            let max_x = g.dst_x.saturating_add(entry.logical_w as i32);
             #[allow(clippy::cast_possible_wrap)]
             let max_y = g.dst_y.saturating_add(entry.h as i32);
             damage_max_x = damage_max_x.max(max_x);
@@ -6652,7 +6665,7 @@ impl RenderEngine {
             glyphs_to_draw.push(super::frame_builder::RecordedTextGlyph {
                 atlas_x: entry.atlas_x,
                 atlas_y: entry.atlas_y,
-                w: entry.w,
+                logical_w: entry.logical_w,
                 h: entry.h,
                 dst_x: g.dst_x,
                 dst_y: g.dst_y,
@@ -6676,7 +6689,7 @@ impl RenderEngine {
                         staging_pin_idx,
                         atlas_x: entry.atlas_x,
                         atlas_y: entry.atlas_y,
-                        w: entry.w,
+                        packed_w: entry.packed_w,
                         h: entry.h,
                         insert_key: key,
                         insert_entry: entry,
@@ -6748,7 +6761,12 @@ impl RenderEngine {
         );
         for g in &glyphs_to_draw {
             if let Some(inst) = crate::kms::vk::text_pipeline::GlyphInstanceData::from_glyph(
-                g.dst_x, g.dst_y, g.atlas_x, g.atlas_y, g.w, g.h,
+                g.dst_x,
+                g.dst_y,
+                g.atlas_x,
+                g.atlas_y,
+                g.logical_w,
+                g.h,
             ) {
                 instance_data.extend_from_slice(inst.as_bytes());
             }
@@ -9076,7 +9094,14 @@ fn emit_recorded_op_into_cb(
         Op::GlyphUpload(up) => {
             let atlas = inner.glyph_atlas.as_mut().ok_or(RenderError::NoVk)?;
             let staging_buffer = pins.staging_buffers[up.staging_pin_idx.0 as usize].buffer;
-            atlas.record_upload(cb, staging_buffer, up.atlas_x, up.atlas_y, up.w, up.h);
+            atlas.record_upload(
+                cb,
+                staging_buffer,
+                up.atlas_x,
+                up.atlas_y,
+                up.packed_w,
+                up.h,
+            );
             Ok(())
         }
         Op::CompositeGlyphs(cg) => {
@@ -14646,6 +14671,215 @@ mod tests {
         assert_eq!(stats2.glyphs_dropped, 1);
 
         engine.drain_all(&mut platform);
+    }
+
+    /// Step 2 proof (component-alpha glyphs plan,
+    /// `docs/superpowers/plans/2026-09-10-component-alpha-glyphs-plan.md`):
+    /// `AtlasEntry.w` split into `packed_w` (atlas footprint) and
+    /// `logical_w` (the glyph's own size). While the two agree, either
+    /// field paints identical pixels, so a green suite says nothing
+    /// about which one a given consumer actually reads — this test
+    /// manufactures a cache entry where they DISAGREE and checks each
+    /// consumer against the correct one, through the real
+    /// `image_text` code path (not a reimplementation of it).
+    ///
+    /// A first glyph is uploaded for real at packed_w == logical_w ==
+    /// 40, with its 40 texels spatially varying — left half (cols
+    /// 0..20) opaque, right half (20..40) transparent — so the atlas
+    /// holds content a wrong-width sample would visibly disagree with.
+    /// Its cache entry is then overwritten in place (same atlas slot,
+    /// same uploaded pixels) with `logical_w` shrunk to 10 while
+    /// `packed_w` stays 40. A second `image_text` call at the SAME
+    /// glyph key is then a committed cache hit: it never re-uploads,
+    /// so every downstream value comes from the (now-asymmetric)
+    /// `AtlasEntry`, not from anything this test computes itself.
+    #[test]
+    #[ignore = "needs live Vulkan ICD"]
+    fn atlas_entry_packed_vs_logical_width_feed_the_right_consumers() {
+        let Some(mut platform) = live_platform() else {
+            eprintln!("no VkContext available — skipping");
+            return;
+        };
+        let mut store = DrawableStore::new();
+        let mut engine = RenderEngine::new(&platform).expect("engine");
+
+        let real_target = alloc_drawable_3a(&platform, &mut store, 0x1, 64, 32);
+        // Window + scene-participating so presentation damage
+        // accumulates (mirrors `image_text_run_records_damage_on_target`).
+        let probe_target = alloc_drawable_3a_with_kind(
+            &platform,
+            &mut store,
+            0x2,
+            64,
+            32,
+            super::super::store::DrawableKind::Window,
+            true,
+        );
+
+        // Pre-clear the probe target to black so a painted quad — or
+        // the absence of one — is unambiguous on readback.
+        engine
+            .fill_rect(
+                &mut store,
+                &mut platform,
+                Dst::server_internal(probe_target),
+                vk::Rect2D {
+                    offset: vk::Offset2D::default(),
+                    extent: vk::Extent2D {
+                        width: 64,
+                        height: 32,
+                    },
+                },
+                [0.0, 0.0, 0.0, 1.0],
+            )
+            .expect("clear");
+
+        // Real 40×20 upload: left half (texels 0..20) opaque, right
+        // half (20..40) transparent.
+        let font_xid = 4242;
+        let codepoint = u32::from(b'Z');
+        let (w, h) = (40usize, 20usize);
+        let mut pixels = vec![0u8; w * h];
+        for row in 0..h {
+            for col in 0..20 {
+                pixels[row * w + col] = 0xFF;
+            }
+        }
+        let real_glyph = PreparedGlyph {
+            dst_x: 0,
+            dst_y: 0,
+            w,
+            h,
+            pixels,
+            codepoint,
+        };
+        let stats = engine
+            .image_text(
+                &mut store,
+                &mut platform,
+                Dst::server_internal(real_target),
+                font_xid,
+                [1.0, 1.0, 1.0, 1.0],
+                &[real_glyph],
+            )
+            .expect("image_text (real upload)");
+        assert_eq!(stats.atlas_interns, 1);
+        assert_eq!(stats.glyph_uploads, 1);
+
+        // The glyph insert is transactional — pending until the frame
+        // closes (`commit_close_success`). Close it now so the entry
+        // is actually in `glyph_atlas`'s cache before we read it back.
+        engine
+            .close_open_frame(
+                &mut store,
+                &mut platform,
+                crate::kms::render::frame_builder::CloseReason::SyncWait,
+            )
+            .expect("close frame after real upload");
+
+        // Overwrite the cached entry: same atlas slot (same uploaded
+        // pixels), but logical_w now disagrees with packed_w.
+        let key = GlyphKey {
+            font_xid,
+            codepoint,
+        };
+        let inner = engine.inner.as_mut().expect("inner");
+        let atlas = inner
+            .glyph_atlas
+            .as_mut()
+            .expect("atlas init by first call");
+        let real_entry = atlas.lookup(key).expect("entry cached by real upload");
+        assert_eq!(real_entry.packed_w, 40);
+        assert_eq!(real_entry.logical_w, 40);
+        let asymmetric_entry = AtlasEntry {
+            packed_w: 40,
+            logical_w: 10,
+            ..real_entry
+        };
+        atlas.insert_entry(key, asymmetric_entry);
+
+        // Second call, same key: a committed hit. dst_x/dst_y/w/h/pixels
+        // on this input glyph are irrelevant on the hit path — only the
+        // cached entry's fields drive geometry — so they're placeholders.
+        let probe_glyph = PreparedGlyph {
+            dst_x: 5,
+            dst_y: 5,
+            w: 1,
+            h: 1,
+            pixels: vec![0u8; 1],
+            codepoint,
+        };
+        let stats2 = engine
+            .image_text(
+                &mut store,
+                &mut platform,
+                Dst::server_internal(probe_target),
+                font_xid,
+                [1.0, 1.0, 1.0, 1.0],
+                &[probe_glyph],
+            )
+            .expect("image_text (cache hit)");
+        assert_eq!(
+            stats2.atlas_interns, 0,
+            "must be a cache hit, not a re-upload, or this proves nothing"
+        );
+        assert_eq!(stats2.glyph_uploads, 0);
+
+        // (1) Damage extent: the append-time damage union must use
+        // logical_w (10), not packed_w (40).
+        let d = store.get(probe_target).expect("drawable");
+        let rects: Vec<vk::Rect2D> = d.presentation_damage.rects().to_vec();
+        let probe_rect = rects
+            .iter()
+            .find(|r| r.offset.x == 5 && r.offset.y == 5)
+            .unwrap_or_else(|| panic!("no damage rect at (5,5): {rects:?}"));
+        assert_eq!(
+            probe_rect.extent.width, 10,
+            "damage extent used packed_w (40) instead of logical_w (10)"
+        );
+        assert_eq!(probe_rect.extent.height, 20);
+
+        // (2) Instance geometry: the dst quad is logical_w (10) wide,
+        // and its atlas UV span must ALSO be logical_w wide (never the
+        // packed footprint) — so it samples only texels 0..10, a
+        // subset of the real upload's opaque 0..20, and paints fully
+        // opaque white. Had the instance geometry used packed_w (40)
+        // for the atlas span instead, the 10-pixel-wide quad would
+        // stretch across all 40 texels and its right half would land
+        // on the transparent texels 20..40, producing a visibly mixed
+        // opaque/transparent pattern instead of a solid one.
+        engine.drain_all(&mut platform);
+        let out = engine
+            .get_image(
+                &mut store,
+                &mut platform,
+                Src::server_internal(probe_target),
+                vk::Rect2D {
+                    offset: vk::Offset2D::default(),
+                    extent: vk::Extent2D {
+                        width: 64,
+                        height: 32,
+                    },
+                },
+                32,
+            )
+            .expect("get_image");
+        let pixel_at = |x: usize, y: usize| {
+            let off = (y * 64 + x) * 4;
+            (out[off], out[off + 1], out[off + 2], out[off + 3])
+        };
+        for y in 5..25 {
+            for x in 5..15 {
+                let (b, g, r, _a) = pixel_at(x, y);
+                assert_eq!(
+                    (b, g, r),
+                    (0xFF, 0xFF, 0xFF),
+                    "probe quad pixel ({x},{y}) not fully opaque — instance geometry likely \
+                     sampled packed_w's atlas span instead of logical_w's: \
+                     ({b:#x},{g:#x},{r:#x})",
+                );
+            }
+        }
     }
 
     // ── Stage 3c.3 acceptance tests ─────────────────────────────

--- a/crates/yserver/src/kms/render/engine.rs
+++ b/crates/yserver/src/kms/render/engine.rs
@@ -8858,10 +8858,13 @@ pub(crate) struct CompositeGlyphInput<'a> {
     /// skip the upload (space glyphs after pen-only adjustment).
     pub w: u32,
     pub h: u32,
-    /// Glyph pixels as stored in the glyphset: dense A8 (native a8 /
-    /// ARGB32-preconverted) or raw A1 wire. A1→A8 expansion is
-    /// deferred to the engine's atlas-miss branch
-    /// ([`GlyphPixels::to_a8`]) so a resident glyph never re-expands.
+    /// Glyph pixels as stored in the glyphset: dense A8 (native a8),
+    /// raw A1 wire, or raw ARGB32 wire (`[B, G, R, A]` CARD32s).
+    /// Conversion to the atlas's dense A8 coverage plane — A1
+    /// expansion, ARGB32 reduction to the mean of logical R, G, B —
+    /// is deferred to the engine's atlas-miss branch
+    /// ([`GlyphPixels::to_a8`]) so a resident glyph never
+    /// re-converts.
     pub pixels: GlyphPixels<'a>,
     /// Dst-space top-left corner for the glyph quad.
     pub dst_x: i32,

--- a/crates/yserver/src/kms/render/engine.rs
+++ b/crates/yserver/src/kms/render/engine.rs
@@ -8310,6 +8310,85 @@ impl SourceDrawable {
     }
 }
 
+/// #137 tier 1 — admit a `ResolvedSource::Drawable` glyph source whose
+/// *sampled domain* is a single pixel under a repeat that maps that
+/// pixel over the whole plane. Such a picture is a constant colour by
+/// definition, so collapsing it to `foreground_premul` is **exact**,
+/// not an approximation: the same answer Xorg's per-glyph
+/// `Composite(op, pSrc, glyphPicture, pDst)` computes
+/// (`../xserver/render/glyph.c:575` `miGlyphs`), by a cheaper route.
+///
+/// Java2D paints all text through `XRSolidSrcPict` — a 1x1 pixmap
+/// picture with `repeat=Normal` — rather than `CreateSolidFill`, which
+/// is why every Java/AWT text draw was discarded.
+///
+/// Returns the 1x1 read rect **in backing (storage) space**, or `None`
+/// when the source is not of that shape and must keep dropping.
+///
+/// The four admission rules, each of which has a way to be got wrong
+/// that no simple test would catch:
+///
+/// - **`mask_fmt == 0` only.** That is the branch Java takes, and the
+///   one whose reference behaviour is per-glyph compositing. For
+///   `mask_format != 0` Xorg accumulates an A8 mask and composites
+///   once; `render_composite_glyphs` takes the parameter as
+///   `_mask_fmt` and ignores it, always taking the per-glyph shortcut.
+///   That is a known deviation, and admitting a new class of source
+///   into it would broaden incorrect behaviour rather than fix
+///   anything.
+/// - **The sampled DOMAIN, not the backing storage.** A window picture
+///   can resolve to a 1x1 logical domain sitting inside a much larger
+///   redirected backing ([`SourceDrawable::content`]); testing the
+///   storage extent would reject exactly that case, which is the one a
+///   naive pixmap-only test still passes.
+/// - **`Repeat::None` is not admissible even at 1x1.** Outside the
+///   single pixel the source reads as transparent, so the correct
+///   result paints only the glyph area overlapping that one pixel.
+///   Collapsing it to a colour would paint every glyph.
+///   `Normal`/`Pad`/`Reflect` all map one pixel onto the whole plane,
+///   so all three are exact.
+/// - **The rect must lie inside the storage.** [`Src::server_internal`]
+///   is an unclipped backing-space handle and `get_image` clamps, so an
+///   offset outside the allocation would silently read nothing; drop
+///   instead.
+///
+/// A source `PictTransform` needs no gate: with a one-pixel domain and
+/// a plane-covering repeat every source coordinate maps onto that same
+/// pixel, whatever the matrix.
+pub(crate) fn uniform_pixel_glyph_source(
+    src: SourceDrawable,
+    repeat: Repeat,
+    storage: vk::Extent2D,
+    mask_fmt: u32,
+) -> Option<vk::Rect2D> {
+    if mask_fmt != 0 {
+        return None;
+    }
+    match repeat {
+        Repeat::Normal | Repeat::Pad | Repeat::Reflect => {}
+        Repeat::None => return None,
+    }
+    let domain = src.domain().unwrap_or(storage);
+    if domain.width != 1 || domain.height != 1 {
+        return None;
+    }
+    let (x, y) = src.offset();
+    if x < 0
+        || y < 0
+        || u32::try_from(x).ok()? >= storage.width
+        || u32::try_from(y).ok()? >= storage.height
+    {
+        return None;
+    }
+    Some(vk::Rect2D {
+        offset: vk::Offset2D { x, y },
+        extent: vk::Extent2D {
+            width: 1,
+            height: 1,
+        },
+    })
+}
+
 /// Picture source resolved against `KmsCore.pictures` by the
 /// backend wrapper. The engine doesn't read protocol records
 /// directly; the wrapper hands it one of these.
@@ -12019,6 +12098,67 @@ pub(crate) fn decode_x11_pixel_server_alpha(pixel: u32, depth: u8) -> [f32; 4] {
     c
 }
 
+/// #137 tier 1 — one wire pixel from [`RenderEngine::get_image`] as the
+/// premultiplied `[R, G, B, A]` that `ResolvedSource::Solid` carries.
+///
+/// The whole point of this conversion is that the result must equal what
+/// the engine's own sampler would have produced for that pixel, or the
+/// collapse is not exact. So it reproduces, on the CPU, exactly the two
+/// decisions the sampling path makes for a drawable source:
+///
+/// - the **swizzle** (`swizzle_class_for_pict_format`): an `R8_UNORM`
+///   storage — depth 8 or depth 1 — is an alpha mask, sampled
+///   `(0, 0, 0, R)`; a BGRA storage is sampled as it lies.
+/// - **force-opaque** (`resolve_force_opaque_pict_format` and the
+///   `BgraNoAlpha` swizzle, which agree): a depth-24 storage, or a
+///   picture declaring `xRGB24` / `xRGB32`, has no client-meaningful
+///   alpha byte and reads as `a = 1.0`.
+///
+/// Both of the conversions here fail *silently* when wrong, which is
+/// why they are pinned by a test rather than reasoned about:
+///
+/// - `get_image` returns wire order — `[B, G, R, A]`, blue in the low
+///   byte — while `ResolvedSource::Solid` is logical `[R, G, B, A]`. A
+///   swap turns blue text red and nothing errors.
+/// - taking the stored byte as alpha on a depth-24 source would give
+///   `a = 0.0` and paint nothing at all: the exact symptom of the bug
+///   being fixed, which would be maximally confusing to debug.
+///
+/// No premultiplication is applied. X RENDER storage is premultiplied
+/// already (as is the `CreateSolidFill` wire colour, which v2 stores
+/// as-is), so the channels pass through untouched.
+///
+/// `None` for a short buffer or a depth v2 has no RENDER format for.
+#[must_use]
+pub(crate) fn premul_from_wire_pixel(wire: &[u8], depth: u8, pict_format: u32) -> Option<[f32; 4]> {
+    use yserver_protocol::x11::{RENDER_FMT_RGB24, RENDER_FMT_XRGB32};
+    // Divide rather than multiply by a reciprocal: `decode_x11_pixel_bgra`
+    // and every other channel decode in this file divide, and the two do
+    // not agree to the last bit.
+    match depth {
+        24 | 32 => {
+            let px = wire.get(..4)?;
+            let (b, g, r, a) = (px[0], px[1], px[2], px[3]);
+            let opaque =
+                depth == 24 || pict_format == RENDER_FMT_RGB24 || pict_format == RENDER_FMT_XRGB32;
+            Some([
+                f32::from(r) / 255.0,
+                f32::from(g) / 255.0,
+                f32::from(b) / 255.0,
+                if opaque { 1.0 } else { f32::from(a) / 255.0 },
+            ])
+        }
+        // A8: alpha only. Premultiplied, the colour channels of a
+        // pure-alpha picture are zero — which is what the
+        // `AlphaOnlyR8` swizzle's `(0, 0, 0, R)` samples.
+        8 => Some([0.0, 0.0, 0.0, f32::from(*wire.first()?) / 255.0]),
+        // A1: `pack_from_storage` returns one bit per pixel, LSB
+        // first, so pixel 0 is bit 0 of byte 0.
+        1 => Some([0.0, 0.0, 0.0, f32::from(*wire.first()? & 1)]),
+        _ => None,
+    }
+}
+
 /// Decode an X11 pixel for direct storage writes.
 ///
 /// `R8_UNORM` targets are alpha-mask style storages, so the byte must
@@ -12157,6 +12297,206 @@ mod tests {
                 )
                 .is_none()
             );
+        }
+    }
+
+    // ── #137 tier 1: which drawable glyph sources are admissible ──
+    // Pure predicate, no Vk. Every assertion here is a claim about
+    // exactness: an admitted source must be one whose sampled value is
+    // the SAME for every destination pixel, because the glyph path
+    // collapses it to one colour.
+    mod uniform_glyph_source {
+        use super::super::{DrawableId, SourceDrawable, uniform_pixel_glyph_source};
+        use crate::kms::cpu_types::Repeat;
+        use ash::vk;
+
+        fn ext(w: u32, h: u32) -> vk::Extent2D {
+            vk::Extent2D {
+                width: w,
+                height: h,
+            }
+        }
+
+        const REPEATS: [Repeat; 3] = [Repeat::Normal, Repeat::Pad, Repeat::Reflect];
+
+        /// The cross product the plan asks for: only a 1x1 sampled
+        /// domain, only a plane-covering repeat, only `mask_format 0`.
+        #[test]
+        fn admits_exactly_one_pixel_under_a_covering_repeat() {
+            for (w, h) in [(1u32, 1u32), (1, 2), (2, 1), (16, 16)] {
+                let src = SourceDrawable::whole(DrawableId::for_tests(1));
+                let storage = ext(w, h);
+                let one_pixel = w == 1 && h == 1;
+                for repeat in REPEATS {
+                    let got = uniform_pixel_glyph_source(src, repeat, storage, 0);
+                    assert_eq!(
+                        got.is_some(),
+                        one_pixel,
+                        "storage {w}x{h} under {repeat:?} at mask_format 0"
+                    );
+                }
+                // RepeatNone reads transparent outside the pixel, so it
+                // is NOT one colour over the plane even at 1x1.
+                assert!(
+                    uniform_pixel_glyph_source(src, Repeat::None, storage, 0).is_none(),
+                    "storage {w}x{h} under RepeatNone"
+                );
+                // mask_format != 0 selects Xorg's accumulate-into-a-mask
+                // branch, which we do not implement; keep dropping.
+                for repeat in REPEATS {
+                    assert!(
+                        uniform_pixel_glyph_source(src, repeat, storage, 0x21).is_none(),
+                        "storage {w}x{h} under {repeat:?} at a non-zero mask_format"
+                    );
+                }
+            }
+        }
+
+        /// The redirected-window shape, and the one a pixmap-only test
+        /// would pass while leaving broken: a 1x1 CONTENT domain inside
+        /// a large backing is admissible, and the read rect is at the
+        /// content OFFSET, not the backing origin.
+        #[test]
+        fn a_one_pixel_content_domain_inside_a_large_backing_is_admitted_at_its_offset() {
+            let src = SourceDrawable::content(DrawableId::for_tests(2), (7, 9), ext(1, 1));
+            let rect = uniform_pixel_glyph_source(src, Repeat::Normal, ext(640, 480), 0)
+                .expect("a 1x1 content domain is admissible whatever the storage size");
+            assert_eq!(rect.offset.x, 7);
+            assert_eq!(rect.offset.y, 9);
+            assert_eq!(rect.extent, ext(1, 1));
+        }
+
+        /// The converse: a large content domain inside a 1x1-looking
+        /// read is not admissible. The domain wins over the storage in
+        /// both directions.
+        #[test]
+        fn a_larger_content_domain_drops_even_when_the_storage_is_small() {
+            let src = SourceDrawable::content(DrawableId::for_tests(3), (0, 0), ext(4, 4));
+            assert!(uniform_pixel_glyph_source(src, Repeat::Normal, ext(1, 1), 0).is_none());
+        }
+
+        /// `whole()` over a 1x1 storage — Java's `XRSolidSrcPict` — is
+        /// admitted and read at the origin.
+        #[test]
+        fn a_one_by_one_pixmap_is_admitted_at_the_origin() {
+            let src = SourceDrawable::whole(DrawableId::for_tests(4));
+            for repeat in REPEATS {
+                let rect = uniform_pixel_glyph_source(src, repeat, ext(1, 1), 0)
+                    .expect("1x1 storage sampled whole");
+                assert_eq!(rect.offset.x, 0);
+                assert_eq!(rect.offset.y, 0);
+            }
+        }
+
+        /// `Src::server_internal` is unclipped and `get_image` clamps,
+        /// so an offset outside the allocation would read nothing at
+        /// all. Drop rather than read out of range.
+        #[test]
+        fn an_offset_outside_the_storage_drops() {
+            let id = DrawableId::for_tests(5);
+            for offset in [(64, 0), (0, 64), (-1, 0), (0, -1)] {
+                let src = SourceDrawable::content(id, offset, ext(1, 1));
+                assert!(
+                    uniform_pixel_glyph_source(src, Repeat::Normal, ext(64, 64), 0).is_none(),
+                    "offset {offset:?} is outside a 64x64 storage"
+                );
+            }
+        }
+    }
+
+    // ── #137 tier 1: one wire pixel -> a premultiplied colour ──
+    // The two conversions in this function are silent when wrong, so
+    // they are pinned here rather than reasoned about: a channel swap
+    // paints the wrong colour and a wrong alpha paints nothing.
+    // Deliberately non-grey and non-symmetric values throughout, so no
+    // assertion can pass under a swap.
+    mod premul_from_wire {
+        use super::super::premul_from_wire_pixel;
+        use yserver_protocol::x11::{RENDER_FMT_ARGB32, RENDER_FMT_RGB24, RENDER_FMT_XRGB32};
+
+        /// `get_image` hands back wire order, blue in the low byte;
+        /// `ResolvedSource::Solid` is logical `[R, G, B, A]`.
+        #[test]
+        fn depth_32_keeps_the_stored_alpha_and_reorders_to_rgba() {
+            // Wire [B, G, R, A] = 0x11 blue, 0x22 green, 0x33 red,
+            // 0x44 alpha.
+            let got = premul_from_wire_pixel(&[0x11, 0x22, 0x33, 0x44], 32, RENDER_FMT_ARGB32)
+                .expect("depth 32 is supported");
+            let want = [
+                0x33 as f32 / 255.0,
+                0x22 as f32 / 255.0,
+                0x11 as f32 / 255.0,
+                0x44 as f32 / 255.0,
+            ];
+            assert_eq!(got, want, "expected [R, G, B, A] from wire [B, G, R, A]");
+        }
+
+        /// A depth-24 source has no alpha. Taking the stored byte would
+        /// give `a = 0.0` and paint nothing -- the same symptom as the
+        /// bug being fixed.
+        #[test]
+        fn depth_24_forces_opaque_whatever_the_stored_byte_says() {
+            for stored_alpha in [0x00u8, 0x7f, 0xff] {
+                let got = premul_from_wire_pixel(&[0x11, 0x22, 0x33, stored_alpha], 24, 0)
+                    .expect("depth 24 is supported");
+                assert!(
+                    (got[3] - 1.0).abs() < f32::EPSILON,
+                    "depth 24 with stored alpha {stored_alpha:#x} must read a = 1.0, got {}",
+                    got[3],
+                );
+                assert_eq!(got[0], 0x33 as f32 / 255.0);
+                assert_eq!(got[2], 0x11 as f32 / 255.0);
+            }
+        }
+
+        /// A depth-32 storage wrapped by an `xRGB32` picture declares
+        /// its alpha byte to be padding; the sampler pins alpha to ONE
+        /// for it, so this must too.
+        #[test]
+        fn an_alphaless_pict_format_forces_opaque_at_depth_32() {
+            for fmt in [RENDER_FMT_XRGB32, RENDER_FMT_RGB24] {
+                let got = premul_from_wire_pixel(&[0x11, 0x22, 0x33, 0x00], 32, fmt)
+                    .expect("depth 32 is supported");
+                assert!(
+                    (got[3] - 1.0).abs() < f32::EPSILON,
+                    "pict_format {fmt} declares no alpha, so a = 1.0"
+                );
+            }
+        }
+
+        /// A8 is alpha-only, matching the `AlphaOnlyR8` swizzle's
+        /// `(0, 0, 0, R)`. Premultiplied, a pure-alpha picture's colour
+        /// channels are zero.
+        #[test]
+        fn depth_8_is_alpha_only() {
+            let got = premul_from_wire_pixel(&[0x40, 0, 0, 0], 8, 0).expect("A8 is supported");
+            assert_eq!(got, [0.0, 0.0, 0.0, 0x40 as f32 / 255.0]);
+        }
+
+        /// A1 arrives bit-packed, LSB first.
+        #[test]
+        fn depth_1_reads_bit_zero() {
+            assert_eq!(
+                premul_from_wire_pixel(&[0x01, 0, 0, 0], 1, 0).expect("A1 is supported"),
+                [0.0, 0.0, 0.0, 1.0]
+            );
+            // Bit 0 clear, higher bits set: pixel 0 is still zero.
+            assert_eq!(
+                premul_from_wire_pixel(&[0xfe, 0, 0, 0], 1, 0).expect("A1 is supported"),
+                [0.0, 0.0, 0.0, 0.0]
+            );
+        }
+
+        /// A short read (a clamped-away rect) and a depth with no
+        /// RENDER format must both decline rather than index past the
+        /// buffer or invent a colour.
+        #[test]
+        fn a_short_buffer_or_an_unsupported_depth_declines() {
+            assert!(premul_from_wire_pixel(&[], 32, RENDER_FMT_ARGB32).is_none());
+            assert!(premul_from_wire_pixel(&[0x11, 0x22, 0x33], 32, RENDER_FMT_ARGB32).is_none());
+            assert!(premul_from_wire_pixel(&[], 8, 0).is_none());
+            assert!(premul_from_wire_pixel(&[0x11, 0x22, 0x33, 0x44], 4, 0).is_none());
+            assert!(premul_from_wire_pixel(&[0x11, 0x22, 0x33, 0x44], 16, 0).is_none());
         }
     }
 

--- a/crates/yserver/src/kms/render/engine.rs
+++ b/crates/yserver/src/kms/render/engine.rs
@@ -46,7 +46,7 @@ use ash::vk;
 
 use super::{
     glyph_atlas::GlyphAtlas,
-    glyph_pixels::GlyphPixels,
+    glyph_pixels::{GlyphPixels, GlyphSourceFormat},
     platform::{FenceTicket, PlatformBackend, PresentCompletionSignal},
     present_completion::{PendingPresentBatch, PendingPresentEntry, PresentBatchWait},
     store::{DrawableId, DrawableStore, RetiredImage},
@@ -1125,7 +1125,7 @@ struct RenderEngineInner {
     /// `ImageText8/16` path always uses the
     /// `(Over, B8G8R8A8, true)` entry — identical blend state to
     /// the historical singleton.
-    text_pipelines: HashMap<(u8, vk::Format, bool), TextPipeline>,
+    text_pipelines: HashMap<(u8, vk::Format, bool, bool), TextPipeline>,
     /// Stage 3a: latest atlas-upload ticket. Cloned onto every
     /// atlas-consuming SubmittedOp (text runs, RENDER glyphs in
     /// Stage 3d) so the upload's per-call staging buffer and the
@@ -1289,14 +1289,20 @@ struct RenderEngineInner {
 
 impl RenderEngineInner {
     /// Look up or lazily build the text pipeline for
-    /// `(op, dst_format, dst_has_alpha)`. Mirrors the RENDER
-    /// `Composite` pipeline cache's get-or-build
-    /// (`render_pipeline.rs`); blend state comes from
-    /// `StdPictOp::blend_factors` so the two paths agree by
-    /// construction. Callers must have validated `op` as a
+    /// `(op, dst_format, dst_has_alpha, component_alpha)`. Mirrors
+    /// the RENDER `Composite` pipeline cache's get-or-build
+    /// (`render_pipeline.rs`) — including its fourth key dimension,
+    /// so the two caches key on the same four facts; blend state
+    /// comes from `StdPictOp::blend_factors` so the two paths agree
+    /// by construction. Callers must have validated `op` as a
     /// standard fixed-function PictOp (0..=12, not Saturate) and
     /// built `glyph_atlas` first (the pipeline's descriptor set
     /// binds the atlas view at construction).
+    ///
+    /// `component_alpha` must already be gated on the device's
+    /// `dualSrcBlend` — `RenderEngine::effective_glyph_layout` is the
+    /// one place that decides it, so a `true` here means the atlas
+    /// really does hold four planes for this run.
     ///
     /// Build happens at RECORD time (where `&mut self` is
     /// available); emit only looks the entry up — a recorded
@@ -1307,11 +1313,13 @@ impl RenderEngineInner {
         op: u8,
         dst_format: vk::Format,
         dst_has_alpha: bool,
+        component_alpha: bool,
         context: &str,
     ) -> Result<(), RenderError> {
         use crate::kms::vk::render_pipeline::StdPictOp;
         if let std::collections::hash_map::Entry::Vacant(e) =
-            self.text_pipelines.entry((op, dst_format, dst_has_alpha))
+            self.text_pipelines
+                .entry((op, dst_format, dst_has_alpha, component_alpha))
         {
             let Some(std_op) = StdPictOp::from_u8(op) else {
                 // Callers gate to the standard family before this.
@@ -1328,6 +1336,7 @@ impl RenderEngineInner {
                 dst_format,
                 std_op,
                 dst_has_alpha,
+                component_alpha,
                 atlas_view,
             ) {
                 Ok(p) => {
@@ -1568,6 +1577,23 @@ impl RenderEngineInner {
 enum FrameBuilderTraceFilter {
     DrawableId(u64),
     RedirectedArgbBackings,
+}
+
+/// The fields one `CompositeGlyphs` request shares across every draw
+/// run it is recorded as. Carried as a struct so
+/// [`RenderEngine::record_glyph_runs`] stays inside clippy's argument
+/// budget, and so a future run-splitter cannot accidentally vary one
+/// of them per run — all six are request-wide by specification.
+struct GlyphRunCommon {
+    dst_id: DrawableId,
+    dst_old_layout: vk::ImageLayout,
+    /// Wire PictOp, validated at append.
+    op: u8,
+    dst_has_alpha: bool,
+    foreground_rgba: [f32; 4],
+    /// The request's clip scissor list; every run scissors to all of
+    /// it (one clip region per request, spec stage 2b).
+    clip_scissors: Vec<vk::Rect2D>,
 }
 
 impl RenderEngine {
@@ -5828,10 +5854,18 @@ impl RenderEngine {
         }
         // Core ImageText is always the Over+BGRA8 blend — the
         // legacy singleton entry, bit-identical blend state.
+        //
+        // And never component-alpha: core text bitmaps are A8 by
+        // construction (the server rasterised them itself from a core
+        // font), so `false` is unconditional here. That is one half
+        // of design invariant 8; the other half is the per-glyph
+        // assertion in the walk below, which is what would catch an
+        // atlas entry arriving from the glyphset namespace.
         inner.ensure_text_pipeline(
             3, // Over
             vk::Format::B8G8R8A8_UNORM,
             true,
+            false, // component_alpha — core text is single-plane A8
             "image_text (frame_builder)",
         )?;
 
@@ -6015,6 +6049,21 @@ impl RenderEngine {
             if entry.logical_w == 0 || entry.h == 0 {
                 continue;
             }
+            // Design invariant 8, asserted rather than assumed:
+            // `image_text` and `composite_glyphs` share this atlas
+            // and this recorded op, and `GlyphKey.font_xid` carries a
+            // CORE FONT host xid here but a GLYPHSET host xid there.
+            // A single xid allocator means the two namespaces cannot
+            // collide, so a hit here is always one of our own
+            // single-plane entries — but were they ever to collide,
+            // core text would sample a 4-plane entry as if it had one
+            // plane, and nothing else in the path would notice.
+            debug_assert_eq!(
+                entry.layout,
+                GlyphLayout::A8,
+                "image_text found a non-A8 atlas entry for key {key:?}; the core-font \
+                 and glyphset xid namespaces must not overlap",
+            );
             // Project glyph bbox into damage tracker.
             damage_min_x = damage_min_x.min(g.dst_x);
             damage_min_y = damage_min_y.min(g.dst_y);
@@ -6031,6 +6080,7 @@ impl RenderEngine {
                 h: entry.h,
                 dst_x: g.dst_x,
                 dst_y: g.dst_y,
+                layout: entry.layout,
             });
         }
 
@@ -6104,6 +6154,7 @@ impl RenderEngine {
                 g.atlas_y,
                 g.logical_w,
                 g.h,
+                g.layout,
             ) {
                 instance_data.extend_from_slice(inst.as_bytes());
             }
@@ -6310,9 +6361,10 @@ impl RenderEngine {
         // dimension (only DST_ALPHA-referencing ops care).
         let dst_has_alpha = dst_has_alpha_for_pict_format(dst_format, dst_depth, dst_pict_format);
 
-        // (2) Lazy-init atlas + the (op, format, has_alpha) text
-        //     pipeline entry. Build at RECORD time so emit can look
-        //     the entry up immutably.
+        // (2) Lazy-init the atlas. The text pipelines this request
+        //     needs are built at step (8a), once the per-glyph walk
+        //     has said which layouts its entries carry — still at
+        //     RECORD time, so emit can look them up immutably.
         if inner.glyph_atlas.is_none() {
             match GlyphAtlas::new(Arc::clone(&inner.vk)) {
                 Ok(a) => inner.glyph_atlas = Some(a),
@@ -6324,12 +6376,14 @@ impl RenderEngine {
                 }
             }
         }
-        inner.ensure_text_pipeline(
-            op,
-            dst_format,
-            dst_has_alpha,
-            "composite_glyphs (frame_builder)",
-        )?;
+        // A single request can mix glyph formats — the items stream's
+        // inline `count == 255` element rewrites the active glyphset
+        // mid-stream and glyphsets can differ in picture format — and
+        // pipeline state is immutable, so the request is recorded as
+        // one op per contiguous same-layout run. The pipelines those
+        // runs bind are built after the per-glyph walk, from the
+        // layouts the ATLAS ENTRIES actually carry; see step (8a).
+        let component_alpha_supported = inner.vk.component_alpha_supported;
 
         // (3) Open the frame if not open. `submit_group_ticket_or_open`
         //     either returns the existing shared ticket (if a sibling
@@ -6602,19 +6656,45 @@ impl RenderEngine {
                 // expanded here — on the atlas-MISS path only, so a glyph
                 // already resident in the atlas never re-expands (#2,
                 // 2026-07-08 render-optimization gaps).
-                let Some(a8) = g.pixels.to_a8(g.w, g.h) else {
+                //
+                // The layout is decided FIRST, because it selects
+                // both the bytes staged and the atlas footprint
+                // reserved. `ComponentAlpha` stages four adjacent
+                // coverage planes (logical R, G, B, A) and reserves
+                // `4 * w` texels; `A8` stages one plane at `w`,
+                // reducing an ARGB32 source to the mean of its
+                // colour channels — the `dualSrcBlend`-less
+                // fallback.
+                let layout = Self::effective_glyph_layout(
+                    g.pixels.source_format(),
+                    component_alpha_supported,
+                );
+                let Some(atlas_bytes) = g.pixels.to_atlas_bytes(g.w, g.h, layout) else {
                     log::warn!(
                         "render composite_glyphs (frame_builder): glyph pixels too short \
-                         for {}x{}; dropping pre-pack",
+                         for {}x{} at layout {layout:?}; dropping pre-pack",
                         g.w,
                         g.h,
                     );
                     stats.glyphs_dropped += 1;
                     continue;
                 };
-                let copy_len = a8.len();
-                let Some((atlas_x, atlas_y)) =
-                    inner.glyph_atlas.as_mut().expect("init").pack(g.w, g.h)
+                let copy_len = atlas_bytes.len();
+                // The PACKED footprint — what the shelf packer
+                // reserves and what the upload copy region covers.
+                // The dst quad, the damage extent and the instance
+                // geometry all take `g.w` instead; feeding the packed
+                // width to any of those stretches the glyph across
+                // its own planes (design invariant 9).
+                let packed_w = match layout {
+                    GlyphLayout::A8 => g.w,
+                    GlyphLayout::ComponentAlpha => g.w.saturating_mul(super::glyph_pixels::PLANES),
+                };
+                let Some((atlas_x, atlas_y)) = inner
+                    .glyph_atlas
+                    .as_mut()
+                    .expect("init")
+                    .pack(packed_w, g.h)
                 else {
                     inner.glyph_atlas.as_mut().expect("init").note_full_once();
                     stats.glyphs_dropped += 1;
@@ -6626,7 +6706,7 @@ impl RenderEngine {
                     Arc::clone(&inner.vk),
                     upload_bytes.max(1),
                 )?);
-                let src_slice: &[u8] = &a8;
+                let src_slice: &[u8] = &atlas_bytes;
                 // SAFETY: staging is HOST_COHERENT, mapped for at
                 // least `upload_bytes` bytes (clamped to 1 below);
                 // `src_slice.len() == copy_len == upload_bytes`.
@@ -6637,15 +6717,20 @@ impl RenderEngine {
                         copy_len,
                     );
                 }
+                debug_assert_eq!(
+                    copy_len,
+                    (packed_w as usize) * (g.h as usize),
+                    "the staged bytes must exactly fill the reserved atlas footprint",
+                );
                 let new_entry = AtlasEntry {
                     atlas_x,
                     atlas_y,
-                    packed_w: g.w,
+                    packed_w,
                     logical_w: g.w,
                     h: g.h,
                     pen_left: 0,
                     pen_top: 0,
-                    layout: GlyphLayout::A8,
+                    layout,
                 };
                 new_uploads.push((key, new_entry, staging));
                 stats.glyph_uploads += 1;
@@ -6669,6 +6754,11 @@ impl RenderEngine {
                 h: entry.h,
                 dst_x: g.dst_x,
                 dst_y: g.dst_y,
+                // From the ATLAS ENTRY, never recomputed from the
+                // input: the entry is what the pipeline will sample,
+                // and for a glyph that interned in an EARLIER request
+                // it is the only authority on how it was packed.
+                layout: entry.layout,
             });
         }
 
@@ -6705,6 +6795,37 @@ impl RenderEngine {
 
         if glyphs_to_draw.is_empty() {
             return Ok(stats);
+        }
+
+        // (8a) Text pipelines for exactly the layouts this request's
+        //      glyphs turned out to have. Built at RECORD time, so
+        //      emit only ever looks an entry up.
+        //
+        //      Derived from the recorded glyphs — i.e. from the ATLAS
+        //      ENTRIES — and not from the inputs' source formats. The
+        //      two agree today, because `component_alpha_supported`
+        //      is fixed for the life of the device, so an entry's
+        //      layout is always what `effective_glyph_layout` answers
+        //      for its glyphset's format. But it is the entry the run
+        //      binds a pipeline for, and an entry can have interned
+        //      in an EARLIER request; keying this off the protocol
+        //      tags would let emit look up a pipeline nobody built.
+        //
+        //      This sits after the per-glyph walk and before the
+        //      runs, which leaves the close+reopen decision exactly
+        //      where it was (invariant 7c) — a pipeline build is not
+        //      a frame op.
+        for layout in [GlyphLayout::A8, GlyphLayout::ComponentAlpha] {
+            if !glyphs_to_draw.iter().any(|g| g.layout == layout) {
+                continue;
+            }
+            inner.ensure_text_pipeline(
+                op,
+                dst_format,
+                dst_has_alpha,
+                layout == GlyphLayout::ComponentAlpha,
+                "composite_glyphs (frame_builder)",
+            )?;
         }
 
         // (7) Build the clip scissor list. #133 step 3 (P4): the inline
@@ -6748,37 +6869,251 @@ impl RenderEngine {
             }
         }
 
-        // (8b) Build + pin the per-glyph instance vertex buffer (#1
-        //      glyph batching). Instance data carries dst rects + atlas
-        //      TEXEL coords; the shader normalizes UV by the atlas
-        //      extent (per-run push constant at emit), so this recorded
-        //      data survives a future atlas grow/repack. Pinned into the
-        //      open frame exactly like the trapezoid path so it outlives
-        //      the deferred submit.
-        let mut instance_data: Vec<u8> = Vec::with_capacity(
-            glyphs_to_draw.len()
-                * std::mem::size_of::<crate::kms::vk::text_pipeline::GlyphInstanceData>(),
-        );
-        for g in &glyphs_to_draw {
-            if let Some(inst) = crate::kms::vk::text_pipeline::GlyphInstanceData::from_glyph(
-                g.dst_x,
-                g.dst_y,
-                g.atlas_x,
-                g.atlas_y,
-                g.logical_w,
-                g.h,
-            ) {
-                instance_data.extend_from_slice(inst.as_bytes());
-            }
-        }
-        let instance_count = u32::try_from(
-            instance_data.len()
-                / std::mem::size_of::<crate::kms::vk::text_pipeline::GlyphInstanceData>(),
-        )
-        .unwrap_or(0);
-        if instance_count == 0 {
+        // (8b/9) Form the draw runs and hand them to the shared run
+        //      recorder, which builds + pins ONE instance buffer for
+        //      the whole request and appends one op per run. Runs are
+        //      contiguous stretches of equal effective `GlyphLayout`
+        //      in REQUEST ORDER — a request can switch glyphset
+        //      mid-stream and glyphsets can differ in format, and
+        //      pipeline state is immutable, so a mixed request needs
+        //      one op per stretch. Never regrouped by format: see
+        //      `split_glyph_runs`.
+        //
+        //      On a device WITHOUT `dualSrcBlend` there is exactly
+        //      one run whatever the request mixes: the upload reduces
+        //      every ARGB32 glyph to a single A8 plane, so every
+        //      glyph has the same effective layout and the split is
+        //      inert. With it, an alternating stream really does
+        //      record several ops.
+        //
+        //      Whatever the run count, the clip region built above,
+        //      the damage union mutated above and the
+        //      `mark_contents_modified` below stay ONE per request: a
+        //      client sent one request and must see one damage event
+        //      and one region for it.
+        let runs = Self::split_glyph_runs(&glyphs_to_draw);
+        let recorded_instances = Self::record_glyph_runs(
+            inner,
+            &runs,
+            &GlyphRunCommon {
+                dst_id,
+                dst_old_layout: dst_pre_frame_layout,
+                op,
+                dst_has_alpha,
+                foreground_rgba,
+                clip_scissors,
+            },
+        )?;
+        if recorded_instances == 0 {
             return Ok(stats);
         }
+        // Request-wide, one per request however many runs were
+        // recorded (spec stage 2b).
+        store.mark_contents_modified(dst_id);
+
+        // (10) Do NOT auto-close. Frame closes via M2 (next non-ported
+        //      op), M3 (maybe_composite), timeout, sync_wait, or
+        //      shutdown.
+        Ok(stats)
+    }
+
+    /// The atlas layout a glyph of `source` effectively gets — the
+    /// value written into its [`AtlasEntry`] when it interns, and the
+    /// value [`Self::split_glyph_runs`] groups on.
+    ///
+    /// **Derived here, not tagged by the parser.** The backend's
+    /// items parse tags each [`CompositeGlyphInput`] with the
+    /// glyphset's picture format, which is protocol state. Turning
+    /// that into a layout depends on `component_alpha_supported`
+    /// (device state the protocol layer has no business reading) and
+    /// on what the atlas upload actually stores — so it lives here,
+    /// beside atlas allocation and pipeline choice, where the three
+    /// cannot drift apart.
+    ///
+    /// **`component_alpha_supported` is the device half of the
+    /// answer, and this is the ONLY place it is consulted for
+    /// glyphs.** `dualSrcBlend` is an optional Vulkan 1.0 feature
+    /// (Broadcom V3D ships without it) and the `SRC1_*` blend factors
+    /// the component-alpha path needs are unavailable without it. So
+    /// where it is absent, an ARGB32 glyph is REDUCED to one
+    /// grayscale coverage plane at upload
+    /// ([`reduce_argb32_glyph_to_a8_coverage`](super::glyph_pixels::reduce_argb32_glyph_to_a8_coverage))
+    /// and is genuinely an A8 entry in the atlas — which is exactly
+    /// the grayscale AA `vk/device.rs` already promises there.
+    ///
+    /// Deciding it here — once, beside atlas allocation and pipeline
+    /// choice — is what keeps the three from drifting: the layout
+    /// selects the packed width the uploader stages, the pipeline the
+    /// emit binds and the run boundaries the splitter cuts, and an
+    /// entry tagged `ComponentAlpha` over a single-plane upload would
+    /// be sampled as garbage. It is also why the fallback needs no
+    /// runtime switch: `component_alpha_supported` is fixed for the
+    /// life of the device, so the atlas never holds mixed state, and
+    /// the reduction is a pure function testable on its own
+    /// (`feedback_no_feature_kill_switches`).
+    ///
+    /// One clean consequence worth naming: on a device without
+    /// `dualSrcBlend` every glyph has the same effective layout, so a
+    /// mixed-format request forms exactly ONE run and
+    /// [`Self::split_glyph_runs`] is inert.
+    fn effective_glyph_layout(
+        source: GlyphSourceFormat,
+        component_alpha_supported: bool,
+    ) -> GlyphLayout {
+        match source {
+            // A8 is already a coverage plane; A1 expands into one.
+            GlyphSourceFormat::A8 | GlyphSourceFormat::A1 => GlyphLayout::A8,
+            // ARGB32 carries per-channel coverage on the wire (or
+            // colour, for an emoji glyphset — Xorg's `NeedsComponent`
+            // makes no attempt to tell them apart and neither do we).
+            // Four packed planes where the device can blend them,
+            // the grayscale mean where it cannot.
+            GlyphSourceFormat::Argb32 => {
+                if component_alpha_supported {
+                    GlyphLayout::ComponentAlpha
+                } else {
+                    GlyphLayout::A8
+                }
+            }
+        }
+    }
+
+    /// Split `glyphs` into contiguous runs — one per maximal stretch
+    /// of equal effective [`GlyphLayout`] — **in request order**.
+    ///
+    /// The layout is read off each glyph
+    /// ([`RecordedTextGlyph::layout`]) rather than from a parallel
+    /// slice the caller has to keep in lockstep: a second sequence
+    /// indexed by glyph position is free to drift from it, and the
+    /// drift is silent (a glyph sampled by the wrong pipeline).
+    ///
+    /// Glyphs of different layouts need different pipelines, pipeline
+    /// state is immutable, and one recorded op is one `vkCmdDraw`
+    /// with one pipeline — so a request that mixes formats has to
+    /// become several ops (spec stage 2b).
+    ///
+    /// **Contiguous, never regrouped.** Gathering all the A8 glyphs
+    /// into one run and all the component-alpha glyphs into another
+    /// is the obvious optimisation and it is wrong: PictOps are not
+    /// commutative in general, so reordering changes pixels wherever
+    /// two glyph quads overlap — and overlap is ordinary (kerning,
+    /// italics, combining marks), not exotic. Only `Add` would be
+    /// safe to reorder, and special-casing one op would leave a
+    /// reordering splitter in the tree for every other op to trip
+    /// over.
+    ///
+    /// The cost of that is bounded and known: a stream alternating
+    /// format every glyph degrades to one draw per glyph, which is
+    /// what Xorg does on this path anyway — `render/glyph.c` issues
+    /// one `CompositePicture` per glyph for `maskFormat == 0`, so our
+    /// worst case is its normal case. Real clients switch glyphset
+    /// per font or AA change, so the common case stays one run.
+    fn split_glyph_runs(
+        glyphs: &[super::frame_builder::RecordedTextGlyph],
+    ) -> Vec<&[super::frame_builder::RecordedTextGlyph]> {
+        let mut runs: Vec<&[super::frame_builder::RecordedTextGlyph]> = Vec::new();
+        let mut start = 0usize;
+        for i in 1..glyphs.len() {
+            if glyphs[i].layout != glyphs[i - 1].layout {
+                runs.push(&glyphs[start..i]);
+                start = i;
+            }
+        }
+        if start < glyphs.len() {
+            runs.push(&glyphs[start..]);
+        }
+        runs
+    }
+
+    /// Build ONE instance vertex buffer covering `runs` (contiguous
+    /// glyph slices, in request order) and append one
+    /// `RecordedCompositeGlyphs` op per run, each carrying its own
+    /// `(first_instance, instance_count)` range into that buffer.
+    /// Returns the total number of instances recorded — zero means
+    /// nothing was appended and no pin was taken.
+    ///
+    /// **One shared buffer, not one per run.** The frame-pin ceiling
+    /// budgets glyph *uploads* in a pre-pass and then reserves exactly
+    /// **one** further pin for the draw buffer (#137 step 1 / spec
+    /// stage 2c). A buffer per run would make that reservation depend
+    /// on a run count the pre-pass does not know yet, so the pre-pass
+    /// would have to move or run twice. Pinning once, whatever the run
+    /// count, is what keeps that arithmetic true — so this function is
+    /// the only place a `CompositeGlyphs` instance buffer is pinned.
+    ///
+    /// **Runs arrive already cut, from [`Self::split_glyph_runs`].**
+    /// Glyphs of different `GlyphLayout`s need different pipelines
+    /// and pipeline state is immutable, so a request that mixes
+    /// formats is recorded as several contiguous runs (spec stage
+    /// 2b). This function only ranges them over one buffer: the clip
+    /// region, the damage union and the `mark_contents_modified` stay
+    /// with the caller, one per request however many runs it hands
+    /// over. Production hands over exactly one while the upload
+    /// reduces ARGB32 to A8, so a test that hands over two is still
+    /// driving the code that ships.
+    ///
+    /// Instance data carries dst rects + atlas TEXEL coords; the
+    /// shader normalizes UV by the atlas extent (a per-run push
+    /// constant at emit), so recorded data survives a future atlas
+    /// grow/repack. The buffer is pinned into the open frame exactly
+    /// like the trapezoid path so it outlives the deferred submit.
+    ///
+    /// # Errors
+    ///
+    /// `Vk(...)` if the staging buffer cannot be allocated.
+    fn record_glyph_runs(
+        inner: &mut RenderEngineInner,
+        runs: &[&[super::frame_builder::RecordedTextGlyph]],
+        common: &GlyphRunCommon,
+    ) -> Result<u32, RenderError> {
+        type Instance = crate::kms::vk::text_pipeline::GlyphInstanceData;
+        let stride = std::mem::size_of::<Instance>();
+        let total_glyphs: usize = runs.iter().map(|r| r.len()).sum();
+        let mut instance_data: Vec<u8> = Vec::with_capacity(total_glyphs * stride);
+        // (first_instance, instance_count, layout) per run. A glyph
+        // whose geometry does not fit an instance is dropped, so a
+        // run's count is what actually landed in the buffer, not its
+        // glyph count — and the next run's `first_instance` follows
+        // the bytes, never the glyph index.
+        //
+        // The layout comes off the run's first glyph: the splitter
+        // cut the run precisely so every glyph in it agrees, and it
+        // selects BOTH the pipeline the recorded op will bind and
+        // each instance's packed plane stride.
+        let mut ranges: Vec<(u32, u32, GlyphLayout)> = Vec::with_capacity(runs.len());
+        for run in runs {
+            let first_instance = u32::try_from(instance_data.len() / stride).unwrap_or(0);
+            let Some(layout) = run.first().map(|g| g.layout) else {
+                continue;
+            };
+            for g in *run {
+                debug_assert_eq!(
+                    g.layout, layout,
+                    "a recorded glyph run must be homogeneous in effective layout",
+                );
+                if let Some(inst) = Instance::from_glyph(
+                    g.dst_x,
+                    g.dst_y,
+                    g.atlas_x,
+                    g.atlas_y,
+                    g.logical_w,
+                    g.h,
+                    g.layout,
+                ) {
+                    instance_data.extend_from_slice(inst.as_bytes());
+                }
+            }
+            let end = u32::try_from(instance_data.len() / stride).unwrap_or(0);
+            let instance_count = end.saturating_sub(first_instance);
+            if instance_count > 0 {
+                ranges.push((first_instance, instance_count, layout));
+            }
+        }
+        let total_instances = u32::try_from(instance_data.len() / stride).unwrap_or(0);
+        if total_instances == 0 || ranges.is_empty() {
+            return Ok(0);
+        }
+
         let instance_buf = {
             let needed = u64::try_from(instance_data.len()).unwrap_or(0).max(1);
             let buf = StagingBuffer::new_with_usage(
@@ -6795,43 +7130,46 @@ impl RenderEngine {
             }
             buf
         };
-        let instance_pin = inner
-            .frame_builder
-            .open
-            .as_mut()
-            .expect("open")
-            .pins
-            .pin_staging(Arc::new(instance_buf));
+        let open = inner.frame_builder.open.as_mut().expect("open");
+        // Exactly one pin for the whole request — the pin the ceiling
+        // reserved.
+        let instance_pin = open.pins.pin_staging(Arc::new(instance_buf));
 
-        // (9) Append the draw op. No damage_rect carried — damage was
-        //     already mutated at append time above.
-        inner
-            .frame_builder
-            .open
-            .as_mut()
-            .expect("open")
-            .push_op_and_set_layouts(
+        // No damage_rect carried on any run: damage is mutated at
+        // append time by the caller, once for the whole request.
+        for (run_idx, (first_instance, instance_count, layout)) in ranges.into_iter().enumerate() {
+            // Run 0 finds the destination in the frame's pre-op
+            // layout; every later run finds it as the run before left
+            // it, and `record_text_run_scissored` ends in
+            // SHADER_READ_ONLY_OPTIMAL. Carrying the pre-op layout on
+            // run 2+ would declare a wrong `oldLayout` in its
+            // barrier — and a pre-op `UNDEFINED` would license the
+            // driver to discard the earlier runs' pixels.
+            let dst_old_layout = if run_idx == 0 {
+                common.dst_old_layout
+            } else {
+                vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL
+            };
+            open.push_op_and_set_layouts(
                 super::frame_builder::RecordedOp::CompositeGlyphs(
                     super::frame_builder::RecordedCompositeGlyphs {
-                        dst_id,
-                        dst_old_layout: dst_pre_frame_layout,
-                        op,
-                        dst_has_alpha,
-                        foreground_rgba,
+                        dst_id: common.dst_id,
+                        dst_old_layout,
+                        op: common.op,
+                        dst_has_alpha: common.dst_has_alpha,
+                        foreground_rgba: common.foreground_rgba,
+                        component_alpha: layout == GlyphLayout::ComponentAlpha,
                         instance_pin,
+                        first_instance,
                         instance_count,
-                        clip_scissors,
+                        clip_scissors: common.clip_scissors.clone(),
                         damage_rect: None,
                     },
                 ),
-                &[(dst_id, vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL)],
+                &[(common.dst_id, vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL)],
             );
-        store.mark_contents_modified(dst_id);
-
-        // (10) Do NOT auto-close. Frame closes via M2 (next non-ported
-        //      op), M3 (maybe_composite), timeout, sync_wait, or
-        //      shutdown.
-        Ok(stats)
+        }
+        Ok(total_instances)
     }
 
     // ── Op: render_composite (Stage 3c) ─────────────────────────
@@ -8846,9 +9184,9 @@ pub(crate) struct PreparedGlyph {
 /// the items stream's running pen + glyph metrics. Lifetimes:
 /// `pixels` borrows the glyph's stored bytes from
 /// `KmsCore.glyphsets[gs_xid].glyphs[glyph_id].pixels`; the engine
-/// resolves them to dense A8 and copies into a per-glyph
-/// `StagingBuffer` **only on an atlas miss**, so the borrow only
-/// needs to outlive the engine call itself.
+/// resolves them to the atlas's packed form and copies into a
+/// per-glyph `StagingBuffer` **only on an atlas miss**, so the borrow
+/// only needs to outlive the engine call itself.
 pub(crate) struct CompositeGlyphInput<'a> {
     /// Glyphset xid the glyph came from (atlas key namespace).
     pub gs_xid: u32,
@@ -8860,10 +9198,29 @@ pub(crate) struct CompositeGlyphInput<'a> {
     pub h: u32,
     /// Glyph pixels as stored in the glyphset: dense A8 (native a8),
     /// raw A1 wire, or raw ARGB32 wire (`[B, G, R, A]` CARD32s).
-    /// Conversion to the atlas's dense A8 coverage plane — A1
-    /// expansion, ARGB32 reduction to the mean of logical R, G, B —
-    /// is deferred to the engine's atlas-miss branch
-    /// ([`GlyphPixels::to_a8`]) so a resident glyph never
+    ///
+    /// **This is also the glyph's format tag** — the PROTOCOL fact,
+    /// and the only format fact the backend is entitled to state:
+    /// [`GlyphPixels::source_format`] reads it back off the variant.
+    /// The mapping is total and 1:1, so a separate `source_format`
+    /// field beside this one would be a second encoding of the same
+    /// fact, free to disagree with the bytes it describes.
+    ///
+    /// A single request may switch glyphset mid-stream (the inline
+    /// `count == 255` items element), and glyphsets may differ in
+    /// format, so one request can interleave A8 and ARGB32 glyphs.
+    /// The engine maps the format to the glyph's effective
+    /// [`GlyphLayout`](crate::kms::vk::glyph::GlyphLayout) via
+    /// [`RenderEngine::effective_glyph_layout`] and forms one draw
+    /// run per contiguous stretch of equal layout; that mapping
+    /// depends on `component_alpha_supported` and on what the atlas
+    /// upload stores, which is device state the backend has no
+    /// business reading.
+    ///
+    /// Conversion to the packed atlas form — A1 expansion, an ARGB32
+    /// four-plane pack or its grayscale reduction — is deferred to
+    /// the engine's atlas-miss branch
+    /// ([`GlyphPixels::to_atlas_bytes`]) so a resident glyph never
     /// re-converts.
     pub pixels: GlyphPixels<'a>,
     /// Dst-space top-left corner for the glyph quad.
@@ -9134,7 +9491,12 @@ fn emit_recorded_op_into_cb(
             // (surface as NoVk rather than panicking mid-emit).
             let pipeline = inner
                 .text_pipelines
-                .get(&(cg.op, drawable.storage.format, cg.dst_has_alpha))
+                .get(&(
+                    cg.op,
+                    drawable.storage.format,
+                    cg.dst_has_alpha,
+                    cg.component_alpha,
+                ))
                 .ok_or(RenderError::NoVk)?;
             crate::kms::vk::ops::text::record_text_run_scissored(
                 &vk,
@@ -9143,6 +9505,7 @@ fn emit_recorded_op_into_cb(
                 atlas_extent,
                 pipeline,
                 instance_buf,
+                cg.first_instance,
                 cg.instance_count,
                 cg.foreground_rgba,
                 &cg.clip_scissors,
@@ -10584,7 +10947,9 @@ fn emit_recorded_image_text_into_cb(
     // entry, built at record time by `ensure_text_pipeline`.
     let pipeline = inner
         .text_pipelines
-        .get(&(3, vk::Format::B8G8R8A8_UNORM, true))
+        // `false` — core text is never component-alpha (design
+        // invariant 8).
+        .get(&(3, vk::Format::B8G8R8A8_UNORM, true, false))
         .ok_or(RenderError::NoVk)?;
     // image_text uses single-run record_text_run (no clip scissors),
     // distinct from composite_glyphs's record_text_run_scissored.
@@ -10602,6 +10967,8 @@ fn emit_recorded_image_text_into_cb(
             atlas_extent,
             pipeline,
             instance_buf,
+            // Core text records one run per call; no split, no offset.
+            0,
             it.instance_count,
             it.foreground_rgba,
             &[clamp_rect(bounds, drawable_extent)],
@@ -16857,6 +17224,1098 @@ mod tests {
             stats.glyphs_dropped,
         );
 
+        engine.drain_all(&mut platform);
+    }
+
+    // ── #137 step 4a: `first_instance`, plumbed end to end ──────
+    //
+    // A `CompositeGlyphs` request will have to be recorded as SEVERAL
+    // contiguous draw runs — glyphs of different `GlyphLayout`s need
+    // different pipelines, and pipeline state is immutable — all
+    // sharing ONE instance buffer, so the request still costs exactly
+    // one frame pin (the one the ceiling reserves). Each run therefore
+    // carries a `(first_instance, instance_count)` range.
+    //
+    // Production forms exactly one run today, so `record_glyph_runs`
+    // is the seam these two tests drive. The first drives the SAME
+    // function production calls, handed two ranges instead of one; the
+    // second pins `cmd_draw`'s `firstInstance` argument at its own
+    // level, without the recorder in between.
+    //
+    // The failure mode is an unplumbed `first_instance`: a run whose
+    // offset stays 0 draws run 0's glyphs a second time instead of its
+    // own. Nothing downstream of a run splitter could tell that apart
+    // from a splitter bug, which is why it is pinned here, before the
+    // splitter exists.
+
+    /// The glyphset the step-4a fixtures intern into: two 2×2 glyphs,
+    /// each of HALF coverage. Half, and composited with `Add`, so
+    /// drawing one of them twice is observable — see
+    /// `RUN_SPLIT_OP`.
+    const RUN_SPLIT_GS: u32 = 0x7401;
+    /// `Add` (wire PictOp 12), the op the run-split fixture composites
+    /// with. It is deliberately NOT idempotent at partial coverage:
+    /// under `Over` with opaque foreground, drawing range 0's glyph a
+    /// second time lands the same white on the same pixels, so a
+    /// `first_instance` error that ALSO widens the count (`count =
+    /// end - first_instance`, which is how the recorder computes it)
+    /// would paint an indistinguishable result. With `Add` at coverage
+    /// 0x80 the double draw saturates to 0xFF and the two
+    /// destinations differ.
+    const RUN_SPLIT_OP: u8 = 12;
+    /// Half coverage, so `Add`ing it twice is distinguishable from
+    /// `Add`ing it once.
+    const RUN_SPLIT_COVERAGE: u8 = 0x80;
+    /// Left glyph: instance 0 of the shared buffer.
+    const RUN_SPLIT_DST_0: (i32, i32) = (2, 2);
+    /// Right glyph: instance 1. Disjoint from instance 0's quad, so
+    /// "instance 1 was never drawn" is directly observable.
+    const RUN_SPLIT_DST_1: (i32, i32) = (10, 2);
+
+    fn run_split_glyph_inputs(pixels: &[u8; 4]) -> [CompositeGlyphInput<'_>; 2] {
+        [
+            CompositeGlyphInput {
+                gs_xid: RUN_SPLIT_GS,
+                glyph_id: 1,
+                w: 2,
+                h: 2,
+                pixels: GlyphPixels::A8(pixels),
+                dst_x: RUN_SPLIT_DST_0.0,
+                dst_y: RUN_SPLIT_DST_0.1,
+            },
+            CompositeGlyphInput {
+                gs_xid: RUN_SPLIT_GS,
+                glyph_id: 2,
+                w: 2,
+                h: 2,
+                pixels: GlyphPixels::A8(pixels),
+                dst_x: RUN_SPLIT_DST_1.0,
+                dst_y: RUN_SPLIT_DST_1.1,
+            },
+        ]
+    }
+
+    /// The two interned glyphs as `RecordedTextGlyph`s at the fixture
+    /// positions — the same values the per-glyph walk in
+    /// `composite_glyphs_via_frame_builder` builds.
+    fn run_split_recorded_glyphs(
+        engine: &RenderEngine,
+    ) -> Vec<super::super::frame_builder::RecordedTextGlyph> {
+        let atlas = engine
+            .inner
+            .as_ref()
+            .expect("inner")
+            .glyph_atlas
+            .as_ref()
+            .expect("atlas built by the production call");
+        [(1_u32, RUN_SPLIT_DST_0), (2_u32, RUN_SPLIT_DST_1)]
+            .into_iter()
+            .map(|(glyph_id, (dst_x, dst_y))| {
+                let entry = atlas
+                    .lookup(GlyphKey {
+                        font_xid: RUN_SPLIT_GS,
+                        codepoint: glyph_id,
+                    })
+                    .expect("glyph committed to the atlas by the drained frame");
+                super::super::frame_builder::RecordedTextGlyph {
+                    atlas_x: entry.atlas_x,
+                    atlas_y: entry.atlas_y,
+                    logical_w: entry.logical_w,
+                    h: entry.h,
+                    dst_x,
+                    dst_y,
+                    layout: entry.layout,
+                }
+            })
+            .collect()
+    }
+
+    /// Two A8 glyphs recorded as **two** `(first_instance, count)`
+    /// ranges through `record_glyph_runs` must render exactly what the
+    /// same two glyphs render as production's single range.
+    ///
+    /// With `first_instance` unplumbed, the second range redraws the
+    /// first glyph and the right-hand quad never appears, so the two
+    /// destinations differ. The two "must be painted" assertions keep
+    /// the comparison from passing on two blank images.
+    #[test]
+    #[ignore = "needs live Vulkan ICD"]
+    fn a_glyph_run_split_into_two_ranges_renders_as_one_range() {
+        let Some(mut platform) = live_platform() else {
+            eprintln!("no Vk — skipping");
+            return;
+        };
+        let mut store = DrawableStore::new();
+        let mut engine = RenderEngine::new(&platform).expect("engine");
+        let one_range = alloc_drawable_3a(&platform, &mut store, 0x1, 32, 32);
+        let two_ranges = alloc_drawable_3a(&platform, &mut store, 0x2, 32, 32);
+        let full = vk::Rect2D {
+            offset: vk::Offset2D::default(),
+            extent: vk::Extent2D {
+                width: 32,
+                height: 32,
+            },
+        };
+        let black = [0.0, 0.0, 0.0, 1.0];
+        let white = [1.0, 1.0, 1.0, 1.0];
+
+        // Both destinations start from the same fully-defined content
+        // (the storage allocation itself is not initialised — see
+        // `window_storage_init_covers_the_whole_allocation`).
+        for id in [one_range, two_ranges] {
+            engine
+                .fill_rect(
+                    &mut store,
+                    &mut platform,
+                    Dst::server_internal(id),
+                    full,
+                    black,
+                )
+                .expect("fill_rect");
+        }
+
+        // (1) The baseline, through production: ONE run over both
+        //     glyphs. This also interns them and builds the
+        //     (Over, BGRA8, has-alpha) text pipeline that step (3)
+        //     reuses.
+        let pixels = [RUN_SPLIT_COVERAGE; 4];
+        let glyphs = run_split_glyph_inputs(&pixels);
+        engine
+            .composite_glyphs(
+                &mut store,
+                &mut platform,
+                Dst::server_internal(one_range),
+                RUN_SPLIT_OP,
+                0, // pict_format unknown → depth heuristic
+                white,
+                &glyphs,
+                None,
+            )
+            .expect("composite_glyphs");
+        // Read the baseline back. `get_image` is what CLOSES the open
+        // frame (`drain_all` holds no `store` borrow and so cannot
+        // commit a close), and the atlas cache inserts are
+        // transactional on close-success — so this is also what makes
+        // the entries below look-up-able.
+        let out_one = engine
+            .get_image(
+                &mut store,
+                &mut platform,
+                Src::server_internal(one_range),
+                full,
+                32,
+            )
+            .expect("get_image one range");
+
+        // (2) Reopen a frame on the second destination and first-touch
+        //     it, exactly as any second op in a frame would find it.
+        //     Its content is already the black fill from above; this
+        //     repeats it only to open a frame and touch the drawable.
+        engine
+            .fill_rect(
+                &mut store,
+                &mut platform,
+                Dst::server_internal(two_ranges),
+                full,
+                black,
+            )
+            .expect("fill_rect reopen");
+
+        // (3) The same glyphs, recorded as TWO ranges over one shared
+        //     instance buffer, through the function production uses.
+        let recorded = run_split_recorded_glyphs(&engine);
+        assert_eq!(recorded.len(), 2, "both glyphs must have interned");
+        let pins_before = engine
+            .inner
+            .as_ref()
+            .expect("inner")
+            .frame_builder
+            .open
+            .as_ref()
+            .expect("frame open after fill_rect")
+            .pins
+            .len();
+        let inner = engine.inner.as_mut().expect("inner");
+        let dst_old_layout = inner.current_layout_for_drawable(&store, two_ranges);
+        let instances = RenderEngine::record_glyph_runs(
+            inner,
+            &[&recorded[..1], &recorded[1..]],
+            &GlyphRunCommon {
+                dst_id: two_ranges,
+                dst_old_layout,
+                op: RUN_SPLIT_OP,
+                dst_has_alpha: dst_has_alpha_for_pict_format(vk::Format::B8G8R8A8_UNORM, 32, 0),
+                foreground_rgba: white,
+                clip_scissors: vec![full],
+            },
+        )
+        .expect("record_glyph_runs");
+        assert_eq!(instances, 2, "both glyphs must have become instances");
+        store.mark_contents_modified(two_ranges);
+
+        // Two runs, ONE instance pin — the property the frame-pin
+        // ceiling's single reserved pin rests on.
+        {
+            let open = engine
+                .inner
+                .as_ref()
+                .expect("inner")
+                .frame_builder
+                .open
+                .as_ref()
+                .expect("frame still open");
+            assert_eq!(
+                open.pins.len(),
+                pins_before + 1,
+                "two runs must share ONE pinned instance buffer",
+            );
+            let runs = open
+                .ops
+                .iter()
+                .filter(|op| {
+                    matches!(
+                        op,
+                        super::super::frame_builder::RecordedOp::CompositeGlyphs(_)
+                    )
+                })
+                .count();
+            assert_eq!(runs, 2, "the helper must have recorded two runs");
+        }
+
+        // (4) Read the two-range destination back and compare.
+        let out_two = engine
+            .get_image(
+                &mut store,
+                &mut platform,
+                Src::server_internal(two_ranges),
+                full,
+                32,
+            )
+            .expect("get_image two ranges");
+
+        // Teeth: both quads really are painted, so the equality below
+        // is not comparing two black images.
+        let px = |buf: &[u8], x: usize, y: usize| {
+            let o = (y * 32 + x) * 4;
+            [buf[o], buf[o + 1], buf[o + 2], buf[o + 3]]
+        };
+        let bg = px(&out_one, 30, 30);
+        for (x, y) in [
+            (RUN_SPLIT_DST_0.0 as usize, RUN_SPLIT_DST_0.1 as usize),
+            (RUN_SPLIT_DST_1.0 as usize, RUN_SPLIT_DST_1.1 as usize),
+        ] {
+            assert_ne!(
+                px(&out_one, x, y),
+                bg,
+                "the one-range baseline must paint the glyph at ({x}, {y})",
+            );
+            assert_ne!(
+                px(&out_two, x, y),
+                bg,
+                "the two-range recording must paint the glyph at ({x}, {y}) — a \
+                 `first_instance` left at zero redraws range 0's glyph instead",
+            );
+        }
+        assert_eq!(
+            out_two, out_one,
+            "recording the same glyphs as two ranges over one shared instance \
+             buffer must be pixel-identical to recording them as one range",
+        );
+
+        engine.drain_all(&mut platform);
+    }
+
+    /// `record_text_run_scissored` at a NONZERO `first_instance`, with
+    /// no recorder in between: a 2-instance buffer drawn as the range
+    /// `[1, 2)` must paint the second glyph's quad and leave the
+    /// first's untouched.
+    ///
+    /// This is the argument-level companion to the seam test above —
+    /// it fails if `first_instance` reaches the function but not
+    /// `cmd_draw`'s fourth argument.
+    #[test]
+    #[ignore = "needs live Vulkan ICD"]
+    fn record_text_run_scissored_draws_only_the_requested_instance_range() {
+        let Some(mut platform) = live_platform() else {
+            eprintln!("no Vk — skipping");
+            return;
+        };
+        let Some(pool) = platform.ops_command_pool_handle() else {
+            eprintln!("no ops command pool — skipping");
+            return;
+        };
+        let mut store = DrawableStore::new();
+        let mut engine = RenderEngine::new(&platform).expect("engine");
+        let target = alloc_drawable_3a(&platform, &mut store, 0x1, 32, 32);
+        let full = vk::Rect2D {
+            offset: vk::Offset2D::default(),
+            extent: vk::Extent2D {
+                width: 32,
+                height: 32,
+            },
+        };
+        let white = [1.0, 1.0, 1.0, 1.0];
+
+        // Intern the glyphs + build the text pipeline through
+        // production, then drain so the atlas cache inserts commit and
+        // the atlas image is left in SHADER_READ_ONLY_OPTIMAL.
+        let pixels = [0xFFu8; 4];
+        let glyphs = run_split_glyph_inputs(&pixels);
+        engine
+            .fill_rect(
+                &mut store,
+                &mut platform,
+                Dst::server_internal(target),
+                full,
+                [0.0, 0.0, 0.0, 1.0],
+            )
+            .expect("fill_rect");
+        engine
+            .composite_glyphs(
+                &mut store,
+                &mut platform,
+                Dst::server_internal(target),
+                3,
+                0,
+                white,
+                &glyphs,
+                None,
+            )
+            .expect("composite_glyphs warm-up");
+        // `get_image` is what closes the frame, and the atlas cache
+        // inserts commit on close-success — `drain_all` holds no
+        // `store` borrow and cannot close.
+        engine
+            .get_image(
+                &mut store,
+                &mut platform,
+                Src::server_internal(target),
+                full,
+                32,
+            )
+            .expect("get_image closes the warm-up frame");
+
+        // Repaint the destination black so the warm-up's own quads are
+        // gone and only this test's draw can put pixels down — and
+        // close again, so no recorded op can land AFTER the
+        // out-of-band draw below and overwrite it.
+        engine
+            .fill_rect(
+                &mut store,
+                &mut platform,
+                Dst::server_internal(target),
+                full,
+                [0.0, 0.0, 0.0, 1.0],
+            )
+            .expect("fill_rect clear");
+        engine
+            .get_image(
+                &mut store,
+                &mut platform,
+                Src::server_internal(target),
+                full,
+                32,
+            )
+            .expect("get_image closes the clear frame");
+
+        // A 2-instance buffer, in glyph order.
+        let recorded = run_split_recorded_glyphs(&engine);
+        let mut bytes: Vec<u8> = Vec::new();
+        for g in &recorded {
+            let inst = crate::kms::vk::text_pipeline::GlyphInstanceData::from_glyph(
+                g.dst_x,
+                g.dst_y,
+                g.atlas_x,
+                g.atlas_y,
+                g.logical_w,
+                g.h,
+                g.layout,
+            )
+            .expect("instance geometry");
+            bytes.extend_from_slice(inst.as_bytes());
+        }
+        {
+            let inner = engine.inner.as_mut().expect("inner");
+            let vk_ctx = Arc::clone(&inner.vk);
+            let buf = StagingBuffer::new_with_usage(
+                Arc::clone(&vk_ctx),
+                u64::try_from(bytes.len()).expect("len"),
+                vk::BufferUsageFlags::VERTEX_BUFFER,
+            )
+            .expect("instance buffer");
+            unsafe {
+                std::ptr::copy_nonoverlapping(bytes.as_ptr(), buf.mapped.as_ptr(), bytes.len());
+            }
+            let atlas_extent = inner.glyph_atlas.as_ref().expect("atlas").extent();
+            let pipeline = inner
+                .text_pipelines
+                .get(&(3, vk::Format::B8G8R8A8_UNORM, true, false))
+                .expect("pipeline built by the warm-up");
+            let drawable = store.get_mut(target).expect("target");
+            let mut adapter = StorageTextTarget {
+                extent: drawable.storage.extent,
+                image: drawable.storage.image,
+                image_view: drawable.storage.image_view,
+                current_layout: drawable.storage.current_layout,
+            };
+            crate::kms::vk::ops::run_one_shot_op(&vk_ctx, pool, |vk, cb| {
+                crate::kms::vk::ops::text::record_text_run_scissored(
+                    vk,
+                    cb,
+                    &mut adapter,
+                    atlas_extent,
+                    pipeline,
+                    buf.buffer,
+                    // Range [1, 2): the SECOND instance only.
+                    1,
+                    1,
+                    white,
+                    &[full],
+                )
+            })
+            .expect("one-shot text run");
+            drawable.storage.current_layout = adapter.current_layout;
+        }
+
+        let out = engine
+            .get_image(
+                &mut store,
+                &mut platform,
+                Src::server_internal(target),
+                full,
+                32,
+            )
+            .expect("get_image");
+        let px = |x: usize, y: usize| {
+            let o = (y * 32 + x) * 4;
+            [out[o], out[o + 1], out[o + 2], out[o + 3]]
+        };
+        let bg = px(30, 30);
+        assert_ne!(
+            px(RUN_SPLIT_DST_1.0 as usize, RUN_SPLIT_DST_1.1 as usize),
+            bg,
+            "instance 1 is the range's only member and must be drawn",
+        );
+        assert_eq!(
+            px(RUN_SPLIT_DST_0.0 as usize, RUN_SPLIT_DST_0.1 as usize),
+            bg,
+            "instance 0 is BELOW first_instance and must not be drawn — a \
+             hardcoded firstInstance of 0 draws it",
+        );
+
+        engine.drain_all(&mut platform);
+    }
+
+    // ── #137 step 4b: the run splitter ────────────────────────────
+    //
+    // A single `CompositeGlyphs` request can switch glyphset
+    // mid-stream (the inline `count == 255` items element) and
+    // glyphsets can differ in picture format, so one request can
+    // interleave A8 and ARGB32 glyphs — which need different
+    // pipelines, and pipeline state is immutable. The request is
+    // therefore recorded as several contiguous runs.
+    //
+    // Both tests below share one fixture: a real items stream over
+    // two glyphsets of different formats, parsed by the production
+    // parse (`parse_composite_glyph_items`). The first asserts the
+    // splitter's ORDER; the second asserts that today it produces
+    // exactly one run.
+
+    /// Two glyphsets — A8 and ARGB32 — and an items stream that
+    /// alternates between them via the inline `count == 255`
+    /// element. Returns `(glyphsets, initial_gs_xid, items)`.
+    ///
+    /// The stream is deliberately not one-glyph-per-element:
+    /// elements of 2, 1, 1 and 2 glyphs, so a run has to span an
+    /// element boundary (glyphs 0-1) and two same-format glyphs
+    /// inside one element must stay in one run (glyphs 4-5). Source
+    /// formats come out as A8, A8, ARGB32, A8, ARGB32, ARGB32 and
+    /// the pen advances one pixel per glyph, so `dst_x` doubles as
+    /// each glyph's index in request order.
+    fn mixed_format_items_fixture() -> (HashMap<u32, crate::kms::core::GlyphSetState>, u32, Vec<u8>)
+    {
+        use crate::kms::core::{GlyphSetFormat, GlyphSetState, StoredGlyph};
+
+        const GS_A8: u32 = 0x4B01;
+        const GS_ARGB32: u32 = 0x4B02;
+
+        let mut glyphsets: HashMap<u32, GlyphSetState> = HashMap::new();
+        for (xid, format, bytes_per_pixel) in [
+            (GS_A8, GlyphSetFormat::A8, 1),
+            (GS_ARGB32, GlyphSetFormat::Argb32, 4),
+        ] {
+            let mut glyphs = HashMap::new();
+            // Ids 1..=6, so every glyph the stream names resolves in
+            // whichever glyphset is active at the time.
+            for glyph_id in 1..=6u32 {
+                glyphs.insert(
+                    glyph_id,
+                    StoredGlyph {
+                        width: 1,
+                        height: 1,
+                        x: 0,
+                        y: 0,
+                        x_off: 1,
+                        y_off: 0,
+                        pixels: vec![0x80; bytes_per_pixel],
+                        format,
+                    },
+                );
+            }
+            glyphsets.insert(xid, GlyphSetState { format, glyphs });
+        }
+
+        // Element layout: count(u8) pad pad pad dx(i16) dy(i16), then
+        // `count` 1-byte ids padded to a 4-byte boundary (minor 23).
+        let mut items: Vec<u8> = Vec::new();
+        let element = |items: &mut Vec<u8>, ids: &[u8]| {
+            items.extend_from_slice(&[
+                u8::try_from(ids.len()).expect("count"),
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            ]);
+            items.extend_from_slice(ids);
+            while !items.len().is_multiple_of(4) {
+                items.push(0);
+            }
+        };
+        let switch_to = |items: &mut Vec<u8>, xid: u32| {
+            items.extend_from_slice(&[255u8, 0, 0, 0]);
+            items.extend_from_slice(&xid.to_le_bytes());
+        };
+        element(&mut items, &[1, 2]); // glyphs 0,1 — A8 (initial gs)
+        switch_to(&mut items, GS_ARGB32);
+        element(&mut items, &[3]); // glyph 2 — ARGB32
+        switch_to(&mut items, GS_A8);
+        element(&mut items, &[4]); // glyph 3 — A8
+        switch_to(&mut items, GS_ARGB32);
+        element(&mut items, &[5, 6]); // glyphs 4,5 — ARGB32
+
+        (glyphsets, GS_A8, items)
+    }
+
+    /// The parsed glyphs as the per-glyph walk would record them —
+    /// one `RecordedTextGlyph` per parsed glyph, same order, each
+    /// tagged with the effective layout a device with (or without)
+    /// `dualSrcBlend` gives it. The atlas coordinates are irrelevant
+    /// to the splitter; `dst_x` carries the glyph's request-order
+    /// index.
+    fn recorded_from_parsed(
+        parsed: &[super::super::backend::ParsedGlyph],
+        component_alpha_supported: bool,
+    ) -> Vec<super::super::frame_builder::RecordedTextGlyph> {
+        parsed
+            .iter()
+            .map(|p| super::super::frame_builder::RecordedTextGlyph {
+                atlas_x: 0,
+                atlas_y: 0,
+                logical_w: p.w,
+                h: p.h,
+                dst_x: p.dst_x,
+                dst_y: p.dst_y,
+                layout: RenderEngine::effective_glyph_layout(
+                    p.source_format,
+                    component_alpha_supported,
+                ),
+            })
+            .collect()
+    }
+
+    /// The splitter must cut CONTIGUOUS runs in REQUEST ORDER.
+    ///
+    /// Homogeneity alone is not the property worth testing: a
+    /// splitter that gathers all the A8 glyphs into one run and all
+    /// the component-alpha glyphs into another is perfectly
+    /// homogeneous and wrong — PictOps are not commutative, so
+    /// reordering changes pixels wherever two glyph quads overlap,
+    /// and overlap is ordinary (kerning, italics, combining marks).
+    /// So the load-bearing assertion is that concatenating the runs
+    /// reproduces the input glyph sequence exactly: same glyphs, same
+    /// order, none lost or duplicated at a boundary.
+    ///
+    /// The layout sequence here is heterogeneous, which is what
+    /// `effective_glyph_layout` answers for this stream on a device
+    /// WITH `dualSrcBlend` — i.e. what production produces on
+    /// lavapipe, RADV and every desktop GPU. The companion test
+    /// below covers the device that has none, where the same stream
+    /// collapses to one run.
+    #[test]
+    fn a_mixed_format_items_stream_splits_into_ordered_homogeneous_runs() {
+        let (glyphsets, initial_gs, items) = mixed_format_items_fixture();
+        let parsed = super::super::backend::parse_composite_glyph_items(
+            &glyphsets, 23, initial_gs, 0, 0, &items,
+        );
+
+        // The tag follows the inline glyphset change, in request
+        // order. If the parse ignored the `count == 255` element this
+        // would be all-A8, and no splitter could recover.
+        assert_eq!(
+            parsed
+                .glyphs
+                .iter()
+                .map(|p| p.source_format)
+                .collect::<Vec<_>>(),
+            vec![
+                GlyphSourceFormat::A8,
+                GlyphSourceFormat::A8,
+                GlyphSourceFormat::Argb32,
+                GlyphSourceFormat::A8,
+                GlyphSourceFormat::Argb32,
+                GlyphSourceFormat::Argb32,
+            ],
+            "source-format tags must follow the inline glyphset change, in request order",
+        );
+
+        // Layouts as a `dualSrcBlend` device gives them: ARGB32
+        // interns as four packed planes, A8 as one.
+        let recorded = recorded_from_parsed(&parsed.glyphs, true);
+        // Request-order index, carried in dst_x by the fixture's
+        // one-pixel pen advance.
+        assert_eq!(
+            recorded.iter().map(|g| g.dst_x).collect::<Vec<_>>(),
+            vec![0, 1, 2, 3, 4, 5],
+            "the fixture's pen must advance one pixel per glyph",
+        );
+
+        let layouts: Vec<GlyphLayout> = recorded.iter().map(|g| g.layout).collect();
+        assert_eq!(
+            layouts,
+            vec![
+                GlyphLayout::A8,
+                GlyphLayout::A8,
+                GlyphLayout::ComponentAlpha,
+                GlyphLayout::A8,
+                GlyphLayout::ComponentAlpha,
+                GlyphLayout::ComponentAlpha,
+            ],
+            "on a dualSrcBlend device ARGB32 interns as four packed planes",
+        );
+        let runs = RenderEngine::split_glyph_runs(&recorded);
+
+        // (a) Contiguous and maximal: 2 + 1 + 1 + 2. One run per
+        //     glyph would also be homogeneous and ordered; these
+        //     lengths reject it, and they prove a run spans an
+        //     element boundary (glyphs 0-1) while two same-format
+        //     glyphs in one element stay together (glyphs 4-5).
+        assert_eq!(
+            runs.iter().map(|r| r.len()).collect::<Vec<_>>(),
+            vec![2, 1, 1, 2],
+            "runs must be maximal contiguous stretches of one layout",
+        );
+
+        // (b) ORDER, and nothing lost or duplicated: the runs
+        //     concatenated ARE the input sequence.
+        let flattened: Vec<super::super::frame_builder::RecordedTextGlyph> =
+            runs.iter().flat_map(|r| r.iter().copied()).collect();
+        assert_eq!(
+            flattened, recorded,
+            "concatenating the runs must reproduce the glyphs in request order",
+        );
+
+        // (c) Homogeneous, and adjacent runs differ — so the cut is
+        //     exactly where the layout changes.
+        let mut at = 0usize;
+        let mut run_layouts = Vec::new();
+        for run in &runs {
+            let slice = &layouts[at..at + run.len()];
+            assert!(
+                slice.iter().all(|l| *l == slice[0]),
+                "run at {at} mixes layouts: {slice:?}",
+            );
+            run_layouts.push(slice[0]);
+            at += run.len();
+        }
+        assert_eq!(at, layouts.len(), "the runs must cover every glyph");
+        assert_eq!(
+            run_layouts,
+            vec![
+                GlyphLayout::A8,
+                GlyphLayout::ComponentAlpha,
+                GlyphLayout::A8,
+                GlyphLayout::ComponentAlpha,
+            ],
+            "adjacent runs must differ in layout, in request order",
+        );
+    }
+
+    /// The splitter is inert **exactly where `dualSrcBlend` is
+    /// absent**, and only there.
+    ///
+    /// This test used to assert inertness unconditionally, because
+    /// step 3's upload reduction applied on every device: an ARGB32
+    /// glyph WAS an A8 glyph in the atlas, so a mixed request could
+    /// only ever form one run. Step 5 narrowed that reduction to
+    /// `!component_alpha_supported`, and lavapipe and RADV both
+    /// report `dualSrcBlend`, so the unconditional claim is now
+    /// false on every device CI and the desktop actually run on.
+    ///
+    /// What survives is the conditional half, which is worth more:
+    /// with the reduction in force every glyph of a mixed stream has
+    /// the SAME effective layout, so the split really is inert there,
+    /// and a device that cannot blend four planes never records an op
+    /// asking it to. The `true` case — several runs from the same
+    /// stream — is the sibling test above.
+    #[test]
+    fn the_run_split_is_inert_only_where_component_alpha_is_unsupported() {
+        let (glyphsets, initial_gs, items) = mixed_format_items_fixture();
+        let parsed = super::super::backend::parse_composite_glyph_items(
+            &glyphsets, 23, initial_gs, 0, 0, &items,
+        );
+        assert_eq!(parsed.glyphs.len(), 6, "fixture must parse six glyphs");
+        assert!(
+            parsed
+                .glyphs
+                .iter()
+                .any(|p| p.source_format == GlyphSourceFormat::Argb32),
+            "fixture must actually mix formats, or inertness is vacuous",
+        );
+
+        // No `dualSrcBlend`: the upload reduces ARGB32 to one
+        // grayscale coverage plane, so every glyph is an A8 entry.
+        let recorded = recorded_from_parsed(&parsed.glyphs, false);
+        let layouts: Vec<GlyphLayout> = recorded.iter().map(|g| g.layout).collect();
+        assert!(
+            layouts.iter().all(|l| *l == GlyphLayout::A8),
+            "without dualSrcBlend the upload reduces every source format to one \
+             A8 plane: {layouts:?}",
+        );
+
+        let runs = RenderEngine::split_glyph_runs(&recorded);
+        assert_eq!(runs.len(), 1, "a reduced request must record as ONE run");
+        assert_eq!(
+            runs[0],
+            &recorded[..],
+            "the single run must carry every glyph, in request order",
+        );
+
+        // And the same stream on a device that CAN blend four planes
+        // does not collapse — so the assertion above is a statement
+        // about the device, not a tautology about the fixture.
+        let with_ca = recorded_from_parsed(&parsed.glyphs, true);
+        assert_eq!(
+            RenderEngine::split_glyph_runs(&with_ca).len(),
+            4,
+            "with dualSrcBlend the same mixed stream must record as four runs",
+        );
+    }
+
+    /// The layout derivation itself, as a table — the one place
+    /// `component_alpha_supported` is consulted for glyphs, and the
+    /// pure test of the `dualSrcBlend`-less fallback's SELECTION
+    /// (`glyph_pixels` tests pin the reduction's arithmetic).
+    ///
+    /// No runtime switch is needed to reach either column: the
+    /// function takes the capability as an argument
+    /// (`feedback_no_feature_kill_switches`).
+    #[test]
+    fn the_effective_layout_answers_component_alpha_only_for_argb32_on_a_capable_device() {
+        for supported in [false, true] {
+            for source in [GlyphSourceFormat::A8, GlyphSourceFormat::A1] {
+                assert_eq!(
+                    RenderEngine::effective_glyph_layout(source, supported),
+                    GlyphLayout::A8,
+                    "{source:?} is a single coverage plane whatever the device does",
+                );
+            }
+        }
+        assert_eq!(
+            RenderEngine::effective_glyph_layout(GlyphSourceFormat::Argb32, true),
+            GlyphLayout::ComponentAlpha,
+            "ARGB32 on a dualSrcBlend device packs four planes",
+        );
+        assert_eq!(
+            RenderEngine::effective_glyph_layout(GlyphSourceFormat::Argb32, false),
+            GlyphLayout::A8,
+            "ARGB32 without dualSrcBlend reduces to one grayscale plane — the \
+             fallback vk/device.rs already promises",
+        );
+    }
+
+    // ── #137 step 5: the packed footprint reaches the UPLOAD ─────
+    //
+    // `AtlasEntry` carries `packed_w` (what the packer reserved and
+    // what the copy region covers) and `logical_w` (the glyph's own
+    // size). Step 2 split them but could not assert which one the
+    // recorded upload gets, because production built both from a
+    // single variable and no call path produced an asymmetric entry.
+    // Component alpha is the first and only path where they differ,
+    // so this is the first step where the assertion is reachable —
+    // and the failure mode is an upload copying a QUARTER of the
+    // glyph, three planes left as whatever the atlas held.
+
+    /// The recorded `GlyphUpload` for a component-alpha glyph carries
+    /// the PACKED width, and its committed entry carries both widths.
+    ///
+    /// The op is inspected on the still-open frame, before the close
+    /// that replays it — `packed_w` is exactly what
+    /// `GlyphAtlas::record_upload` passes as the copy region's
+    /// `image_extent.width`.
+    #[test]
+    #[ignore = "needs live Vulkan ICD"]
+    fn a_component_alpha_glyph_upload_records_the_packed_width() {
+        let Some(mut platform) = live_platform() else {
+            eprintln!("no Vk — skipping");
+            return;
+        };
+        let mut store = DrawableStore::new();
+        let mut engine = RenderEngine::new(&platform).expect("engine");
+        let target = alloc_drawable_3a(&platform, &mut store, 0x1, 32, 32);
+
+        // 2x2 ARGB32 wire, dense CARD32 rows: [B, G, R, A] per pixel.
+        let wire: [u8; 16] = [
+            0x10, 0x20, 0x30, 0x40, 0x11, 0x21, 0x31, 0x41, 0x12, 0x22, 0x32, 0x42, 0x13, 0x23,
+            0x33, 0x43,
+        ];
+        let glyphs = [CompositeGlyphInput {
+            gs_xid: 0x7501,
+            glyph_id: 1,
+            w: 2,
+            h: 2,
+            pixels: GlyphPixels::Argb32Wire(&wire),
+            dst_x: 1,
+            dst_y: 1,
+        }];
+        engine
+            .composite_glyphs(
+                &mut store,
+                &mut platform,
+                Dst::server_internal(target),
+                3, // Over
+                0,
+                [1.0, 1.0, 1.0, 1.0],
+                &glyphs,
+                None,
+            )
+            .expect("composite_glyphs");
+
+        let supported = engine
+            .inner
+            .as_ref()
+            .expect("inner")
+            .vk
+            .component_alpha_supported;
+        let uploads: Vec<(u32, u32, GlyphLayout, u32)> = engine
+            .inner
+            .as_ref()
+            .expect("inner")
+            .frame_builder
+            .open
+            .as_ref()
+            .expect("the call opened a frame")
+            .ops
+            .iter()
+            .filter_map(|op| match op {
+                super::super::frame_builder::RecordedOp::GlyphUpload(up) => Some((
+                    up.packed_w,
+                    up.h,
+                    up.insert_entry.layout,
+                    up.insert_entry.logical_w,
+                )),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(uploads.len(), 1, "one glyph, one recorded upload");
+        let (packed_w, h, layout, logical_w) = uploads[0];
+        assert_eq!(h, 2);
+        assert_eq!(logical_w, 2, "the entry's logical width is the glyph's own");
+
+        if supported {
+            assert_eq!(
+                layout,
+                GlyphLayout::ComponentAlpha,
+                "a dualSrcBlend device must intern ARGB32 as four planes",
+            );
+            assert_eq!(
+                packed_w, 8,
+                "the recorded upload must copy the PACKED footprint 4 * 2 = 8; \
+                 receiving the logical width instead copies a quarter of the \
+                 glyph and leaves three planes as whatever the atlas held",
+            );
+            assert_ne!(
+                packed_w, logical_w,
+                "this is the one path where the two widths differ — if they are \
+                 equal here the assertion above is vacuous",
+            );
+        } else {
+            // No dualSrcBlend: the upload reduced to one grayscale
+            // plane, so the two widths coincide and there is nothing
+            // asymmetric to catch here.
+            assert_eq!(layout, GlyphLayout::A8);
+            assert_eq!(packed_w, logical_w);
+        }
+
+        engine.drain_all(&mut platform);
+    }
+
+    /// #137 step 4b, carry-forward from 4a: the destination layout on
+    /// runs 2+.
+    ///
+    /// Run 0 finds the destination in the frame's pre-op layout;
+    /// every later run finds it as the previous run left it, and
+    /// `record_text_run_scissored` ends in `SHADER_READ_ONLY_OPTIMAL`.
+    /// Carrying the pre-op layout on run 2+ declares a wrong
+    /// `oldLayout` in its barrier — and with a pre-op `UNDEFINED`,
+    /// which is exactly what a first-touched destination has, the
+    /// driver is then licensed to DISCARD the earlier runs' pixels.
+    ///
+    /// The oracle is the RECORDED value, not pixels: an `UNDEFINED`
+    /// `oldLayout` is *permitted* to preserve contents, so a pixel
+    /// assertion on lavapipe passes whether the barrier is right or
+    /// wrong. Asserting `dst_old_layout` per run is exact and
+    /// driver-independent. The closing `get_image` then confirms the
+    /// recorded barriers actually emit and submit.
+    #[test]
+    #[ignore = "needs live Vulkan ICD"]
+    fn a_second_glyph_run_records_the_layout_the_first_run_left() {
+        let Some(mut platform) = live_platform() else {
+            eprintln!("no Vk — skipping");
+            return;
+        };
+        let mut store = DrawableStore::new();
+        let mut engine = RenderEngine::new(&platform).expect("engine");
+        let warm = alloc_drawable_3a(&platform, &mut store, 0x1, 32, 32);
+        // The split destination is never painted before the runs are
+        // recorded, so its pre-op layout is the dangerous one.
+        let split_dst = alloc_drawable_3a(&platform, &mut store, 0x2, 32, 32);
+        let full = vk::Rect2D {
+            offset: vk::Offset2D::default(),
+            extent: vk::Extent2D {
+                width: 32,
+                height: 32,
+            },
+        };
+        let white = [1.0, 1.0, 1.0, 1.0];
+
+        // Warm-up through production: interns the two fixture glyphs
+        // and builds the text pipeline emit will look up.
+        engine
+            .fill_rect(
+                &mut store,
+                &mut platform,
+                Dst::server_internal(warm),
+                full,
+                [0.0, 0.0, 0.0, 1.0],
+            )
+            .expect("fill_rect warm");
+        let pixels = [RUN_SPLIT_COVERAGE; 4];
+        let glyphs = run_split_glyph_inputs(&pixels);
+        engine
+            .composite_glyphs(
+                &mut store,
+                &mut platform,
+                Dst::server_internal(warm),
+                RUN_SPLIT_OP,
+                0,
+                white,
+                &glyphs,
+                None,
+            )
+            .expect("composite_glyphs warm");
+        // Closes the frame, which is what commits the atlas inserts.
+        engine
+            .get_image(
+                &mut store,
+                &mut platform,
+                Src::server_internal(warm),
+                full,
+                32,
+            )
+            .expect("get_image warm");
+
+        // Open a frame on the OTHER drawable, so `split_dst` is
+        // untouched when the runs are recorded.
+        engine
+            .fill_rect(
+                &mut store,
+                &mut platform,
+                Dst::server_internal(warm),
+                full,
+                [0.0, 0.0, 0.0, 1.0],
+            )
+            .expect("fill_rect reopen");
+
+        let recorded = run_split_recorded_glyphs(&engine);
+        assert_eq!(recorded.len(), 2, "both glyphs must have interned");
+        let prior_ticket = store
+            .get(split_dst)
+            .and_then(|d| d.last_render_ticket.clone());
+        let inner = engine.inner.as_mut().expect("inner");
+        let pre_op_layout = inner.current_layout_for_drawable(&store, split_dst);
+        // Teeth: if the pre-op layout already WERE
+        // SHADER_READ_ONLY_OPTIMAL, run 0 and run 1 would carry the
+        // same value and the assertions below could not tell a
+        // carried pre-op layout from the correct one. Measured
+        // `UNDEFINED` here — the case where carrying it onto run 1
+        // would license the driver to discard run 0's pixels.
+        assert_ne!(
+            pre_op_layout,
+            vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+            "the split destination's pre-op layout must differ from where a run ends",
+        );
+        // First-touch it exactly as the production path does before
+        // recording against it.
+        {
+            let open = inner.frame_builder.open.as_mut().expect("frame open");
+            open.touched.first_touch(split_dst, prior_ticket);
+            open.layouts.first_touch_drawable(split_dst, pre_op_layout);
+        }
+        let instances = RenderEngine::record_glyph_runs(
+            inner,
+            &[&recorded[..1], &recorded[1..]],
+            &GlyphRunCommon {
+                dst_id: split_dst,
+                dst_old_layout: pre_op_layout,
+                op: RUN_SPLIT_OP,
+                dst_has_alpha: dst_has_alpha_for_pict_format(vk::Format::B8G8R8A8_UNORM, 32, 0),
+                foreground_rgba: white,
+                clip_scissors: vec![full],
+            },
+        )
+        .expect("record_glyph_runs");
+        assert_eq!(instances, 2, "both glyphs must have become instances");
+        store.mark_contents_modified(split_dst);
+
+        let layouts: Vec<vk::ImageLayout> = engine
+            .inner
+            .as_ref()
+            .expect("inner")
+            .frame_builder
+            .open
+            .as_ref()
+            .expect("frame still open")
+            .ops
+            .iter()
+            .filter_map(|op| match op {
+                super::super::frame_builder::RecordedOp::CompositeGlyphs(cg)
+                    if cg.dst_id == split_dst =>
+                {
+                    Some(cg.dst_old_layout)
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            layouts,
+            vec![pre_op_layout, vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL],
+            "run 0 carries the request's pre-op layout; run 1 carries where run 0 left the image",
+        );
+
+        // The recorded barriers must also be emittable: close the
+        // frame and submit them.
+        engine
+            .get_image(
+                &mut store,
+                &mut platform,
+                Src::server_internal(split_dst),
+                full,
+                32,
+            )
+            .expect("get_image closes the two-run frame");
         engine.drain_all(&mut platform);
     }
 }

--- a/crates/yserver/src/kms/render/frame_builder.rs
+++ b/crates/yserver/src/kms/render/frame_builder.rs
@@ -438,7 +438,7 @@ use super::{
     glyph_atlas::{AtlasEntry, GlyphKey},
     store::DrawableId,
 };
-use crate::kms::cpu_types::Rectangle16;
+use crate::kms::{cpu_types::Rectangle16, vk::glyph::GlyphLayout};
 
 /// Index into `OpenFrame::pins.staging_buffers`. Saved on `RecordedOp`
 /// payloads so close-time replay can fetch the right pinned buffer.
@@ -460,6 +460,17 @@ pub(crate) struct RecordedTextGlyph {
     pub(crate) h: u32,
     pub(crate) dst_x: i32,
     pub(crate) dst_y: i32,
+    /// How this glyph's atlas entry is packed, copied off the entry.
+    /// `RenderEngine::split_glyph_runs` cuts runs where it changes,
+    /// and `record_glyph_runs` reads it for both the pipeline the run
+    /// binds and each instance's plane stride.
+    ///
+    /// On the glyph itself rather than in a parallel sequence the
+    /// caller keeps in lockstep: a second slice indexed by glyph
+    /// position is free to drift, and the drift is silent — a glyph
+    /// sampled by the wrong pipeline. `image_text` always sets `A8`
+    /// (design invariant 8).
+    pub(crate) layout: GlyphLayout,
 }
 
 #[derive(Debug)]
@@ -475,13 +486,34 @@ pub(crate) struct RecordedCompositeGlyphs {
     /// alpha (`dst_has_alpha_for_pict_format` at append time) —
     /// the third text-pipeline cache-key dimension.
     pub(crate) dst_has_alpha: bool,
+    /// Whether this run's glyphs are four-plane component-alpha
+    /// entries — the FOURTH text-pipeline cache-key dimension, the
+    /// same one `RenderPipelineCache` keys on. Selects the fragment
+    /// shader's `COMPONENT_ALPHA` specialization and the `SRC1_*`
+    /// dual-source blend factors.
+    ///
+    /// Per RUN, not per request: a request that switches glyphset
+    /// mid-stream can interleave formats, and the splitter's whole
+    /// job is to make each recorded op homogeneous in this.
+    pub(crate) component_alpha: bool,
     pub(crate) foreground_rgba: [f32; 4],
     /// Pin index of the per-glyph instance vertex buffer (built at
     /// record time, `#1` glyph batching). Emit binds
     /// `pins.staging_buffers[instance_pin.0].buffer` and issues one
     /// instanced draw per clip rect.
     pub(crate) instance_pin: PinnedStagingIdx,
-    /// Number of glyph instances in that buffer (`vkCmdDraw` instance count).
+    /// First glyph instance this run draws (`vkCmdDraw`'s
+    /// `firstInstance`). One `CompositeGlyphs` request may be recorded
+    /// as several contiguous runs — glyphs of different `GlyphLayout`s
+    /// need different pipelines and pipeline state is immutable — but
+    /// all runs of one request share ONE instance buffer, so a request
+    /// costs exactly one instance pin however many runs it splits into
+    /// (the frame-pin ceiling reserves exactly one). Each run therefore
+    /// carries its own `(first_instance, instance_count)` range into
+    /// that shared buffer.
+    pub(crate) first_instance: u32,
+    /// Number of glyph instances this run draws, starting at
+    /// `first_instance` (`vkCmdDraw` instance count).
     pub(crate) instance_count: u32,
     pub(crate) clip_scissors: Vec<vk::Rect2D>,
     /// Damage rect to commit on close-success. Pre-computed at append
@@ -1182,8 +1214,10 @@ mod op_tests {
             dst_old_layout: vk::ImageLayout::UNDEFINED,
             op: 3, // Over
             dst_has_alpha: true,
+            component_alpha: false,
             foreground_rgba: [1.0, 0.0, 0.0, 1.0],
             instance_pin: PinnedStagingIdx(7),
+            first_instance: 0,
             instance_count: 3,
             clip_scissors: vec![scissor],
             damage_rect: Some(vk::Rect2D {
@@ -1298,8 +1332,10 @@ mod op_tests {
             dst_old_layout: vk::ImageLayout::UNDEFINED,
             op: 3, // Over
             dst_has_alpha: true,
+            component_alpha: false,
             foreground_rgba: [0.0; 4],
             instance_pin: PinnedStagingIdx(0),
+            first_instance: 0,
             instance_count: 0,
             clip_scissors: Vec::new(),
             damage_rect: None,

--- a/crates/yserver/src/kms/render/frame_builder.rs
+++ b/crates/yserver/src/kms/render/frame_builder.rs
@@ -453,7 +453,10 @@ pub(crate) struct PinnedStagingIdx(pub(crate) u32);
 pub(crate) struct RecordedTextGlyph {
     pub(crate) atlas_x: u32,
     pub(crate) atlas_y: u32,
-    pub(crate) w: u32,
+    /// The glyph's own (logical) width — feeds the dst quad size and
+    /// the instance geometry. Never the atlas footprint; see
+    /// `AtlasEntry::logical_w`.
+    pub(crate) logical_w: u32,
     pub(crate) h: u32,
     pub(crate) dst_x: i32,
     pub(crate) dst_y: i32,
@@ -500,7 +503,9 @@ pub(crate) struct RecordedGlyphUpload {
     pub(crate) staging_pin_idx: PinnedStagingIdx,
     pub(crate) atlas_x: u32,
     pub(crate) atlas_y: u32,
-    pub(crate) w: u32,
+    /// The atlas footprint width — what the copy region covers.
+    /// Never the glyph's logical size; see `AtlasEntry::packed_w`.
+    pub(crate) packed_w: u32,
     pub(crate) h: u32,
     /// Cache-insert pair to commit on close-success (atlas's lookup
     /// becomes hit-able by this key after the frame ticket signals,
@@ -1207,16 +1212,18 @@ mod op_tests {
         let entry = AtlasEntry {
             atlas_x: 0,
             atlas_y: 32,
-            w: 8,
+            packed_w: 8,
+            logical_w: 8,
             h: 16,
             pen_left: 0,
             pen_top: 14,
+            layout: crate::kms::vk::glyph::GlyphLayout::A8,
         };
         let op = RecordedGlyphUpload {
             staging_pin_idx: PinnedStagingIdx(3),
             atlas_x: 0,
             atlas_y: 32,
-            w: 8,
+            packed_w: 8,
             h: 16,
             insert_key: key,
             insert_entry: entry,
@@ -1225,7 +1232,7 @@ mod op_tests {
         assert_eq!(op.staging_pin_idx, PinnedStagingIdx(3));
         assert_eq!(op.atlas_x, 0);
         assert_eq!(op.atlas_y, 32);
-        assert_eq!(op.w, 8);
+        assert_eq!(op.packed_w, 8);
         assert_eq!(op.h, 16);
         assert_eq!(op.insert_key.font_xid, 1234);
         assert_eq!(op.insert_key.codepoint, 65);
@@ -1304,7 +1311,7 @@ mod op_tests {
             staging_pin_idx: PinnedStagingIdx(0),
             atlas_x: 0,
             atlas_y: 0,
-            w: 0,
+            packed_w: 0,
             h: 0,
             insert_key: GlyphKey {
                 font_xid: 0,
@@ -1313,10 +1320,12 @@ mod op_tests {
             insert_entry: AtlasEntry {
                 atlas_x: 0,
                 atlas_y: 0,
-                w: 0,
+                packed_w: 0,
+                logical_w: 0,
                 h: 0,
                 pen_left: 0,
                 pen_top: 0,
+                layout: crate::kms::vk::glyph::GlyphLayout::A8,
             },
         });
         assert_eq!(glyph_upload.dst_id(), None);
@@ -1765,10 +1774,12 @@ mod glyph_insert_tests {
             AtlasEntry {
                 atlas_x: 0,
                 atlas_y: 0,
-                w: 8,
+                packed_w: 8,
+                logical_w: 8,
                 h: 12,
                 pen_left: 0,
                 pen_top: 0,
+                layout: crate::kms::vk::glyph::GlyphLayout::A8,
             },
         );
         p.push(
@@ -1779,10 +1790,12 @@ mod glyph_insert_tests {
             AtlasEntry {
                 atlas_x: 8,
                 atlas_y: 0,
-                w: 8,
+                packed_w: 8,
+                logical_w: 8,
                 h: 12,
                 pen_left: 0,
                 pen_top: 0,
+                layout: crate::kms::vk::glyph::GlyphLayout::A8,
             },
         );
         assert_eq!(p.len(), 2);

--- a/crates/yserver/src/kms/render/glyph_atlas.rs
+++ b/crates/yserver/src/kms/render/glyph_atlas.rs
@@ -503,16 +503,19 @@ mod tests {
             AtlasEntry {
                 atlas_x: ax,
                 atlas_y: ay,
-                w: 8,
+                packed_w: 8,
+                logical_w: 8,
                 h: 16,
                 pen_left: 0,
                 pen_top: 12,
+                layout: crate::kms::vk::glyph::GlyphLayout::A8,
             },
         );
         let got = packer.lookup(key).expect("cache hit");
         assert_eq!(got.atlas_x, ax);
         assert_eq!(got.atlas_y, ay);
-        assert_eq!(got.w, 8);
+        assert_eq!(got.packed_w, 8);
+        assert_eq!(got.logical_w, 8);
         assert_eq!(got.h, 16);
     }
 }

--- a/crates/yserver/src/kms/render/glyph_pixels.rs
+++ b/crates/yserver/src/kms/render/glyph_pixels.rs
@@ -2,12 +2,12 @@
 //! conversion to the dense A8 bitmap the atlas uploader consumes.
 //!
 //! The backend's wire parse forwards a glyph's pixels *as stored in
-//! the glyphset* — dense A8 for `PICT_a8` / ARGB32-preconverted
-//! glyphs, or the raw A1 wire bitmap for `PICT_a1`. Expansion of A1
-//! to A8 is **deferred to the engine's atlas-miss branch** via
-//! [`GlyphPixels::to_a8`]: a glyph already resident in the GPU atlas
-//! is never expanded again, mirroring Xorg/EXA's convert-on-upload
-//! (`exa/exa_glyphs.c`). See
+//! the glyphset* — dense A8 for `PICT_a8`, the raw A1 wire bitmap
+//! for `PICT_a1`, the raw ARGB32 wire bytes for `PICT_a8r8g8b8`.
+//! Conversion to A8 is **deferred to the engine's atlas-miss
+//! branch** via [`GlyphPixels::to_a8`]: a glyph already resident in
+//! the GPU atlas is never converted again, mirroring Xorg/EXA's
+//! convert-on-upload (`exa/exa_glyphs.c`). See
 //! `docs/superpowers/findings/2026-07-08-xorg-render-optimization-gaps.md` #2.
 
 use std::borrow::Cow;
@@ -17,23 +17,33 @@ use std::borrow::Cow;
 /// happens on an atlas miss.
 #[derive(Copy, Clone, Debug)]
 pub(crate) enum GlyphPixels<'a> {
-    /// Dense A8 coverage bitmap, row-major `w × h`. Covers native
-    /// `PICT_a8` glyphs and ARGB32 glyphs already alpha-extracted to
-    /// A8 at ingest (`parse_add_glyphs`).
+    /// Dense A8 coverage bitmap, row-major `w × h`. Native
+    /// `PICT_a8` glyphs.
     A8(&'a [u8]),
     /// Raw A1 wire bitmap: rows padded to a 32-bit scanline unit,
     /// bit order = advertised `bitmap-bit-order` (LSBFirst on the
     /// common little-endian client). Expanded lazily by [`Self::to_a8`].
     A1Wire(&'a [u8]),
+    /// Raw ARGB32 wire bytes, row-major `w × h` CARD32 pixels with
+    /// no per-row padding (stride `4 * w`). **Memory order per pixel
+    /// is `[B, G, R, A]`** — little-endian CARD32 with alpha at bits
+    /// 24-31, so blue is the LOW byte. Reduced to a single A8
+    /// coverage plane by [`Self::to_a8`] via
+    /// [`reduce_argb32_glyph_to_a8_coverage`]; the four channels are
+    /// kept intact this far so the component-alpha path can pack all
+    /// of them (design
+    /// `2026-09-10-component-alpha-glyphs-design.md`, stage 0).
+    Argb32Wire(&'a [u8]),
 }
 
 impl<'a> GlyphPixels<'a> {
     /// Produce the dense `w × h` A8 bitmap the atlas uploader copies
     /// into its staging buffer. `A8` borrows in place (truncated to
-    /// `w × h`); `A1Wire` expands into an owned buffer. Returns
-    /// `None` if the source is too short for the declared dimensions
-    /// (caller drops the glyph), so a malformed request can never
-    /// index out of bounds during upload.
+    /// `w × h`); `A1Wire` expands and `Argb32Wire` reduces into an
+    /// owned buffer. Returns `None` if the source is too short for
+    /// the declared dimensions (caller drops the glyph), so a
+    /// malformed request can never index out of bounds during
+    /// upload.
     pub(crate) fn to_a8(self, w: u32, h: u32) -> Option<Cow<'a, [u8]>> {
         let cells = (w as usize).checked_mul(h as usize)?;
         match self {
@@ -51,8 +61,73 @@ impl<'a> GlyphPixels<'a> {
                 }
                 Some(Cow::Owned(expand_a1_glyph_to_a8(src, w, h)))
             }
+            GlyphPixels::Argb32Wire(src) => {
+                let need = cells.checked_mul(4)?;
+                if src.len() < need {
+                    return None;
+                }
+                Some(Cow::Owned(reduce_argb32_glyph_to_a8_coverage(src, w, h)))
+            }
         }
     }
+}
+
+/// Reduce an ARGB32 glyph's wire bytes to a single A8 coverage
+/// plane, row-major `w × h` at **logical width `w`** — the mean of
+/// logical R, G and B.
+///
+/// **Wire byte order is `[B, G, R, A]`** per pixel: X RENDER
+/// `PICT_a8r8g8b8` is a little-endian CARD32 with alpha-shift 24, so
+/// blue is the LOW byte of the four and alpha the HIGH one. Reading
+/// bytes 1..=3 (i.e. `[G, R, A]`) instead of 0..=2 is the trap here:
+/// it errors nothing and paints plausible-looking text off by a
+/// channel.
+///
+/// **Coverage comes from R, G and B, never from the alpha byte.** A
+/// subpixel-AA client puts one coverage value per LCD subpixel in R,
+/// G and B and leaves alpha at 255 across the whole glyph box —
+/// measured on OpenJDK 25, where a 9×9 glyph had exactly one
+/// distinct alpha value (255, all 81 pixels) against 28 distinct
+/// `max(rgb)` values. Taking the alpha byte therefore yields a solid
+/// `0xFF` rectangle, which is precisely the "text renders as blocks"
+/// defect this reduction fixes.
+///
+/// Pure function of the wire bytes, so it is testable without a GPU
+/// and needs no runtime switch to reach
+/// (`feedback_no_feature_kill_switches`). Today it is the universal
+/// treatment of an ARGB32 glyphset; a later step narrows its
+/// condition to devices lacking `dualSrcBlend`, where the design
+/// already promises grayscale AA (`vk/device.rs`), and packs all four
+/// channels otherwise.
+///
+/// Rows short of `4 * w * h` bytes are left zero rather than
+/// panicking; the caller length-checks first, so this is belt and
+/// braces.
+pub(crate) fn reduce_argb32_glyph_to_a8_coverage(wire: &[u8], w: u32, h: u32) -> Vec<u8> {
+    let w = w as usize;
+    let h = h as usize;
+    // Dense CARD32 rows: X RENDER AddGlyphs pads a glyph row to a
+    // 4-byte boundary, which 4 bytes per pixel already satisfies.
+    let stride = w * 4;
+    let mut a8 = vec![0u8; w * h];
+    for row in 0..h {
+        let row_off = row * stride;
+        if row_off + stride > wire.len() {
+            break;
+        }
+        for col in 0..w {
+            let px = row_off + col * 4;
+            // [B, G, R, A] — blue is the low byte. See above.
+            let b = u32::from(wire[px]);
+            let g = u32::from(wire[px + 1]);
+            let r = u32::from(wire[px + 2]);
+            // Mean of the three logical colour channels, rounded to
+            // nearest. The alpha byte at `px + 3` is deliberately
+            // NOT read: it is 255 everywhere on a subpixel-AA glyph.
+            a8[row * w + col] = u8::try_from((r + g + b + 1) / 3).unwrap_or(u8::MAX);
+        }
+    }
+    a8
 }
 
 /// Expand a wire A1 glyph bitmap to dense A8 (`0x00` / `0xFF` per
@@ -82,7 +157,7 @@ pub(crate) fn expand_a1_glyph_to_a8(pixels: &[u8], gw: u32, gh: u32) -> Vec<u8> 
 
 #[cfg(test)]
 mod tests {
-    use super::{GlyphPixels, expand_a1_glyph_to_a8};
+    use super::{GlyphPixels, expand_a1_glyph_to_a8, reduce_argb32_glyph_to_a8_coverage};
     use std::borrow::Cow;
 
     #[test]
@@ -115,6 +190,144 @@ mod tests {
         // 8x2 needs two 4-byte scanline units; give only one.
         let wire = [0xFFu8, 0, 0, 0];
         assert!(GlyphPixels::A1Wire(&wire).to_a8(8, 2).is_none());
+    }
+
+    #[test]
+    fn to_a8_none_when_argb32_wire_too_short() {
+        // 2x2 needs 4 pixels × 4 bytes = 16; give 15.
+        let wire = [0u8; 15];
+        assert!(GlyphPixels::Argb32Wire(&wire).to_a8(2, 2).is_none());
+    }
+
+    // ── the ARGB32 → A8 coverage reduction ──
+    // Subpixel/LCD-antialiased text used to render as one solid block
+    // per glyph because ingest kept the ARGB32 **alpha** byte as the
+    // coverage plane, and a subpixel-AA client leaves alpha at 255
+    // across the whole glyph box.
+
+    #[test]
+    fn argb32_reduction_is_the_mean_of_logical_rgb_at_exact_values() {
+        // Wire memory order is [B, G, R, A]: blue LOW, alpha HIGH.
+        //
+        // px0: B=0x20 G=0x60 R=0xA0 A=0xE0 → (0xA0+0x60+0x20)/3 = 96.
+        // px1: B=0x10 G=0x40 R=0x50 A=0xFF → (0x50+0x40+0x10+1)/3 = 53.
+        //
+        // Exact values, not a "the channels differ" check: that would
+        // pass with red and blue reversed. The two pixels together
+        // also pin the reduction against the near misses —
+        //   * reading bytes 1..=3 as if they were R,G,B (i.e. [G,R,A])
+        //     gives 160 and 133, not 96 and 53;
+        //   * taking the alpha byte gives 0xE0 and 0xFF;
+        //   * taking any single colour channel gives one of the
+        //     inputs — px1's mean 53 is not 0x10, 0x40 or 0x50, and
+        //     px0's 96 rules out R and B.
+        let wire = [0x20u8, 0x60, 0xA0, 0xE0, 0x10, 0x40, 0x50, 0xFF];
+        let a8 = reduce_argb32_glyph_to_a8_coverage(&wire, 2, 1);
+        assert_eq!(
+            a8,
+            vec![96u8, 53u8],
+            "coverage must be the mean of logical R, G and B read from \
+             wire bytes [B, G, R, A]"
+        );
+
+        // Same answer through the uploader's entry point, so the
+        // engine's atlas-miss branch cannot be wired to a different
+        // reduction than the one tested here.
+        let via_to_a8 = GlyphPixels::Argb32Wire(&wire).to_a8(2, 1).expect("fits");
+        assert!(
+            matches!(via_to_a8, Cow::Owned(_)),
+            "ARGB32 must reduce into an owned buffer"
+        );
+        assert_eq!(&*via_to_a8, &[96u8, 53u8]);
+    }
+
+    #[test]
+    fn argb32_reduction_of_a_subpixel_aa_glyph_is_not_a_solid_block() {
+        // Synthetic 9×9 glyph reproducing the *measured* signature of
+        // OpenJDK 25's LCD glyphs (one vng run, temporary
+        // instrumentation): alpha has exactly ONE distinct value, 255
+        // over all 81 pixels, while max(R,G,B) spans dozens. These
+        // are not the literal Java bytes — the instrumentation
+        // recorded histograms, not the glyph — but the property that
+        // makes the old code fail is the whole fixture.
+        const W: usize = 9;
+        const H: usize = 9;
+        let mut wire = vec![0u8; W * H * 4];
+        for row in 0..H {
+            for col in 0..W {
+                let px = (row * W + col) * 4;
+                wire[px] = u8::try_from((row * 29 + col * 7) % 256).expect("masked");
+                wire[px + 1] = u8::try_from((row * 13 + col * 23 + 5) % 256).expect("masked");
+                wire[px + 2] = u8::try_from((row * 41 + col * 3 + 11) % 256).expect("masked");
+                wire[px + 3] = 0xFF;
+            }
+        }
+
+        // The fixture really does have the measured shape.
+        let mut alphas: Vec<u8> = wire.iter().skip(3).step_by(4).copied().collect();
+        alphas.dedup();
+        assert_eq!(alphas, vec![0xFFu8], "fixture: alpha constant 255");
+        let mut maxima: Vec<u8> = (0..W * H)
+            .map(|i| wire[i * 4].max(wire[i * 4 + 1]).max(wire[i * 4 + 2]))
+            .collect();
+        maxima.sort_unstable();
+        maxima.dedup();
+        assert!(
+            maxima.len() >= 28,
+            "fixture: max(rgb) must span the measured spread; got {}",
+            maxima.len()
+        );
+
+        let a8 = reduce_argb32_glyph_to_a8_coverage(&wire, 9, 9);
+        assert_eq!(a8.len(), W * H);
+
+        // The regression guard. Reading the alpha byte for coverage
+        // yields 0xFF everywhere, i.e. a solid block — exactly the
+        // reported defect, and invisible to any assertion weaker than
+        // this one.
+        assert!(
+            a8.iter().any(|&v| v != a8[0]),
+            "reduced coverage must vary across the glyph; a constant \
+             plane means the alpha byte was read instead of R, G, B"
+        );
+        assert!(
+            a8.iter().any(|&v| v != 0xFF),
+            "reduced coverage must not be a solid 0xFF block"
+        );
+
+        // Exact spot checks, so the mapping is pinned and not merely
+        // shown to be non-constant.
+        assert_eq!(a8[0], 5, "(0,0): B=0x00 G=0x05 R=0x0B → 5");
+        assert_eq!(a8[4 * W + 4], 160, "(4,4): B=0x90 G=0xA1 R=0xAF → 160");
+        assert_eq!(a8[8 * W + 8], 59, "(8,8)");
+    }
+
+    #[test]
+    fn a8_and_a1_glyphs_are_untouched_by_the_argb32_reduction() {
+        // Invariant 1 of the design: an A8 or A1 glyphset must be
+        // byte-identical before and after. That is the overwhelmingly
+        // common path. Asserted here at the dispatch that gained the
+        // new variant.
+        let a8_src = [0x00u8, 0x7F, 0xFF, 0x40, 0xEE, 0xEE];
+        let out = GlyphPixels::A8(&a8_src).to_a8(2, 2).expect("fits");
+        assert!(
+            matches!(out, Cow::Borrowed(_)),
+            "A8 must still borrow in place — no reduction, no copy"
+        );
+        assert_eq!(
+            &*out,
+            &a8_src[..4],
+            "A8 coverage bytes must pass through unchanged"
+        );
+
+        let a1_wire = [0b0101_0011u8, 0, 0, 0];
+        let out = GlyphPixels::A1Wire(&a1_wire).to_a8(8, 1).expect("fits");
+        assert_eq!(
+            &*out,
+            &expand_a1_glyph_to_a8(&a1_wire, 8, 1)[..],
+            "A1 must still take the LSBFirst expansion, unchanged"
+        );
+        assert_eq!(&*out, &[0xFF, 0xFF, 0, 0, 0xFF, 0, 0xFF, 0]);
     }
 
     // ── issue #77: bitmap fonts (terminus) rendered backwards ──

--- a/crates/yserver/src/kms/render/glyph_pixels.rs
+++ b/crates/yserver/src/kms/render/glyph_pixels.rs
@@ -12,6 +12,8 @@
 
 use std::borrow::Cow;
 
+use crate::kms::vk::glyph::GlyphLayout;
+
 /// Pixel source for one glyph, as stored in its glyphset. Cheap to
 /// carry (two `&[u8]` variants); the actual A1→A8 expansion only
 /// happens on an atlas miss.
@@ -36,7 +38,99 @@ pub(crate) enum GlyphPixels<'a> {
     Argb32Wire(&'a [u8]),
 }
 
+/// The glyphset picture format a glyph is **stored** in — the
+/// protocol fact, tagged onto every `CompositeGlyphInput` by the
+/// backend's items parse.
+///
+/// Deliberately NOT a rendering decision. Which pipeline a glyph
+/// ends up on is its effective [`GlyphLayout`]
+/// (`crate::kms::vk::glyph::GlyphLayout`), derived in the engine by
+/// `RenderEngine::effective_glyph_layout`: that mapping depends on
+/// device state (`component_alpha_supported`) and on what the atlas
+/// upload stores, neither of which the protocol layer should be
+/// consulting. The parse answers "what did the client give us"; the
+/// engine answers "what can this device do with it".
+///
+/// One variant per [`GlyphPixels`] variant, and the parse derives
+/// both from the same `GlyphSetFormat` match, so the byte encoding
+/// and the format tag cannot disagree.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub(crate) enum GlyphSourceFormat {
+    /// `PICT_a8` — one coverage byte per pixel.
+    A8,
+    /// `PICT_a1` — one coverage BIT per pixel, 32-bit padded rows.
+    A1,
+    /// `PICT_a8r8g8b8` — per-channel coverage (subpixel/LCD AA) or
+    /// colour (emoji).
+    Argb32,
+}
+
 impl<'a> GlyphPixels<'a> {
+    /// The glyphset picture format these bytes came in.
+    ///
+    /// The mapping between the two enums is total and 1:1, so the
+    /// pair of them on one glyph would be two encodings of one fact,
+    /// free to disagree. This accessor is the single encoding:
+    /// `CompositeGlyphInput` no longer carries a separate
+    /// `source_format` field.
+    pub(crate) fn source_format(self) -> GlyphSourceFormat {
+        match self {
+            GlyphPixels::A8(_) => GlyphSourceFormat::A8,
+            GlyphPixels::A1Wire(_) => GlyphSourceFormat::A1,
+            GlyphPixels::Argb32Wire(_) => GlyphSourceFormat::Argb32,
+        }
+    }
+
+    /// Produce the exact bytes the atlas uploader stages for an entry
+    /// of `layout`, at that layout's packed width:
+    ///
+    /// * [`GlyphLayout::A8`] — one dense `w × h` coverage plane, via
+    ///   [`Self::to_a8`]. An `ARGB32` source is REDUCED to the mean of
+    ///   its logical R, G, B here; that is the `dualSrcBlend`-less
+    ///   fallback the device layer promises, and the only path an
+    ///   ARGB32 glyph takes on such a device.
+    /// * [`GlyphLayout::ComponentAlpha`] — FOUR horizontally adjacent
+    ///   coverage planes (logical R, G, B, A) at packed width
+    ///   `4 * w`, via
+    ///   [`pack_argb32_glyph_to_component_alpha_planes`].
+    ///
+    /// Returns `None` if the source is too short for the declared
+    /// dimensions, or if `ComponentAlpha` is asked of a source that
+    /// is not `ARGB32` — the caller derives the layout from this
+    /// glyph's own source format
+    /// (`RenderEngine::effective_glyph_layout`), so that combination
+    /// is a logic error, not client input, and staging a single-plane
+    /// A8 glyph under a four-plane layout would sample three
+    /// neighbours as its G, B and A coverage.
+    pub(crate) fn to_atlas_bytes(
+        self,
+        w: u32,
+        h: u32,
+        layout: GlyphLayout,
+    ) -> Option<Cow<'a, [u8]>> {
+        match layout {
+            GlyphLayout::A8 => self.to_a8(w, h),
+            GlyphLayout::ComponentAlpha => {
+                let GlyphPixels::Argb32Wire(src) = self else {
+                    log::error!(
+                        "glyph upload: component-alpha layout asked of a {:?} source; \
+                         only ARGB32 carries four channels",
+                        self.source_format(),
+                    );
+                    return None;
+                };
+                let cells = (w as usize).checked_mul(h as usize)?;
+                let need = cells.checked_mul(4)?;
+                if src.len() < need {
+                    return None;
+                }
+                Some(Cow::Owned(pack_argb32_glyph_to_component_alpha_planes(
+                    src, w, h,
+                )))
+            }
+        }
+    }
+
     /// Produce the dense `w × h` A8 bitmap the atlas uploader copies
     /// into its staging buffer. `A8` borrows in place (truncated to
     /// `w × h`); `A1Wire` expands and `Argb32Wire` reduces into an
@@ -94,11 +188,22 @@ impl<'a> GlyphPixels<'a> {
 ///
 /// Pure function of the wire bytes, so it is testable without a GPU
 /// and needs no runtime switch to reach
-/// (`feedback_no_feature_kill_switches`). Today it is the universal
-/// treatment of an ARGB32 glyphset; a later step narrows its
-/// condition to devices lacking `dualSrcBlend`, where the design
-/// already promises grayscale AA (`vk/device.rs`), and packs all four
-/// channels otherwise.
+/// (`feedback_no_feature_kill_switches`).
+///
+/// **Narrowed, not replaced.** This is now the treatment of an ARGB32
+/// glyphset on a device WITHOUT `dualSrcBlend` only, where
+/// `vk/device.rs` already promises grayscale AA — `component_alpha`
+/// is then unavailable, `RenderEngine::effective_glyph_layout` answers
+/// `A8` for every source format, and this reduction is what makes the
+/// letterforms legible instead of solid blocks. With `dualSrcBlend`
+/// present the glyph is packed as four planes by
+/// [`pack_argb32_glyph_to_component_alpha_planes`] instead and this
+/// function is not called.
+///
+/// The mean is **symmetric in its arguments**, so no test of this
+/// reduction can detect an R↔B transposition; only the packed path's
+/// exact-texel assertions can. The mistake this one guards against is
+/// reading bytes `1..=3` (including alpha, dropping blue).
 ///
 /// Rows short of `4 * w * h` bytes are left zero rather than
 /// panicking; the caller length-checks first, so this is belt and
@@ -130,6 +235,86 @@ pub(crate) fn reduce_argb32_glyph_to_a8_coverage(wire: &[u8], w: u32, h: u32) ->
     a8
 }
 
+/// Pack an `ARGB32` glyph's wire bytes into **four horizontally
+/// adjacent coverage planes** — logical R, G, B, A in that order,
+/// each `w` texels wide — row-major at packed width `4 * w` and
+/// height `h`.
+///
+/// This is the real component-alpha path: X RENDER gives a glyph
+/// carrying both alpha and RGB per-channel coverage semantics
+/// (Xorg's `NeedsComponent`), a subpixel-AA client puts one coverage
+/// value per LCD subpixel in R, G and B, and the fragment shader
+/// applies each as that channel's own coverage.
+///
+/// **Wire byte order is `[B, G, R, A]`** per pixel: `PICT_a8r8g8b8`
+/// is a little-endian CARD32 with alpha-shift 24, so blue is the LOW
+/// byte and alpha the HIGH one. **Packed texel order is logical R, G,
+/// B, A** — i.e. plane 0 holds wire byte 2, plane 1 wire byte 1,
+/// plane 2 wire byte 0, plane 3 wire byte 3. Both ends of that
+/// mapping are stated deliberately: a channel swap here paints
+/// plausible-looking text in the wrong colour and errors nothing
+/// (design invariant 4), and unlike the grayscale reduction — whose
+/// mean is symmetric and therefore blind to it — this is where an
+/// R↔B transposition is detectable at all.
+///
+/// **Four planes, not three.** Java's alpha byte is 255 across the
+/// whole glyph box, but the shader needs the glyph's own alpha for
+/// the ALPHA channel's blend factor, and Xorg applies component-alpha
+/// to every `ARGB32` glyphset rather than only to the ones whose
+/// alpha happens to be constant. Dropping it would work for this JVM
+/// and break on the next client (design invariant 3). A
+/// component-alpha glyph therefore costs 4× its area in the atlas.
+///
+/// Layout, for `w = 3`:
+///
+/// ```text
+///  row 0: R R R | G G G | B B B | A A A
+///  row 1: R R R | G G G | B B B | A A A
+/// ```
+///
+/// The four planes are distinct images that merely happen to be
+/// adjacent, which is why the shader reaches them by `texelFetch` at
+/// an explicit plane stride and never by interpolating a UV across
+/// the packed run.
+///
+/// Rows short of `4 * w * h` bytes are left zero rather than
+/// panicking; the caller length-checks first, so this is belt and
+/// braces.
+pub(crate) fn pack_argb32_glyph_to_component_alpha_planes(wire: &[u8], w: u32, h: u32) -> Vec<u8> {
+    let w = w as usize;
+    let h = h as usize;
+    // Dense CARD32 rows: X RENDER AddGlyphs pads a glyph row to a
+    // 4-byte boundary, which 4 bytes per pixel already satisfies.
+    let src_stride = w * 4;
+    let packed_w = w * PLANES as usize;
+    let mut out = vec![0u8; packed_w * h];
+    for row in 0..h {
+        let row_off = row * src_stride;
+        if row_off + src_stride > wire.len() {
+            break;
+        }
+        let out_row = row * packed_w;
+        for col in 0..w {
+            let px = row_off + col * 4;
+            // Wire [B, G, R, A] → packed planes [R, G, B, A].
+            let b = wire[px];
+            let g = wire[px + 1];
+            let r = wire[px + 2];
+            let a = wire[px + 3];
+            out[out_row + col] = r;
+            out[out_row + w + col] = g;
+            out[out_row + 2 * w + col] = b;
+            out[out_row + 3 * w + col] = a;
+        }
+    }
+    out
+}
+
+/// Coverage planes a `ComponentAlpha` atlas entry occupies: logical
+/// R, G, B, A. The atlas footprint of such a glyph is
+/// `PLANES * logical_w` texels wide.
+pub(crate) const PLANES: u32 = 4;
+
 /// Expand a wire A1 glyph bitmap to dense A8 (`0x00` / `0xFF` per
 /// pixel), row-major `w × h`.
 ///
@@ -157,7 +342,11 @@ pub(crate) fn expand_a1_glyph_to_a8(pixels: &[u8], gw: u32, gh: u32) -> Vec<u8> 
 
 #[cfg(test)]
 mod tests {
-    use super::{GlyphPixels, expand_a1_glyph_to_a8, reduce_argb32_glyph_to_a8_coverage};
+    use super::{
+        GlyphPixels, PLANES, expand_a1_glyph_to_a8, pack_argb32_glyph_to_component_alpha_planes,
+        reduce_argb32_glyph_to_a8_coverage,
+    };
+    use crate::kms::vk::glyph::GlyphLayout;
     use std::borrow::Cow;
 
     #[test]
@@ -328,6 +517,226 @@ mod tests {
             "A1 must still take the LSBFirst expansion, unchanged"
         );
         assert_eq!(&*out, &[0xFF, 0xFF, 0, 0, 0xFF, 0, 0xFF, 0]);
+    }
+
+    // ── the ARGB32 → four-plane component-alpha pack ──
+    // The real subpixel path. Unlike the grayscale reduction above —
+    // whose mean is symmetric and therefore blind to an R↔B
+    // transposition — these are the assertions where the channel
+    // mapping is detectable at all.
+
+    #[test]
+    fn argb32_packs_four_planes_in_logical_rgba_order_at_exact_values() {
+        // ONE pixel, four mutually distinct channel values, so every
+        // near miss lands somewhere visible:
+        //   wire  [B, G, R, A] = [0x20, 0x60, 0xA0, 0xE0]
+        //   packed plane order   [R, G, B, A] = [0xA0, 0x60, 0x20, 0xE0]
+        //
+        // Deliberately not an `r != g != b` check: that passes with
+        // red and blue reversed, which is the single most likely
+        // mistake here.
+        let wire = [0x20u8, 0x60, 0xA0, 0xE0];
+        let packed = pack_argb32_glyph_to_component_alpha_planes(&wire, 1, 1);
+        assert_eq!(
+            packed,
+            vec![0xA0u8, 0x60, 0x20, 0xE0],
+            "packed texels must be logical R, G, B, A read from wire [B, G, R, A]",
+        );
+        // The three ways to get it wrong, spelled out so the failure
+        // message names them:
+        //   * R/B swapped        → [0x20, 0x60, 0xA0, 0xE0]
+        //   * planes in wire order → [0x20, 0x60, 0xA0, 0xE0] (same)
+        //   * alpha dropped, RGB only → length 3
+        assert_ne!(
+            packed,
+            vec![0x20u8, 0x60, 0xA0, 0xE0],
+            "packing the wire bytes in place leaves blue in the R plane",
+        );
+        assert_eq!(packed.len(), 4, "four planes, not three: alpha is used");
+    }
+
+    #[test]
+    fn argb32_packs_planes_as_adjacent_texel_runs_at_four_times_the_width() {
+        // 3×2 glyph, every pixel of a row distinct, so the row layout
+        // is pinned: R R R | G G G | B B B | A A A, contiguous, at
+        // packed width 4 * 3 = 12.
+        const W: usize = 3;
+        const H: usize = 2;
+        let mut wire = vec![0u8; W * H * 4];
+        for row in 0..H {
+            for col in 0..W {
+                let px = (row * W + col) * 4;
+                let base = u8::try_from(row * 0x40 + col * 0x10).expect("small");
+                wire[px] = base; // B
+                wire[px + 1] = base + 1; // G
+                wire[px + 2] = base + 2; // R
+                wire[px + 3] = base + 3; // A
+            }
+        }
+
+        let packed = pack_argb32_glyph_to_component_alpha_planes(&wire, 3, 2);
+        let packed_w = W * PLANES as usize;
+        assert_eq!(packed.len(), packed_w * H);
+
+        for row in 0..H {
+            for col in 0..W {
+                let base = u8::try_from(row * 0x40 + col * 0x10).expect("small");
+                let at = |plane: usize| packed[row * packed_w + plane * W + col];
+                assert_eq!(at(0), base + 2, "({col},{row}) plane 0 is logical R");
+                assert_eq!(at(1), base + 1, "({col},{row}) plane 1 is logical G");
+                assert_eq!(at(2), base, "({col},{row}) plane 2 is logical B");
+                assert_eq!(at(3), base + 3, "({col},{row}) plane 3 is logical A");
+            }
+        }
+
+        // Row 1's planes must not have landed in row 0's tail: a
+        // packer that wrote at the LOGICAL width would put row 1's R
+        // plane where row 0's G plane belongs.
+        assert_eq!(
+            packed[0..packed_w],
+            [
+                0x02, 0x12, 0x22, 0x01, 0x11, 0x21, 0x00, 0x10, 0x20, 0x03, 0x13, 0x23
+            ],
+            "row 0 must be four contiguous 3-texel plane runs",
+        );
+    }
+
+    #[test]
+    fn argb32_pack_preserves_a_measured_subpixel_glyph_alpha_and_colour_split() {
+        // The measured OpenJDK 25 signature: alpha constant 255,
+        // max(rgb) spanning dozens of values. The pack must keep BOTH
+        // — the colour planes vary and the alpha plane does not — so
+        // a regression that fed the alpha byte into the colour planes
+        // (the original defect) shows up as a constant colour plane.
+        const W: usize = 9;
+        const H: usize = 9;
+        let mut wire = vec![0u8; W * H * 4];
+        for row in 0..H {
+            for col in 0..W {
+                let px = (row * W + col) * 4;
+                wire[px] = u8::try_from((row * 29 + col * 7) % 256).expect("masked");
+                wire[px + 1] = u8::try_from((row * 13 + col * 23 + 5) % 256).expect("masked");
+                wire[px + 2] = u8::try_from((row * 41 + col * 3 + 11) % 256).expect("masked");
+                wire[px + 3] = 0xFF;
+            }
+        }
+
+        let packed = pack_argb32_glyph_to_component_alpha_planes(&wire, 9, 9);
+        let packed_w = W * PLANES as usize;
+        let plane = |k: usize| -> Vec<u8> {
+            (0..H)
+                .flat_map(|row| {
+                    packed[row * packed_w + k * W..row * packed_w + (k + 1) * W].to_vec()
+                })
+                .collect()
+        };
+
+        for k in 0..3 {
+            let p = plane(k);
+            assert!(
+                p.iter().any(|&v| v != p[0]),
+                "colour plane {k} is constant — the alpha byte was packed into it",
+            );
+        }
+        assert!(
+            plane(3).iter().all(|&v| v == 0xFF),
+            "the alpha plane must be the glyph's own alpha, 255 here",
+        );
+        // Exact spot checks against the wire, so the mapping is
+        // pinned and not merely shown to be non-constant.
+        let at = |row: usize, col: usize, k: usize| packed[row * packed_w + k * W + col];
+        assert_eq!(at(4, 4, 0), wire[(4 * W + 4) * 4 + 2], "R plane");
+        assert_eq!(at(4, 4, 1), wire[(4 * W + 4) * 4 + 1], "G plane");
+        assert_eq!(at(4, 4, 2), wire[(4 * W + 4) * 4], "B plane");
+    }
+
+    /// The upload entry point routes on the LAYOUT, and the two
+    /// layouts produce different byte counts from the same source —
+    /// which is what makes confusing `packed_w` with `logical_w`
+    /// reachable at all.
+    #[test]
+    fn to_atlas_bytes_routes_a8_to_the_reduction_and_component_alpha_to_the_pack() {
+        let wire = [0x20u8, 0x60, 0xA0, 0xE0, 0x10, 0x40, 0x50, 0xFF];
+        let src = GlyphPixels::Argb32Wire(&wire);
+
+        // `A8` — the no-`dualSrcBlend` fallback. One plane at the
+        // LOGICAL width, the mean of logical R, G, B.
+        let a8 = src.to_atlas_bytes(2, 1, GlyphLayout::A8).expect("fits");
+        assert_eq!(&*a8, &[96u8, 53u8], "A8 layout must take the reduction");
+
+        // `ComponentAlpha` — four planes at 4 * w.
+        let ca = src
+            .to_atlas_bytes(2, 1, GlyphLayout::ComponentAlpha)
+            .expect("fits");
+        assert_eq!(
+            &*ca,
+            &[0xA0u8, 0x50, 0x60, 0x40, 0x20, 0x10, 0xE0, 0xFF],
+            "ComponentAlpha layout must take the four-plane pack",
+        );
+        assert_eq!(
+            ca.len(),
+            4 * a8.len(),
+            "a component-alpha glyph is 4x the area"
+        );
+
+        // Short source: refused on both layouts rather than indexing
+        // out of bounds.
+        let short = GlyphPixels::Argb32Wire(&wire[..7]);
+        assert!(short.to_atlas_bytes(2, 1, GlyphLayout::A8).is_none());
+        assert!(
+            short
+                .to_atlas_bytes(2, 1, GlyphLayout::ComponentAlpha)
+                .is_none()
+        );
+    }
+
+    /// An A8 or A1 source can never be staged under a four-plane
+    /// layout: it has no G, B or A channel, and three neighbours
+    /// would be sampled as them. The caller derives the layout from
+    /// this glyph's own source format, so this is a logic error
+    /// caught here rather than a wrong picture.
+    #[test]
+    fn to_atlas_bytes_refuses_component_alpha_for_a_single_channel_source() {
+        let a8 = [0x10u8, 0x20, 0x30, 0x40];
+        assert!(
+            GlyphPixels::A8(&a8)
+                .to_atlas_bytes(2, 2, GlyphLayout::ComponentAlpha)
+                .is_none(),
+        );
+        let a1 = [0b0000_0001u8, 0, 0, 0];
+        assert!(
+            GlyphPixels::A1Wire(&a1)
+                .to_atlas_bytes(8, 1, GlyphLayout::ComponentAlpha)
+                .is_none(),
+        );
+        // And they still work under the layout they DO have.
+        assert!(
+            GlyphPixels::A8(&a8)
+                .to_atlas_bytes(2, 2, GlyphLayout::A8)
+                .is_some(),
+        );
+    }
+
+    /// The format tag is derived from the byte encoding, not carried
+    /// beside it — the simplification that removed
+    /// `CompositeGlyphInput.source_format`. Total and 1:1, asserted
+    /// so a new variant cannot be added without answering here.
+    #[test]
+    fn source_format_is_one_to_one_with_the_pixel_variant() {
+        use super::GlyphSourceFormat;
+        let bytes = [0u8; 8];
+        assert_eq!(
+            GlyphPixels::A8(&bytes).source_format(),
+            GlyphSourceFormat::A8
+        );
+        assert_eq!(
+            GlyphPixels::A1Wire(&bytes).source_format(),
+            GlyphSourceFormat::A1
+        );
+        assert_eq!(
+            GlyphPixels::Argb32Wire(&bytes).source_format(),
+            GlyphSourceFormat::Argb32
+        );
     }
 
     // ── issue #77: bitmap fonts (terminus) rendered backwards ──

--- a/crates/yserver/src/kms/render/telemetry.rs
+++ b/crates/yserver/src/kms/render/telemetry.rs
@@ -58,11 +58,15 @@ pub(crate) enum GetImageSite {
     CursorDepth1 = 10,
     /// `read_cursor_bgra_pixmap` — ARGB cursor read.
     CursorBgra = 11,
+    /// `uniform_glyph_source_premul` — #137 tier 1: the one-pixel read
+    /// that collapses a uniform drawable glyph source to a colour. On
+    /// the hottest RENDER path there is, hence its own attribution.
+    GlyphSource = 12,
 }
 
 /// Number of [`GetImageSite`] variants — width of the
 /// `get_image_by_site` attribution array.
-pub(crate) const GET_IMAGE_SITE_COUNT: usize = 12;
+pub(crate) const GET_IMAGE_SITE_COUNT: usize = 13;
 
 /// Single-second accumulator. Reset on every emission tick.
 #[derive(Debug, Default, Clone, Copy)]
@@ -568,7 +572,8 @@ impl Telemetry {
              copy_area_cpu_pixmap_clip/s={} copy_area_cpu_rop/s={} \
              get_image_calls/s={} promote_exportable_runs/s={} clip_mask_reads/s={} \
              get_image_by_site/s[clip={} client={} fillpat={} cpufill={} cpupat={} \
-             copyrop={} putrop={} imgtext={} copyplane={} rdepth1={} curs1={} cursbgra={}] \
+             copyrop={} putrop={} imgtext={} copyplane={} rdepth1={} curs1={} cursbgra={} \
+             glyphsrc={}] \
              cpufill_reason/s[depth_lt8={} partial_planemask={} d1_gxcopy={} d1_noncopy={}] \
              clip_cache/s[hit={} miss_other_xid={} miss_no_entry={}] \
              descriptor_pool_creates/s={} descriptor_pool_resets/s={} \
@@ -656,6 +661,7 @@ impl Telemetry {
             b.get_image_by_site[GetImageSite::ReadDepth1 as usize],
             b.get_image_by_site[GetImageSite::CursorDepth1 as usize],
             b.get_image_by_site[GetImageSite::CursorBgra as usize],
+            b.get_image_by_site[GetImageSite::GlyphSource as usize],
             b.cpufill_depth_lt8,
             b.cpufill_partial_planemask,
             b.cpufill_depth1_gxcopy,

--- a/crates/yserver/src/kms/render/telemetry.rs
+++ b/crates/yserver/src/kms/render/telemetry.rs
@@ -290,6 +290,29 @@ pub struct Bucket {
     pub clip_cache_hit: u64,
     pub clip_cache_miss_no_entry: u64,
     pub clip_cache_miss_other_xid: u64,
+    /// #137 step 5: outcome of the uniform-glyph-source colour cache,
+    /// per tier-1 `CompositeGlyphs` whose source is a 1x1 drawable.
+    ///
+    /// These are the plan's **would-hit / would-miss** discriminator,
+    /// now literal rather than hypothetical: with the cache in place a
+    /// would-hit IS a hit. They measure the one property that decides
+    /// whether tier 1's readback costs anything — **how often the client
+    /// recolours the 1x1 source between consecutive `CompositeGlyphs`
+    /// requests** — and they measure it on whatever the user actually
+    /// runs, which is why they exist rather than a benchmark: "is this
+    /// app representative?" has no good answer, "what is this app's hit
+    /// rate?" does.
+    ///
+    /// A hit skips `get_image` entirely, so it also skips the
+    /// `CloseReason::SyncWait` frame close that readback forces — which
+    /// was ~75% of ALL frame closes on the churn probe. Read alongside
+    /// `glyphsrc=` (which counts only MISSES now) and
+    /// `close_reasons[sync_wait=...]`: a high `miss` with a high
+    /// `sync_wait` share is a client defeating the cache by recolouring
+    /// per string, and is the signal that the ordering itself, not the
+    /// cache, is the remaining lever.
+    pub glyph_src_cache_hit: u64,
+    pub glyph_src_cache_miss: u64,
     /// Stage 5 Task 4 layer 1: vkCreateDescriptorPool calls in this
     /// second. Should reach a near-zero floor after warm-up under
     /// the descriptor-pool-ring design (spec 2026-05-21).
@@ -574,6 +597,7 @@ impl Telemetry {
              get_image_by_site/s[clip={} client={} fillpat={} cpufill={} cpupat={} \
              copyrop={} putrop={} imgtext={} copyplane={} rdepth1={} curs1={} cursbgra={} \
              glyphsrc={}] \
+             glyph_src_cache/s[hit={} miss={}] \
              cpufill_reason/s[depth_lt8={} partial_planemask={} d1_gxcopy={} d1_noncopy={}] \
              clip_cache/s[hit={} miss_other_xid={} miss_no_entry={}] \
              descriptor_pool_creates/s={} descriptor_pool_resets/s={} \
@@ -662,6 +686,8 @@ impl Telemetry {
             b.get_image_by_site[GetImageSite::CursorDepth1 as usize],
             b.get_image_by_site[GetImageSite::CursorBgra as usize],
             b.get_image_by_site[GetImageSite::GlyphSource as usize],
+            b.glyph_src_cache_hit,
+            b.glyph_src_cache_miss,
             b.cpufill_depth_lt8,
             b.cpufill_partial_planemask,
             b.cpufill_depth1_gxcopy,
@@ -824,6 +850,20 @@ impl Telemetry {
                 self.bucket.clip_cache_miss_no_entry += 1;
                 self.lifetime.clip_cache_miss_no_entry += 1;
             }
+        }
+    }
+
+    /// #137 step 5: one tier-1 uniform-glyph-source resolution, `true`
+    /// if the cached colour was reused (no readback, and no
+    /// `CloseReason::SyncWait` frame close). See
+    /// [`Bucket::glyph_src_cache_hit`].
+    pub(crate) fn record_uniform_glyph_source_cache(&mut self, hit: bool) {
+        if hit {
+            self.bucket.glyph_src_cache_hit += 1;
+            self.lifetime.glyph_src_cache_hit += 1;
+        } else {
+            self.bucket.glyph_src_cache_miss += 1;
+            self.lifetime.glyph_src_cache_miss += 1;
         }
     }
 

--- a/crates/yserver/src/kms/vk/glyph.rs
+++ b/crates/yserver/src/kms/vk/glyph.rs
@@ -62,14 +62,54 @@ pub struct GlyphKey {
 /// `dst_x = pen_x + entry.pen_left`,
 /// `dst_y = pen_y - entry.pen_top` (FreeType's `bitmap_top` is the
 /// y-up offset from the baseline to the glyph's top row).
+///
+/// `packed_w` and `logical_w` are the same number today — every
+/// glyph is a single A8 plane, so the atlas footprint and the dst
+/// quad width coincide. They diverge once a glyph is packed as
+/// multiple horizontally-adjacent planes (component-alpha: 4
+/// planes of `logical_w` each, `packed_w == 4 * logical_w`): the
+/// atlas copy region and the packer need the **footprint**
+/// (`packed_w`), while the dst quad, the damage extent and the
+/// instance geometry need the **glyph's own size** (`logical_w`).
+/// Keep them as two fields rather than deriving one from the other
+/// (e.g. from `layout`) — a derived value invites a call site to
+/// use the wrong one, and the failure mode is a subtly misaligned
+/// or stretched glyph rather than a compile error.
 #[derive(Copy, Clone, Debug)]
 pub struct AtlasEntry {
     pub atlas_x: u32,
     pub atlas_y: u32,
-    pub w: u32,
+    /// Width of the atlas footprint in texels — what the packer
+    /// reserved and what the upload copy region covers. Equal to
+    /// `logical_w` today; `4 * logical_w` once a glyph is packed as
+    /// four component-alpha planes.
+    pub packed_w: u32,
+    /// The glyph's own width in pixels — what the dst quad, the
+    /// damage extent and the instance geometry use. Never a
+    /// multiple of the plane count, unlike `packed_w`.
+    pub logical_w: u32,
     pub h: u32,
     pub pen_left: i32,
     pub pen_top: i32,
+    /// Which pipeline should sample this entry, and whether its
+    /// packed width encodes multiple planes at a fixed stride. Always
+    /// `A8` today (single plane, `packed_w == logical_w`); a later
+    /// step introduces `ComponentAlpha` for 4-plane entries, at which
+    /// point this also tells the fragment shader the explicit plane
+    /// stride is meaningful rather than incidental.
+    pub layout: GlyphLayout,
+}
+
+/// Selects how an atlas entry's texels are laid out, and therefore
+/// which text pipeline samples it. `A8` is one coverage plane per
+/// glyph pixel (today's only path). `ComponentAlpha` is reserved for
+/// a later step: four adjacent planes (R, G, B, A coverage) packed at
+/// `packed_w == 4 * logical_w`, sampled by a pipeline that gathers
+/// all four instead of one.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum GlyphLayout {
+    A8,
+    ComponentAlpha,
 }
 
 /// Per-backend glyph atlas. Owns the atlas image + view + memory,
@@ -283,10 +323,12 @@ impl GlyphAtlas {
             let entry = AtlasEntry {
                 atlas_x: 0,
                 atlas_y: 0,
-                w,
+                packed_w: w,
+                logical_w: w,
                 h,
                 pen_left,
                 pen_top,
+                layout: GlyphLayout::A8,
             };
             self.cache.insert(key, entry);
             return Some(entry);
@@ -326,10 +368,12 @@ impl GlyphAtlas {
         let entry = AtlasEntry {
             atlas_x,
             atlas_y,
-            w,
+            packed_w: w,
+            logical_w: w,
             h,
             pen_left,
             pen_top,
+            layout: GlyphLayout::A8,
         };
         self.cache.insert(key, entry);
         Some(entry)

--- a/crates/yserver/src/kms/vk/glyph.rs
+++ b/crates/yserver/src/kms/vk/glyph.rs
@@ -63,14 +63,13 @@ pub struct GlyphKey {
 /// `dst_y = pen_y - entry.pen_top` (FreeType's `bitmap_top` is the
 /// y-up offset from the baseline to the glyph's top row).
 ///
-/// `packed_w` and `logical_w` are the same number today — every
-/// glyph is a single A8 plane, so the atlas footprint and the dst
-/// quad width coincide. They diverge once a glyph is packed as
-/// multiple horizontally-adjacent planes (component-alpha: 4
-/// planes of `logical_w` each, `packed_w == 4 * logical_w`): the
-/// atlas copy region and the packer need the **footprint**
-/// (`packed_w`), while the dst quad, the damage extent and the
-/// instance geometry need the **glyph's own size** (`logical_w`).
+/// `packed_w` and `logical_w` coincide for a single-plane `A8`
+/// entry, and DIVERGE for a `ComponentAlpha` one — four
+/// horizontally-adjacent coverage planes of `logical_w` texels each,
+/// so `packed_w == 4 * logical_w`. The atlas copy region and the
+/// packer need the **footprint** (`packed_w`), while the dst quad,
+/// the damage extent and the instance geometry need the **glyph's
+/// own size** (`logical_w`).
 /// Keep them as two fields rather than deriving one from the other
 /// (e.g. from `layout`) — a derived value invites a call site to
 /// use the wrong one, and the failure mode is a subtly misaligned
@@ -81,8 +80,8 @@ pub struct AtlasEntry {
     pub atlas_y: u32,
     /// Width of the atlas footprint in texels — what the packer
     /// reserved and what the upload copy region covers. Equal to
-    /// `logical_w` today; `4 * logical_w` once a glyph is packed as
-    /// four component-alpha planes.
+    /// `logical_w` for an `A8` entry; `4 * logical_w` for a
+    /// `ComponentAlpha` one.
     pub packed_w: u32,
     /// The glyph's own width in pixels — what the dst quad, the
     /// damage extent and the instance geometry use. Never a
@@ -91,21 +90,34 @@ pub struct AtlasEntry {
     pub h: u32,
     pub pen_left: i32,
     pub pen_top: i32,
-    /// Which pipeline should sample this entry, and whether its
-    /// packed width encodes multiple planes at a fixed stride. Always
-    /// `A8` today (single plane, `packed_w == logical_w`); a later
-    /// step introduces `ComponentAlpha` for 4-plane entries, at which
-    /// point this also tells the fragment shader the explicit plane
-    /// stride is meaningful rather than incidental.
+    /// Which pipeline samples this entry, and whether its packed
+    /// width encodes multiple planes at a fixed stride. `A8` is a
+    /// single plane (`packed_w == logical_w`) sampled through the
+    /// interpolated UV; `ComponentAlpha` is four planes fetched by
+    /// texel index at the explicit per-instance plane stride.
+    ///
+    /// Decided in exactly one place —
+    /// `RenderEngine::effective_glyph_layout` — from the glyphset's
+    /// picture format and the device's `dualSrcBlend`. An entry whose
+    /// layout disagreed with the bytes the uploader staged would be
+    /// sampled as garbage.
     pub layout: GlyphLayout,
 }
 
 /// Selects how an atlas entry's texels are laid out, and therefore
-/// which text pipeline samples it. `A8` is one coverage plane per
-/// glyph pixel (today's only path). `ComponentAlpha` is reserved for
-/// a later step: four adjacent planes (R, G, B, A coverage) packed at
+/// which text pipeline samples it.
+///
+/// `A8` is one coverage plane per glyph pixel — every core-text
+/// glyph, every `PICT_a8` / `PICT_a1` glyphset, and every `ARGB32`
+/// glyphset on a device without `dualSrcBlend` (where the upload
+/// reduces the colour channels to their mean).
+///
+/// `ComponentAlpha` is four adjacent planes — **logical R, G, B, A
+/// coverage, in that order** — packed at
 /// `packed_w == 4 * logical_w`, sampled by a pipeline that gathers
-/// all four instead of one.
+/// all four and emits the per-channel alpha factor to output index 1
+/// for dual-source blending. That is X RENDER component alpha, i.e.
+/// subpixel/LCD text antialiasing.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum GlyphLayout {
     A8,

--- a/crates/yserver/src/kms/vk/ops/text.rs
+++ b/crates/yserver/src/kms/vk/ops/text.rs
@@ -83,6 +83,9 @@ pub fn record_text_run<T: TextRunTarget + ?Sized>(
         atlas_extent,
         pipeline,
         instance_buf,
+        // Core text is never split into runs: one buffer, one draw,
+        // from instance 0.
+        0,
         instance_count,
         foreground,
         &full,
@@ -96,6 +99,10 @@ pub fn record_text_run<T: TextRunTarget + ?Sized>(
 /// per-rect scissoring, not v1's union-bbox shortcut, which also
 /// fixes v1's latent `_clip unused` bug).
 ///
+/// `first_instance` / `instance_count` are the run's half-open range
+/// into `instance_buf`, which may hold the instances of several runs
+/// of the same request (see `RecordedCompositeGlyphs::first_instance`).
+///
 /// If `scissors` is empty the function returns without recording
 /// any draw (matches "every clip rect culled" semantics in
 /// `RenderEngine::render_composite`).
@@ -106,6 +113,7 @@ pub fn record_text_run_scissored<T: TextRunTarget + ?Sized>(
     atlas_extent: vk::Extent2D,
     pipeline: &TextPipeline,
     instance_buf: vk::Buffer,
+    first_instance: u32,
     instance_count: u32,
     foreground: [f32; 4],
     scissors: &[vk::Rect2D],
@@ -201,15 +209,21 @@ pub fn record_text_run_scissored<T: TextRunTarget + ?Sized>(
             push_consts.as_bytes(),
         );
 
-        // One instanced draw of all glyphs per clip rect. Instance order
-        // == glyph order (preserves blend order for non-additive ops);
-        // the same buffer is re-read per scissor.
+        // One instanced draw of this run's glyphs per clip rect.
+        // Instance order == glyph order (preserves blend order for
+        // non-additive ops); the same buffer is re-read per scissor.
+        //
+        // `first_instance` is the run's offset into the shared instance
+        // buffer: `[first_instance, first_instance + instance_count)`.
+        // A `CompositeGlyphs` request recorded as several runs pins one
+        // buffer and hands each run its own range, so leaving this at
+        // zero would draw run 0's glyphs for every run.
         for scissor_rect in scissors {
             let scissor = [*scissor_rect];
             crate::vk_count!(cmd_set_scissor);
             device.cmd_set_scissor(cb, 0, &scissor);
             crate::vk_count!(cmd_draw);
-            device.cmd_draw(cb, 4, instance_count, 0, 0);
+            device.cmd_draw(cb, 4, instance_count, 0, first_instance);
         }
 
         crate::vk_count!(cmd_end_rendering);

--- a/crates/yserver/src/kms/vk/shaders/text.frag.glsl
+++ b/crates/yserver/src/kms/vk/shaders/text.frag.glsl
@@ -16,22 +16,90 @@
 // an R8_UNORM attachment (a8 mask pixmap — the cairo/Pango
 // component-alpha text intermediate) stores alpha in `.r`. Same
 // convention as render.frag.glsl's A8_DST constant.
+//
+// COMPONENT_ALPHA — 1 → the glyph is packed as FOUR horizontally
+// adjacent coverage planes in the atlas (logical R, G, B, A, in that
+// order, `plane_stride` texels apart) and each colour channel gets
+// its OWN coverage: X RENDER component-alpha, i.e. subpixel/LCD text
+// AA. The blend equation's per-channel alpha factor rides output
+// index 1 (dual-source blending) where the pipeline's `SRC1_*`
+// factors pick it up.
+//
+// The maths below is EXACTLY render.frag.glsl:257-263 with the
+// packed coverage standing in for its `mask_sample`. The two shaders
+// carry one equation in two places and cannot share code today, so
+// they must be read side by side when either changes.
 
 layout(constant_id = 0) const uint A8_DST = 0u;
+layout(constant_id = 1) const uint COMPONENT_ALPHA = 0u;
 
 layout(location = 0) in vec2 v_uv;
 layout(location = 1) in vec4 v_foreground;
+// Component-alpha coordinate inputs. See text.vert.glsl's
+// "component-alpha coordinate contract" comment — `v_local` is the
+// fragment's offset inside the glyph quad (`0..w` × `0..h`), and the
+// two `flat` inputs are the glyph's atlas origin and the packed plane
+// stride, both in texels. Unread on the A8 path.
+layout(location = 2) in vec2 v_local;
+layout(location = 3) flat in ivec2 v_atlas_origin;
+layout(location = 4) flat in int v_plane_stride;
 
-layout(location = 0) out vec4 out_color;
+// Dual-source output: the SECOND INDEX of location 0, NOT a second
+// location — exactly as render.frag.glsl:66 declares it. The
+// `SRC1_*` blend factors reference index 1 of attachment 0; a
+// `location = 1` output is a second colour attachment and would not
+// link against this pipeline's single attachment.
+layout(location = 0)            out vec4 out_color;
+layout(location = 0, index = 1) out vec4 out_color1;
 
 layout(set = 0, binding = 0) uniform sampler2D atlas;
 
 void main() {
-    float coverage = texture(atlas, v_uv).r;
-    float alpha = v_foreground.a * coverage;
-    if (A8_DST == 1u) {
-        out_color = vec4(alpha);
+    vec4 fg = v_foreground;
+
+    if (COMPONENT_ALPHA == 1u) {
+        // Exact integer texel index inside the glyph. `floor` of the
+        // interpolated `quad * dst_size` recovers it because the quad
+        // is pixel-aligned, so fragment centres sample at `i + 0.5`.
+        ivec2 local = ivec2(floor(v_local));
+        // Plane k lives `k * plane_stride` texels to the right of the
+        // glyph's atlas origin. Order is LOGICAL R, G, B, A — the
+        // upload writes it that way from wire bytes `[B, G, R, A]`
+        // (blue is the LOW byte of the little-endian CARD32). A swap
+        // here paints plausible text in the wrong colour and errors
+        // nothing (design invariant 4).
+        vec4 cov;
+        cov.r = texelFetch(atlas, v_atlas_origin + ivec2(local.x + 0 * v_plane_stride, local.y), 0).r;
+        cov.g = texelFetch(atlas, v_atlas_origin + ivec2(local.x + 1 * v_plane_stride, local.y), 0).r;
+        cov.b = texelFetch(atlas, v_atlas_origin + ivec2(local.x + 2 * v_plane_stride, local.y), 0).r;
+        // The glyph's OWN alpha, from the fourth plane — the one
+        // place the alpha byte is still read, deliberately. Xorg uses
+        // `mask.a` for the alpha channel's factor and `mask.rgb` for
+        // the colour channels'. It is 255 everywhere on this JVM's
+        // glyphs; that is a property of the client, not the format,
+        // so it must NOT be assumed to be 1 (design invariant 3).
+        cov.a = texelFetch(atlas, v_atlas_origin + ivec2(local.x + 3 * v_plane_stride, local.y), 0).r;
+
+        // render.frag.glsl:262-263, verbatim in substance:
+        //   s         = vec4(src.rgb * mask.rgb, src.a * mask.a)
+        //   src_alpha = vec4(src.a   * mask.rgb, src.a * mask.a)
+        vec4 s = vec4(fg.rgb * cov.rgb, fg.a * cov.a);
+        vec4 src_alpha = vec4(fg.a * cov.rgb, fg.a * cov.a);
+        // R8 attachments store alpha in `.r`, so both outputs
+        // collapse to the alpha channel — render.frag.glsl:305,323
+        // does the same for its `A8_DST`.
+        out_color = (A8_DST == 1u) ? vec4(s.a) : s;
+        out_color1 = (A8_DST == 1u) ? vec4(src_alpha.a) : src_alpha;
     } else {
-        out_color = vec4(v_foreground.rgb * coverage, alpha);
+        float coverage = texture(atlas, v_uv).r;
+        float alpha = fg.a * coverage;
+        out_color = (A8_DST == 1u) ? vec4(alpha) : vec4(fg.rgb * coverage, alpha);
+        // Single-source path: the pipeline's blend factors are the
+        // `SRC_ALPHA` family and never reference index 1, but the
+        // output is declared unconditionally (as render.frag.glsl
+        // does) so one module serves both specializations. Write the
+        // uniform src-alpha factor so the value is defined either
+        // way.
+        out_color1 = vec4(alpha);
     }
 }

--- a/crates/yserver/src/kms/vk/shaders/text.vert.glsl
+++ b/crates/yserver/src/kms/vk/shaders/text.vert.glsl
@@ -21,11 +21,44 @@
 // foreground@16). No `GL_EXT_scalar_block_layout` needed, which lets
 // the shader run on devices without the optional `scalarBlockLayout`
 // feature (Broadcom V3D / v3dv on the RPi 4/400).
+//
+// ## The component-alpha coordinate contract
+//
+// `atlas_wh` is ALWAYS the glyph's LOGICAL size in texels, never the
+// packed atlas footprint — a component-alpha glyph occupies
+// `4 * logical_w` texels (four adjacent coverage planes: logical R,
+// G, B, A) and passing that as `atlas_wh` would stretch one glyph
+// across all four planes. The `4w` allocation width never reaches
+// either shader stage (design invariant 9).
+//
+// The fragment shader addresses the planes by `texelFetch` instead,
+// which needs three things this stage supplies:
+//
+//   * `v_local` — the fragment's integer offset INSIDE the glyph,
+//     emitted as `quad * dst_size` so it spans `0..w` × `0..h`. The
+//     fragment shader recovers the texel index with
+//     `ivec2(floor(v_local))`, which is exact because the quad is
+//     pixel-aligned (`dst_origin` and `dst_size` are whole pixels),
+//     so fragment centres land on `i + 0.5`. Recovering it by
+//     multiplying `v_uv` back up by `atlas_extent` instead lands
+//     half a texel out at glyph edges — a one-pixel colour fringe on
+//     some glyphs and not others.
+//   * `v_atlas_origin` — the glyph's atlas top-left in texels, `flat`
+//     so no interpolation happens to it. Values are ≤ the 4096 atlas
+//     side and therefore exactly representable in f32.
+//   * `v_plane_stride` — texels between adjacent packed planes,
+//     `flat`. Carried explicitly even though it currently equals
+//     `dst_size.x`: that identity holds only because glyph blitting
+//     is 1:1, and deriving from it would couple the sampling to an
+//     unrelated invariant whose failure mode is a glyph sampling its
+//     neighbour's plane. Zero for a single-plane (A8) glyph, where
+//     the fragment shader never reads it.
 
 layout(location = 0) in vec2 dst_origin;  // pixels
 layout(location = 1) in vec2 dst_size;     // pixels
 layout(location = 2) in vec2 atlas_xy;     // texels
-layout(location = 3) in vec2 atlas_wh;     // texels
+layout(location = 3) in vec2 atlas_wh;     // texels — LOGICAL glyph size
+layout(location = 4) in uint plane_stride; // texels between planes; 0 for A8
 
 layout(push_constant) uniform PushConsts {
     vec2 viewport;
@@ -35,6 +68,9 @@ layout(push_constant) uniform PushConsts {
 
 layout(location = 0) out vec2 v_uv;
 layout(location = 1) out vec4 v_foreground;
+layout(location = 2) out vec2 v_local;
+layout(location = 3) flat out ivec2 v_atlas_origin;
+layout(location = 4) flat out int v_plane_stride;
 
 void main() {
     vec2 quad = vec2(float(gl_VertexIndex & 1), float((gl_VertexIndex >> 1) & 1));
@@ -45,4 +81,7 @@ void main() {
 
     v_uv = (atlas_xy + quad * atlas_wh) / pc.atlas_extent;
     v_foreground = pc.foreground;
+    v_local = quad * dst_size;
+    v_atlas_origin = ivec2(atlas_xy);
+    v_plane_stride = int(plane_stride);
 }

--- a/crates/yserver/src/kms/vk/text_pipeline.rs
+++ b/crates/yserver/src/kms/vk/text_pipeline.rs
@@ -30,16 +30,25 @@
 //! [`StdPictOp::blend_factors`] so glyph compositing and the general
 //! RENDER `Composite` path agree on Porter-Duff semantics by
 //! construction; the engine caches one pipeline per
-//! `(op, dst_format, dst_has_alpha)` key. The historical
-//! Over+BGRA8 entry is bit-identical to the pre-cache singleton:
+//! `(op, dst_format, dst_has_alpha, component_alpha)` key — the same
+//! four dimensions [`RenderPipelineCache`](super::render_pipeline)
+//! keys on, so the two caches cannot disagree about which blend state
+//! a given composite gets. The historical Over+BGRA8 entry is
+//! bit-identical to the pre-cache singleton:
 //! `blend_factors(Over, BGRA8, _, false)` yields exactly
 //! `(ONE, ONE_MINUS_SRC_ALPHA)`.
+//!
+//! `component_alpha` is set for a run of four-plane packed glyphs
+//! (subpixel/LCD text AA): the fragment shader then gathers logical
+//! R, G, B and A coverage from four adjacent atlas texel runs and
+//! emits the per-channel alpha factor to output INDEX 1 of
+//! attachment 0, which the `SRC1_*` blend factors consume.
 
 use std::sync::Arc;
 
 use ash::vk;
 
-use super::{device::VkContext, render_pipeline::StdPictOp};
+use super::{device::VkContext, glyph::GlyphLayout, render_pipeline::StdPictOp};
 
 const VERTEX_SPV: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/text.vert.spv"));
 const FRAGMENT_SPV: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/text.frag.spv"));
@@ -95,46 +104,79 @@ const _: () = assert!(std::mem::offset_of!(TextPushConsts, foreground) == 16);
 /// Per-glyph instance data for the batched glyph draw (#1). One
 /// `vkCmdDraw(4, N_glyphs, ..)` reads N of these as instance-rate
 /// vertex attributes; the 4-vertex quad still comes from
-/// `gl_VertexIndex`. Layout: 4 × `vec2` = 32 bytes, split into
-/// vertex attributes at offsets 0/8/16/24. Atlas coords are stored
-/// in **texels** (not normalized UVs) — the vertex shader divides by
-/// the `atlas_extent` push constant — so recorded instance data is
-/// independent of any later atlas resize.
+/// `gl_VertexIndex`. Layout: 4 × `vec2` + one `u32` = 36 bytes,
+/// split into vertex attributes at offsets 0/8/16/24/32. Atlas
+/// coords are stored in **texels** (not normalized UVs) — the vertex
+/// shader divides by the `atlas_extent` push constant — so recorded
+/// instance data is independent of any later atlas resize.
+///
+/// **Every width in here is the glyph's LOGICAL width.** A
+/// component-alpha glyph's atlas footprint is `4 * logical_w` texels
+/// (four adjacent coverage planes) and that number must never reach
+/// the shader: as `atlas_wh` it stretches one glyph across all four
+/// planes, and as `dst_size` it paints a quad four times too wide
+/// (design invariant 9). The planes are reached by `texelFetch`
+/// through `plane_stride` instead.
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct GlyphInstanceData {
     /// Dst top-left corner, pixels.
     pub dst_origin: [f32; 2],
-    /// Dst quad size, pixels.
+    /// Dst quad size, pixels. Also the fragment shader's `v_local`
+    /// span, from which it recovers the integer texel index inside
+    /// the glyph.
     pub dst_size: [f32; 2],
-    /// Atlas top-left corner, texels.
+    /// Atlas top-left corner, texels. Delivered `flat` to the
+    /// fragment shader as the component-alpha fetch origin.
     pub atlas_xy: [f32; 2],
-    /// Atlas glyph size, texels.
+    /// The glyph's LOGICAL size in texels — never the packed
+    /// footprint. Feeds the A8 path's interpolated UV; unused by the
+    /// component-alpha path, which fetches by texel index.
     pub atlas_wh: [f32; 2],
+    /// Texels between adjacent packed coverage planes, `flat` to the
+    /// fragment shader. `logical_w` for a `ComponentAlpha` entry,
+    /// `0` for a single-plane `A8` one (where nothing reads it).
+    ///
+    /// Carried explicitly even though it equals `dst_size.x` today:
+    /// that identity holds only because glyph blitting is 1:1, and
+    /// deriving from it couples the sampling to an unrelated
+    /// invariant whose failure mode is a glyph sampling its
+    /// NEIGHBOUR's plane.
+    pub plane_stride: u32,
 }
 
 impl GlyphInstanceData {
-    /// Build instance data for one glyph from integer dst position and
-    /// atlas texel coords. Returns `None` for a zero-area glyph (it
-    /// contributes nothing — e.g. a space after pen-only adjustment),
-    /// so the caller drops it and it never becomes a wasted instance.
+    /// Build instance data for one glyph from integer dst position,
+    /// atlas texel coords, the glyph's **logical** size and the atlas
+    /// entry's [`GlyphLayout`]. Returns `None` for a zero-area glyph
+    /// (it contributes nothing — e.g. a space after pen-only
+    /// adjustment), so the caller drops it and it never becomes a
+    /// wasted instance.
     #[must_use]
     pub fn from_glyph(
         dst_x: i32,
         dst_y: i32,
         atlas_x: u32,
         atlas_y: u32,
-        w: u32,
+        logical_w: u32,
         h: u32,
+        layout: GlyphLayout,
     ) -> Option<Self> {
-        if w == 0 || h == 0 {
+        if logical_w == 0 || h == 0 {
             return None;
         }
         Some(Self {
             dst_origin: [dst_x as f32, dst_y as f32],
-            dst_size: [w as f32, h as f32],
+            dst_size: [logical_w as f32, h as f32],
             atlas_xy: [atlas_x as f32, atlas_y as f32],
-            atlas_wh: [w as f32, h as f32],
+            atlas_wh: [logical_w as f32, h as f32],
+            plane_stride: match layout {
+                // Single plane: the fragment shader samples the
+                // interpolated UV and never reads the stride.
+                GlyphLayout::A8 => 0,
+                // Four planes of `logical_w` texels each.
+                GlyphLayout::ComponentAlpha => logical_w,
+            },
         })
     }
 
@@ -150,10 +192,16 @@ impl GlyphInstanceData {
     }
 }
 
-const _: () = assert!(std::mem::size_of::<GlyphInstanceData>() == 32);
+// Compile-time lock on the vertex-input layout, the same treatment
+// `TextPushConsts` gets. The vertex attribute descriptions below
+// hard-code these offsets and the binding stride; a field reorder
+// that slid `plane_stride` under `atlas_wh`'s attribute would
+// silently feed the shader garbage.
+const _: () = assert!(std::mem::size_of::<GlyphInstanceData>() == 36);
 const _: () = assert!(std::mem::offset_of!(GlyphInstanceData, dst_size) == 8);
 const _: () = assert!(std::mem::offset_of!(GlyphInstanceData, atlas_xy) == 16);
 const _: () = assert!(std::mem::offset_of!(GlyphInstanceData, atlas_wh) == 24);
+const _: () = assert!(std::mem::offset_of!(GlyphInstanceData, plane_stride) == 32);
 
 pub struct TextPipeline {
     vk: Arc<VkContext>,
@@ -188,20 +236,42 @@ impl TextPipeline {
     /// glyph atlas uses this directly; v1 passes its
     /// `GlyphAtlas::image_view()`.
     ///
-    /// `op` + `dst_has_alpha` select the fixed-function blend state
-    /// via [`StdPictOp::blend_factors`] (standard ops 0..=12 only —
-    /// the caller gates out Saturate/Disjoint/Conjoint, which need
-    /// dst readback the text shader doesn't implement). An
-    /// `R8_UNORM` `color_format` sets the `A8_DST` specialization
-    /// constant so the fragment shader replicates alpha across all
-    /// channels (the a8 mask stores alpha in `.r`).
+    /// `op` + `dst_has_alpha` + `component_alpha` select the
+    /// fixed-function blend state via [`StdPictOp::blend_factors`]
+    /// (standard ops 0..=12 only — the caller gates out
+    /// Saturate/Disjoint/Conjoint, which need dst readback the text
+    /// shader doesn't implement). An `R8_UNORM` `color_format` sets
+    /// the `A8_DST` specialization constant so the fragment shader
+    /// replicates alpha across all channels (the a8 mask stores alpha
+    /// in `.r`).
+    ///
+    /// `component_alpha` is the glyph run's effective
+    /// [`GlyphLayout`] — true for a four-plane packed entry. It sets
+    /// the fragment shader's `COMPONENT_ALPHA` constant AND swaps the
+    /// `SRC_ALPHA` blend family for `SRC1_*` (dual-source), and both
+    /// come from the ONE `blend_factors` table `render_pipeline.rs`
+    /// uses, so the glyph and general RENDER paths cannot disagree on
+    /// component-alpha blend state by review error (design invariant
+    /// 5).
+    ///
+    /// The caller must have gated `component_alpha` on
+    /// `VkContext::component_alpha_supported` — the engine does it
+    /// once, in `effective_glyph_layout`, so the atlas layout, the
+    /// pipeline key and the blend state answer the device question in
+    /// exactly one place. Asserted below.
     pub fn new(
         vk: Arc<VkContext>,
         color_format: vk::Format,
         op: StdPictOp,
         dst_has_alpha: bool,
+        component_alpha: bool,
         atlas_image_view: vk::ImageView,
     ) -> Result<Self, TextPipelineError> {
+        debug_assert!(
+            !component_alpha || vk.component_alpha_supported,
+            "component-alpha text pipeline requested on a device without dualSrcBlend; \
+             the layout derivation must gate on component_alpha_supported",
+        );
         let device = &vk.device;
 
         let sampler_info = vk::SamplerCreateInfo::default()
@@ -264,16 +334,29 @@ impl TextPipeline {
         };
 
         let entry = c"main";
-        // Fragment-shader specialization constant (mirrors
+        // Fragment-shader specialization constants (mirrors
         // render_pipeline.rs):
         //   id 0: A8_DST — 1 → replicate computed alpha across all
         //         channels so an R8 attachment stores alpha in `.r`.
+        //   id 1: COMPONENT_ALPHA — 1 → gather the glyph's FOUR packed
+        //         coverage planes (logical R, G, B, A) and emit the
+        //         per-channel alpha factor to output index 1, which the
+        //         `SRC1_*` blend factors below consume.
         let a8_dst: u32 = u32::from(color_format == vk::Format::R8_UNORM);
-        let spec_data = a8_dst.to_ne_bytes();
-        let spec_map_entries = [vk::SpecializationMapEntry::default()
-            .constant_id(0)
-            .offset(0)
-            .size(4)];
+        let ca: u32 = u32::from(component_alpha);
+        let mut spec_data = [0u8; 8];
+        spec_data[..4].copy_from_slice(&a8_dst.to_ne_bytes());
+        spec_data[4..].copy_from_slice(&ca.to_ne_bytes());
+        let spec_map_entries = [
+            vk::SpecializationMapEntry::default()
+                .constant_id(0)
+                .offset(0)
+                .size(4),
+            vk::SpecializationMapEntry::default()
+                .constant_id(1)
+                .offset(4)
+                .size(4),
+        ];
         let spec_info = vk::SpecializationInfo::default()
             .map_entries(&spec_map_entries)
             .data(&spec_data);
@@ -317,12 +400,18 @@ impl TextPipeline {
                 .binding(0)
                 .format(vk::Format::R32G32_SFLOAT)
                 .offset(16),
-            // location 3: atlas_wh : vec2 (offset 24)
+            // location 3: atlas_wh : vec2 (offset 24) — LOGICAL size
             vk::VertexInputAttributeDescription::default()
                 .location(3)
                 .binding(0)
                 .format(vk::Format::R32G32_SFLOAT)
                 .offset(24),
+            // location 4: plane_stride : uint (offset 32)
+            vk::VertexInputAttributeDescription::default()
+                .location(4)
+                .binding(0)
+                .format(vk::Format::R32_UINT)
+                .offset(32),
         ];
         let vertex_input = vk::PipelineVertexInputStateCreateInfo::default()
             .vertex_binding_descriptions(&vi_bindings)
@@ -347,7 +436,12 @@ impl TextPipeline {
         let (src_factor, dst_factor) = op.blend_factors(
             color_format,
             dst_has_alpha,
-            false, // component_alpha — glyph path has no dual-source output
+            // The glyph path DOES have a dual-source output now:
+            // `text.frag.glsl` declares `layout(location = 0, index = 1)`
+            // exactly as `render.frag.glsl:66` does, so `SRC1_COLOR` /
+            // `ONE_MINUS_SRC1_COLOR` resolve to the per-channel alpha
+            // factor `fg.a * cov.rgb`.
+            component_alpha,
         );
         let color_blend_attachments = [vk::PipelineColorBlendAttachmentState::default()
             .blend_enable(true)
@@ -496,7 +590,7 @@ fn create_shader_module(
 
 #[cfg(test)]
 mod tests {
-    use super::GlyphInstanceData;
+    use super::{GlyphInstanceData, GlyphLayout};
 
     #[test]
     fn from_glyph_maps_dst_and_texel_coords() {
@@ -505,16 +599,50 @@ mod tests {
         // (atlas is 1:1 with glyph pixels). Sampler-space normalization
         // by atlas_extent happens in the shader, so instance data holds
         // raw texels here.
-        let g = GlyphInstanceData::from_glyph(-3, 12, 40, 128, 7, 9).expect("nonzero");
+        let g =
+            GlyphInstanceData::from_glyph(-3, 12, 40, 128, 7, 9, GlyphLayout::A8).expect("nonzero");
         assert_eq!(g.dst_origin, [-3.0, 12.0]);
         assert_eq!(g.dst_size, [7.0, 9.0]);
         assert_eq!(g.atlas_xy, [40.0, 128.0]);
         assert_eq!(g.atlas_wh, [7.0, 9.0]);
+        // A single-plane glyph has no plane stride; the fragment
+        // shader's A8 branch never reads it.
+        assert_eq!(g.plane_stride, 0);
     }
 
     #[test]
     fn from_glyph_drops_zero_area() {
-        assert!(GlyphInstanceData::from_glyph(0, 0, 5, 5, 0, 9).is_none());
-        assert!(GlyphInstanceData::from_glyph(0, 0, 5, 5, 9, 0).is_none());
+        assert!(GlyphInstanceData::from_glyph(0, 0, 5, 5, 0, 9, GlyphLayout::A8).is_none());
+        assert!(GlyphInstanceData::from_glyph(0, 0, 5, 5, 9, 0, GlyphLayout::A8).is_none());
+    }
+
+    /// A component-alpha glyph's instance data carries the LOGICAL
+    /// width in both geometry fields and the plane stride separately.
+    ///
+    /// The packed atlas footprint is `4 * logical_w`; the two ways it
+    /// can leak are `atlas_wh = 4w` (one glyph stretched across all
+    /// four planes) and `dst_size = 4w` (a quad four times too wide).
+    /// Neither number appears here, which is design invariant 9 —
+    /// asserted at the only struct that reaches the shader.
+    #[test]
+    fn a_component_alpha_glyph_carries_the_logical_width_and_an_explicit_plane_stride() {
+        let g = GlyphInstanceData::from_glyph(4, 5, 64, 32, 7, 9, GlyphLayout::ComponentAlpha)
+            .expect("nonzero");
+        assert_eq!(g.dst_size, [7.0, 9.0], "dst quad is the logical width");
+        assert_eq!(
+            g.atlas_wh,
+            [7.0, 9.0],
+            "atlas_wh is the logical width — 4 * 7 = 28 would stretch the \
+             glyph across all four planes",
+        );
+        assert_eq!(
+            g.plane_stride, 7,
+            "the stride between adjacent planes is one logical width",
+        );
+        // The packed footprint is nowhere in the instance data.
+        assert!(
+            !g.atlas_wh.contains(&28.0) && !g.dst_size.contains(&28.0),
+            "the 4w allocation width must never reach the shader",
+        );
     }
 }

--- a/crates/yserver/tests/render_acceptance.rs
+++ b/crates/yserver/tests/render_acceptance.rs
@@ -291,6 +291,298 @@ fn render_composite_no_gc_clip_leak() {
     }
 }
 
+// ── #137 tier 1: a uniform drawable glyph source ───────────────
+//
+// Java2D paints all text through `XRSolidSrcPict` — a 1x1 pixmap
+// picture with `repeat=Normal` — rather than `CreateSolidFill`. The
+// glyph path accepted only SolidFill and Gradient sources, so every
+// Java/AWT text draw was silently discarded (#137).
+//
+// A source whose sampled domain is one pixel under a repeat that
+// covers the plane is a constant colour, so collapsing it to a
+// foreground colour is exact. This is the ORDERED-READBACK half of
+// that proof: `get_image` is a Vulkan synchronisation and readback
+// path, so a recording-backend test would assert nothing about the
+// part most likely to be wrong. The byte -> premultiplied-`[f32; 4]`
+// conversion is pinned separately and purely, in
+// `engine::tests::premul_from_wire`.
+//
+// The reference colour throughout: premultiplied opaque
+// R=0x33 G=0x88 B=0xCC. Deliberately non-grey and non-symmetric, so
+// a channel swap cannot pass. Painted `Over` through a fully opaque
+// glyph, the result is that colour exactly.
+const GLYPH_SRC_R: u8 = 0x33;
+const GLYPH_SRC_G: u8 = 0x88;
+const GLYPH_SRC_B: u8 = 0xCC;
+/// X11 pixel `0xAARRGGBB` for the reference colour.
+const GLYPH_SRC_PIXEL: u32 = 0xFF33_88CC;
+/// The dst background: a colour the reference is nowhere near, so
+/// "still the background" is unambiguous evidence of a drop.
+const GLYPH_DST_PIXEL: u32 = 0xFF00_00FF;
+
+/// A glyphset holding one 4x4 fully opaque A8 glyph at id 1.
+/// Same body shapes as `composite_glyphs_clip_intersects_picture`.
+fn opaque_4x4_glyphset(b: &mut KmsBackend) -> u32 {
+    let gs = b
+        .render_create_glyphset(None, yserver_protocol::x11::RENDER_FMT_A8)
+        .expect("render_create_glyphset")
+        .expect("Some(GlyphSetHandle)");
+    let mut add_body: Vec<u8> = Vec::new();
+    add_body.extend_from_slice(&1_u32.to_le_bytes()); // n
+    add_body.extend_from_slice(&1_u32.to_le_bytes()); // id = 1
+    add_body.extend_from_slice(&u16::to_le_bytes(4)); // width
+    add_body.extend_from_slice(&u16::to_le_bytes(4)); // height
+    add_body.extend_from_slice(&i16::to_le_bytes(0)); // x bearing
+    add_body.extend_from_slice(&i16::to_le_bytes(0)); // y bearing
+    add_body.extend_from_slice(&i16::to_le_bytes(4)); // x_off
+    add_body.extend_from_slice(&i16::to_le_bytes(0)); // y_off
+    add_body.extend_from_slice(&[0xFFu8; 16]); // 4x4, all opaque
+    b.render_add_glyphs(None, gs.as_raw(), &add_body)
+        .expect("render_add_glyphs");
+    gs.as_raw()
+}
+
+/// A `w`x`h` pixmap picture filled with `pixel`, at `repeat`
+/// (X RENDER `CPRepeat` value: 0 None, 1 Normal, 2 Pad, 3 Reflect).
+/// Returns `(backing pixmap xid, picture xid)` — the pixmap so a test
+/// can repaint it under the live picture, as Java does.
+fn repeating_pixmap_source(
+    b: &mut KmsBackend,
+    w: u16,
+    h: u16,
+    pixel: u32,
+    repeat: u32,
+) -> (u32, u32) {
+    let pix = b.create_pixmap(None, 32, w, h).expect("create_pixmap");
+    let pix_xid = pix.as_raw();
+    b.fill_rectangle(None, pix_xid, pixel, 0, 0, w, h)
+        .expect("fill_rectangle source");
+    let pic = b
+        .render_create_picture(
+            None,
+            AnyHandle::Pixmap(pix),
+            yserver_protocol::x11::RENDER_FMT_ARGB32,
+            0x0001, // CPRepeat
+            &repeat.to_le_bytes(),
+        )
+        .expect("render_create_picture source")
+        .expect("Some(PictureHandle)")
+        .as_raw();
+    (pix_xid, pic)
+}
+
+/// Stamp glyph id 1 at dst (0, 0) from `src_pic` onto a fresh 4x4
+/// background-filled pixmap and read the result back.
+fn paint_one_glyph(b: &mut KmsBackend, gs: u32, src_pic: u32, mask_fmt: u32) -> Vec<u8> {
+    let dst_pix = b.create_pixmap(None, 32, 4, 4).expect("create_pixmap dst");
+    let dst_xid = dst_pix.as_raw();
+    b.fill_rectangle(None, dst_xid, GLYPH_DST_PIXEL, 0, 0, 4, 4)
+        .expect("fill_rectangle dst");
+    let dst_pic = b
+        .render_create_picture(None, AnyHandle::Pixmap(dst_pix), 0, 0, &[])
+        .expect("render_create_picture dst")
+        .expect("Some(PictureHandle)");
+
+    // One element, one glyph, pen at (0, 0). Element header:
+    // count(u8) + 3 pad + dx(i16) + dy(i16); then 1 id byte padded
+    // to 4.
+    let mut items: Vec<u8> = Vec::new();
+    items.extend_from_slice(&[1u8, 0, 0, 0]);
+    items.extend_from_slice(&i16::to_le_bytes(0));
+    items.extend_from_slice(&i16::to_le_bytes(0));
+    items.extend_from_slice(&[1u8, 0, 0, 0]);
+
+    b.render_composite_glyphs(
+        None,
+        23, // CompositeGlyphs8
+        3,  // Over
+        src_pic,
+        dst_pic.as_raw(),
+        mask_fmt,
+        gs,
+        0,
+        0,
+        &items,
+        0,
+        0,
+    )
+    .expect("render_composite_glyphs");
+
+    b.get_image_pixels_for_tests(dst_xid, 2, 0, 0, 4, 4, !0)
+        .expect("get_image")
+        .expect("Some(bytes)")
+}
+
+/// Every pixel of a 4x4 readback equals `want` (wire BGRA).
+fn assert_all_pixels(out: &[u8], want: [u8; 4], what: &str) {
+    for y in 0..4usize {
+        for x in 0..4usize {
+            let off = (y * 4 + x) * 4;
+            assert_eq!(
+                &out[off..off + 4],
+                &want,
+                "{what}: pixel ({x},{y}) is {:?}, expected {want:?}",
+                &out[off..off + 4],
+            );
+        }
+    }
+}
+
+/// The fix: a 1x1 drawable source under `Normal` / `Pad` / `Reflect`
+/// paints exactly what the equivalent `CreateSolidFill` paints.
+///
+/// Only an absent Vulkan ICD may skip. Past that point every stage —
+/// seed allocation, painting, readback, the assertions — FAILS rather
+/// than skips: CI runs the ignored tests on lavapipe, so skipping on
+/// any error is how a live proof goes vacuous.
+#[test]
+#[ignore = "needs live Vulkan ICD"]
+fn uniform_drawable_glyph_source_paints_like_a_solid_fill() {
+    let mut b = match KmsBackend::for_tests_with_vk() {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("skipping: missing capability — no live Vulkan ICD: {e}");
+            return;
+        }
+    };
+    let gs = opaque_4x4_glyphset(&mut b);
+
+    // The reference: the same premultiplied colour as a SolidFill.
+    // 16-bit LE channels, r g b a, already premultiplied on the wire.
+    let solid = b
+        .render_create_solid_fill(
+            None,
+            [
+                GLYPH_SRC_R,
+                GLYPH_SRC_R,
+                GLYPH_SRC_G,
+                GLYPH_SRC_G,
+                GLYPH_SRC_B,
+                GLYPH_SRC_B,
+                0xFF,
+                0xFF,
+            ],
+        )
+        .expect("render_create_solid_fill")
+        .expect("Some(PictureHandle)")
+        .as_raw();
+    let reference = paint_one_glyph(&mut b, gs, solid, 0);
+    // Guard the oracle itself: an opaque glyph over the background
+    // must have replaced it, or "identical to the reference" would be
+    // satisfied by two equally broken runs.
+    assert_all_pixels(
+        &reference,
+        [GLYPH_SRC_B, GLYPH_SRC_G, GLYPH_SRC_R, 0xFF],
+        "SolidFill reference",
+    );
+
+    for (repeat, name) in [(1u32, "Normal"), (2, "Pad"), (3, "Reflect")] {
+        let (_, src) = repeating_pixmap_source(&mut b, 1, 1, GLYPH_SRC_PIXEL, repeat);
+        let out = paint_one_glyph(&mut b, gs, src, 0);
+        assert_eq!(
+            out, reference,
+            "a 1x1 drawable source under {name} must paint what the SolidFill painted"
+        );
+    }
+}
+
+/// The negatives. Under tier 1 none of these may paint: a test
+/// asserting otherwise would be asserting tier 2 (general drawable
+/// sources), which is future work with its own spec.
+#[test]
+#[ignore = "needs live Vulkan ICD"]
+fn a_non_uniform_or_unrepeated_drawable_glyph_source_still_drops() {
+    let mut b = match KmsBackend::for_tests_with_vk() {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("skipping: missing capability — no live Vulkan ICD: {e}");
+            return;
+        }
+    };
+    let gs = opaque_4x4_glyphset(&mut b);
+    let untouched = [
+        (GLYPH_DST_PIXEL & 0xff) as u8,
+        ((GLYPH_DST_PIXEL >> 8) & 0xff) as u8,
+        ((GLYPH_DST_PIXEL >> 16) & 0xff) as u8,
+        0xFF,
+    ];
+
+    // RepeatNone reads transparent outside its single pixel, so the
+    // correct result paints only the glyph area overlapping that
+    // pixel — not a uniform colour. Collapsing it would paint the
+    // whole glyph.
+    let (_, none_1x1) = repeating_pixmap_source(&mut b, 1, 1, GLYPH_SRC_PIXEL, 0);
+    assert_all_pixels(
+        &paint_one_glyph(&mut b, gs, none_1x1, 0),
+        untouched,
+        "a 1x1 source under RepeatNone",
+    );
+
+    // A sampled domain larger than one pixel is not one colour.
+    let (_, two_by_two) = repeating_pixmap_source(&mut b, 2, 2, GLYPH_SRC_PIXEL, 1);
+    assert_all_pixels(
+        &paint_one_glyph(&mut b, gs, two_by_two, 0),
+        untouched,
+        "a 2x2 source under RepeatNormal",
+    );
+
+    // `mask_format != 0` selects Xorg's accumulate-into-an-A8-mask
+    // branch, which `render_composite_glyphs` does not implement —
+    // it always takes the per-glyph shortcut. Admitting a new source
+    // class into that deviation would broaden wrong behaviour.
+    let (_, normal_1x1) = repeating_pixmap_source(&mut b, 1, 1, GLYPH_SRC_PIXEL, 1);
+    assert_all_pixels(
+        &paint_one_glyph(&mut b, gs, normal_1x1, yserver_protocol::x11::RENDER_FMT_A8),
+        untouched,
+        "a 1x1 source under RepeatNormal at a non-zero mask_format",
+    );
+}
+
+/// #137 invariant 4 — the colour is read per composite, never carried
+/// across a repaint of the source drawable.
+///
+/// This is the shape Java actually uses: it repaints the SAME 1x1
+/// pixmap to change text colour and reuses the picture. A value cached
+/// at `CreatePicture`, or keyed on anything that does not move when the
+/// pixels do, renders every subsequent run of text in the PREVIOUS
+/// colour — which converts a total, obvious failure into an
+/// intermittent wrong-colour one that is harder to notice and harder
+/// to report than the bug being fixed.
+///
+/// Written before any cache exists, so it passes trivially today. That
+/// is the point: it must be in place and green before a cache can make
+/// it fail.
+#[test]
+#[ignore = "needs live Vulkan ICD"]
+fn a_repainted_uniform_glyph_source_paints_the_new_colour() {
+    let mut b = match KmsBackend::for_tests_with_vk() {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("skipping: missing capability — no live Vulkan ICD: {e}");
+            return;
+        }
+    };
+    let gs = opaque_4x4_glyphset(&mut b);
+    let (src_pix, src_pic) = repeating_pixmap_source(&mut b, 1, 1, GLYPH_SRC_PIXEL, 1);
+
+    assert_all_pixels(
+        &paint_one_glyph(&mut b, gs, src_pic, 0),
+        [GLYPH_SRC_B, GLYPH_SRC_G, GLYPH_SRC_R, 0xFF],
+        "the first paint, at the source's original colour",
+    );
+
+    // Repaint the backing pixmap under the live picture. Opaque
+    // premultiplied R=0xEE G=0x11 B=0x55 — no channel shared with the
+    // first colour, so a stale read cannot look like a pass.
+    b.fill_rectangle(None, src_pix, 0xFFEE_1155, 0, 0, 1, 1)
+        .expect("fill_rectangle repaint of the source");
+    assert_all_pixels(
+        &paint_one_glyph(&mut b, gs, src_pic, 0),
+        [0x55, 0x11, 0xEE, 0xFF],
+        "the second paint must use the colour the source was repainted to",
+    );
+}
+
 /// Stage 3d v1-bug-fix gate (plan §3d): v1's
 /// `try_vk_render_composite_glyphs` reads but **ignores** the dst
 /// picture's clip (`kms::backend.rs:5313`); v2 must honour it via

--- a/crates/yserver/tests/render_acceptance.rs
+++ b/crates/yserver/tests/render_acceptance.rs
@@ -583,6 +583,213 @@ fn a_repainted_uniform_glyph_source_paints_the_new_colour() {
     );
 }
 
+// ── #137 step 5: the uniform-glyph-source colour cache ──────────
+//
+// The cache exists for ONE reason, and it is not the copy it avoids:
+// the pixel copy-out measured at 1.5 ms/s, which is noise. It is that
+// `get_image` must `close_open_frame(CloseReason::SyncWait)` before it
+// can wait on its readback fence, and on a text-heavy workload that
+// close was ~75% of ALL frame closes (`frame_builder_opens=237
+// closes=238`, `close_reasons[sync_wait=179]`), dragging
+// `ops/frame_avg` down to 1.6 — the batching
+// `composite_glyphs_via_frame_builder` exists to provide, gone.
+//
+// So the frame close is what these assert against. The staleness
+// regression above (`a_repainted_uniform_glyph_source_paints_the_new_colour`)
+// is the other half: it was written before any cache existed precisely
+// so the cache would be added against a test that fails when it is
+// wrong, and it must stay green.
+
+/// A fresh 4x4 background-filled destination and its picture, kept
+/// across several draws. `paint_one_glyph` allocates a new one per call
+/// and reads it back; these tests need the SAME destination across two
+/// draws with no readback in between, because a readback is itself a
+/// `SyncWait` frame close and would swamp the oracle.
+fn glyph_dst_picture(b: &mut KmsBackend) -> (u32, u32) {
+    let dst_pix = b.create_pixmap(None, 32, 4, 4).expect("create_pixmap dst");
+    let dst_xid = dst_pix.as_raw();
+    let dst_pic = b
+        .render_create_picture(None, AnyHandle::Pixmap(dst_pix), 0, 0, &[])
+        .expect("render_create_picture dst")
+        .expect("Some(PictureHandle)")
+        .as_raw();
+    (dst_xid, dst_pic)
+}
+
+/// One paint the shape a real client draws it: fill the destination,
+/// then stamp glyph id 1 over it from `src_pic`. No readback — the
+/// caller reads the counters instead.
+///
+/// The fill matters to the oracle. It is a paint op, so it leaves a
+/// frame OPEN; the glyph draw that follows either closes it (a
+/// source readback) or batches into it (a cache hit). Without a
+/// preceding paint there may be no open frame to close and "no close
+/// happened" would be vacuously true.
+fn fill_then_stamp_one_glyph(b: &mut KmsBackend, gs: u32, src_pic: u32, dst: (u32, u32)) {
+    let (dst_xid, dst_pic) = dst;
+    b.fill_rectangle(None, dst_xid, GLYPH_DST_PIXEL, 0, 0, 4, 4)
+        .expect("fill_rectangle dst");
+    let mut items: Vec<u8> = Vec::new();
+    items.extend_from_slice(&[1u8, 0, 0, 0]);
+    items.extend_from_slice(&i16::to_le_bytes(0));
+    items.extend_from_slice(&i16::to_le_bytes(0));
+    items.extend_from_slice(&[1u8, 0, 0, 0]);
+    // 23 = CompositeGlyphs8, 3 = Over, mask_format 0 = tier 1.
+    b.render_composite_glyphs(None, 23, 3, src_pic, dst_pic, 0, gs, 0, 0, &items, 0, 0)
+        .expect("render_composite_glyphs");
+}
+
+/// **The whole justification, asserted rather than assumed.** Two glyph
+/// draws from the same unmodified 1x1 source: the first reads the pixel
+/// and closes the open frame with `CloseReason::SyncWait`; the second
+/// hits the cache, does not read, and must therefore leave the frame
+/// open.
+///
+/// The cold draw's `>= 1` is not decoration — it guards the oracle. If
+/// no frame were open at read time the warm assertion would hold
+/// vacuously, and this test would claim a win it never measured.
+#[test]
+#[ignore = "needs live Vulkan ICD"]
+fn a_cached_uniform_glyph_source_skips_the_sync_wait_frame_close() {
+    let mut b = match KmsBackend::for_tests_with_vk() {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("skipping: missing capability — no live Vulkan ICD: {e}");
+            return;
+        }
+    };
+    let gs = opaque_4x4_glyphset(&mut b);
+    let (src_pix, src_pic) = repeating_pixmap_source(&mut b, 1, 1, GLYPH_SRC_PIXEL, 1);
+    let dst = glyph_dst_picture(&mut b);
+
+    let base = b.telemetry_close_reason_sync_wait_for_tests();
+    fill_then_stamp_one_glyph(&mut b, gs, src_pic, dst);
+    let cold = b.telemetry_close_reason_sync_wait_for_tests();
+    assert!(
+        cold > base,
+        "oracle guard: the COLD draw must read the source pixel and close \
+         the open frame with SyncWait — it went {base} -> {cold}, so \
+         'the warm draw closed nothing' would assert nothing"
+    );
+
+    fill_then_stamp_one_glyph(&mut b, gs, src_pic, dst);
+    let warm = b.telemetry_close_reason_sync_wait_for_tests();
+    assert_eq!(
+        warm, cold,
+        "a cache hit must skip get_image and therefore the SyncWait \
+         frame close: {cold} -> {warm}"
+    );
+
+    // And the miss returns the moment the client recolours the source,
+    // which is the correctness price of the cache being version-keyed.
+    // Same counter, so this cannot be satisfied by a cache that simply
+    // never reads again.
+    b.fill_rectangle(None, src_pix, 0xFFEE_1155, 0, 0, 1, 1)
+        .expect("fill_rectangle repaint of the source");
+    let after_repaint_base = b.telemetry_close_reason_sync_wait_for_tests();
+    fill_then_stamp_one_glyph(&mut b, gs, src_pic, dst);
+    let recoloured = b.telemetry_close_reason_sync_wait_for_tests();
+    assert!(
+        recoloured > after_repaint_base,
+        "a repainted source must MISS and read again: \
+         {after_repaint_base} -> {recoloured}"
+    );
+}
+
+/// The hit-rate telemetry, which is what makes the cache's
+/// effectiveness visible in production and a client that defeats it
+/// detectable. A repeated same-colour draw increments would-hit; a
+/// recolour between draws increments would-miss.
+#[test]
+#[ignore = "needs live Vulkan ICD"]
+fn the_uniform_glyph_source_cache_counters_report_hits_and_misses() {
+    let mut b = match KmsBackend::for_tests_with_vk() {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("skipping: missing capability — no live Vulkan ICD: {e}");
+            return;
+        }
+    };
+    let gs = opaque_4x4_glyphset(&mut b);
+    let (src_pix, src_pic) = repeating_pixmap_source(&mut b, 1, 1, GLYPH_SRC_PIXEL, 1);
+    let dst = glyph_dst_picture(&mut b);
+
+    let counters = |b: &KmsBackend| {
+        (
+            b.telemetry().lifetime.glyph_src_cache_hit,
+            b.telemetry().lifetime.glyph_src_cache_miss,
+        )
+    };
+
+    // Cold: one miss, no hit.
+    let (h0, m0) = counters(&b);
+    fill_then_stamp_one_glyph(&mut b, gs, src_pic, dst);
+    let (h1, m1) = counters(&b);
+    assert_eq!((h1 - h0, m1 - m0), (0, 1), "the cold draw must miss");
+
+    // Repeated at the same colour: one hit, no miss.
+    fill_then_stamp_one_glyph(&mut b, gs, src_pic, dst);
+    let (h2, m2) = counters(&b);
+    assert_eq!((h2 - h1, m2 - m1), (1, 0), "a repeat draw must hit");
+
+    // Recoloured between draws: one miss, no hit. This is Java's
+    // pattern, and it is the case the counters exist to make visible.
+    b.fill_rectangle(None, src_pix, 0xFFEE_1155, 0, 0, 1, 1)
+        .expect("fill_rectangle repaint of the source");
+    fill_then_stamp_one_glyph(&mut b, gs, src_pic, dst);
+    let (h3, m3) = counters(&b);
+    assert_eq!(
+        (h3 - h2, m3 - m2),
+        (0, 1),
+        "a recolour between draws must miss"
+    );
+}
+
+/// The two key collisions, end to end on the live path — the pure
+/// versions are in `kms::backend::uniform_glyph_source_cache_tests`.
+///
+/// Two independently created 1x1 pixmaps, each written exactly once,
+/// sit at the SAME `content_version`. A cache keyed on the version
+/// alone hands the second one the first one's colour, and the only
+/// visible symptom is the wrong ink.
+#[test]
+#[ignore = "needs live Vulkan ICD"]
+fn two_uniform_glyph_sources_at_the_same_content_version_keep_their_own_colours() {
+    let mut b = match KmsBackend::for_tests_with_vk() {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("skipping: missing capability — no live Vulkan ICD: {e}");
+            return;
+        }
+    };
+    let gs = opaque_4x4_glyphset(&mut b);
+
+    // Same construction, same number of writes, so the same
+    // content_version — and no channel shared between the colours, so a
+    // cross-hit cannot look like a pass.
+    let (_, first) = repeating_pixmap_source(&mut b, 1, 1, GLYPH_SRC_PIXEL, 1);
+    let (_, second) = repeating_pixmap_source(&mut b, 1, 1, 0xFFEE_1155, 1);
+
+    assert_all_pixels(
+        &paint_one_glyph(&mut b, gs, first, 0),
+        [GLYPH_SRC_B, GLYPH_SRC_G, GLYPH_SRC_R, 0xFF],
+        "the first source's own colour",
+    );
+    assert_all_pixels(
+        &paint_one_glyph(&mut b, gs, second, 0),
+        [0x55, 0x11, 0xEE, 0xFF],
+        "a DIFFERENT drawable at the same content_version must not \
+         inherit the first source's cached colour",
+    );
+    // And back again, so this cannot pass by the cache simply never
+    // hitting in one direction.
+    assert_all_pixels(
+        &paint_one_glyph(&mut b, gs, first, 0),
+        [GLYPH_SRC_B, GLYPH_SRC_G, GLYPH_SRC_R, 0xFF],
+        "the first source again, after the second was cached",
+    );
+}
+
 /// Stage 3d v1-bug-fix gate (plan §3d): v1's
 /// `try_vk_render_composite_glyphs` reads but **ignores** the dst
 /// picture's clip (`kms::backend.rs:5313`); v2 must honour it via

--- a/crates/yserver/tests/render_acceptance.rs
+++ b/crates/yserver/tests/render_acceptance.rs
@@ -790,6 +790,361 @@ fn two_uniform_glyph_sources_at_the_same_content_version_keep_their_own_colours(
     );
 }
 
+// ── #137 stage 3: an ARGB32 (subpixel-AA) glyph, end to end ─────
+//
+// Two changes meet only here, at runtime:
+//
+//   * an `ARGB32` glyph keeps its four channels through
+//     `parse_add_glyphs`, and the engine reduces them to ONE A8
+//     coverage plane on the atlas-miss branch — the mean of logical
+//     R, G, B, `(r + g + b + 1) / 3`;
+//   * `AtlasEntry.w` was split into `packed_w` (the atlas
+//     footprint) and `logical_w` (the glyph's own size).
+//
+// `ARGB32` is the first format whose converted A8 length (`w * h`)
+// differs from its source length (`4 * w * h`) while both widths
+// are still assigned from the same variable, so it is the first
+// case where confusing the two is reachable at all.
+//
+// Neither existing proof crosses that seam: the reduction is
+// pinned as a pure function over wire bytes with no atlas and no
+// GPU, and the `packed_w` / `logical_w` split is pinned through
+// `image_text` over synthetic A8 entries. Nothing anywhere runs an
+// `ARGB32` glyphset through `render_composite_glyphs`.
+//
+// The fixture mimics a real subpixel glyph as measured on OpenJDK
+// 25: **alpha 255 on every pixel**, all the coverage in R, G and B.
+// So a regression to reading the alpha byte paints every pixel of
+// the glyph box at full coverage — a solid block, which is exactly
+// the reported defect — and assertion 1 below fails.
+
+/// The ARGB32 fixture glyph: 8 wide so `w / 4` (2) and `4 * w`
+/// (32) are both distinguishable from `w` in the painted extent,
+/// and 4 high so a transposed read cannot fit.
+const ARGB32_GLYPH_W: u16 = 8;
+const ARGB32_GLYPH_H: u16 = 4;
+
+/// One column of the fixture: wire `[B, G, R]` (alpha is 255 on
+/// every pixel) and the A8 coverage the reduction must produce.
+///
+/// The coverages are hand-computed from `(r + g + b + 1) / 3` and
+/// written out, not read back from the function under test — a
+/// table derived from the code it checks asserts nothing.
+///
+/// The three channels of a column are mutually distinct, so taking
+/// any single channel, or the mean of wire bytes 1..=3 (`g, r, a` —
+/// the realistic off-by-one) disagrees with the expected coverage
+/// on most columns. Column 0 is fully zero and column 7 is
+/// saturated, so the ramp spans the whole range.
+const ARGB32_RAMP: [([u8; 3], u8); 8] = [
+    //  B     G     R      cov    r+g+b -> (sum + 1) / 3
+    ([0x00, 0x00, 0x00], 0x00), //   0 ->   0
+    ([0x10, 0x20, 0x30], 0x20), //  96 ->  32
+    ([0x20, 0x40, 0x60], 0x40), // 192 ->  64
+    ([0x50, 0x78, 0xA0], 0x78), // 360 -> 120
+    ([0x40, 0x80, 0xC0], 0x80), // 384 -> 128
+    ([0x50, 0xA0, 0xF0], 0xA0), // 480 -> 160
+    ([0x80, 0xC0, 0xFF], 0xC0), // 575 -> 192
+    ([0xFE, 0xFF, 0xFF], 0xFF), // 764 -> 255
+];
+
+/// The one column whose blended result is exactly representable, so
+/// it can be asserted byte-for-byte rather than within a rounding
+/// slack. At `cov = 120` each of `0xCC * 120`, `0x88 * 120` and
+/// `0x33 * 120` — and `0xFF * (255 - 120)` — is a whole multiple of
+/// 255, so the ideal `Over` result needs no rounding at all.
+const ARGB32_EXACT_COL: usize = 3;
+
+/// A glyphset in `ARGB32` holding two `8x4` glyphs, both with alpha
+/// `0xFF` on every pixel and `x_off = 8`: id 1 is the coverage ramp
+/// of `ARGB32_RAMP`, id 2 is saturated (`R = G = B = 0xFF`, so it
+/// reduces to coverage `0xFF`).
+///
+/// Id 2 exists to be id 1's RIGHT-HAND NEIGHBOUR in the atlas —
+/// see `intern_argb32_neighbour`.
+///
+/// Rows are dense at `w * 4` bytes with no row padding, in memory
+/// order `[B, G, R, A]` — X RENDER `PICT_a8r8g8b8` is a
+/// little-endian CARD32 with alpha at bits 24-31, so blue is the
+/// low byte. Same body shape as `opaque_4x4_glyphset`.
+fn argb32_ramp_glyphset(b: &mut KmsBackend) -> u32 {
+    let gs = b
+        .render_create_glyphset(None, yserver_protocol::x11::RENDER_FMT_ARGB32)
+        .expect("render_create_glyphset")
+        .expect("Some(GlyphSetHandle)");
+    let mut add_body: Vec<u8> = Vec::new();
+    add_body.extend_from_slice(&2_u32.to_le_bytes()); // n
+    add_body.extend_from_slice(&1_u32.to_le_bytes()); // id = 1, the ramp
+    add_body.extend_from_slice(&2_u32.to_le_bytes()); // id = 2, saturated
+    for _ in 0..2 {
+        add_body.extend_from_slice(&u16::to_le_bytes(ARGB32_GLYPH_W)); // width
+        add_body.extend_from_slice(&u16::to_le_bytes(ARGB32_GLYPH_H)); // height
+        add_body.extend_from_slice(&i16::to_le_bytes(0)); // x bearing
+        add_body.extend_from_slice(&i16::to_le_bytes(0)); // y bearing
+        add_body.extend_from_slice(&i16::to_le_bytes(ARGB32_GLYPH_W as i16)); // x_off
+        add_body.extend_from_slice(&i16::to_le_bytes(0)); // y_off
+    }
+    for _ in 0..ARGB32_GLYPH_H {
+        for (wire, _) in ARGB32_RAMP {
+            add_body.extend_from_slice(&[wire[0], wire[1], wire[2], 0xFF]);
+        }
+    }
+    for _ in 0..ARGB32_GLYPH_H {
+        for _ in 0..ARGB32_GLYPH_W {
+            add_body.extend_from_slice(&[0xFF; 4]);
+        }
+    }
+    b.render_add_glyphs(None, gs.as_raw(), &add_body)
+        .expect("render_add_glyphs");
+    gs.as_raw()
+}
+
+/// Intern glyph 1 and then glyph 2, in that order, so the saturated
+/// glyph 2 lands immediately to the RIGHT of the ramp in the shared
+/// R8 atlas: the shelf packer places same-height glyphs edge to
+/// edge with no gutter.
+///
+/// Without that neighbour the "not `4 * w` wide" half of the extent
+/// assertion has no teeth: an over-wide quad would sample
+/// never-written atlas pixels, read coverage 0 there, and leave the
+/// dst looking correct.
+///
+/// What the mutations actually showed, recorded so nobody re-derives
+/// it: `logical_w = 4 * g.w` at the upload site alone does NOT reach
+/// the dst either way, because `render_composite_glyphs` scissors to
+/// a glyph union computed from the PROTOCOL width — that clip, not
+/// the assertion, is what contains an entry-only width leak. The
+/// extent assertion bites when the union widens too (union at
+/// `4 * p.w` plus the over-wide quad paints this neighbour's
+/// saturated coverage into column 8, and the test fails), and it
+/// bites on its own for the opposite leak, `logical_w = g.w / 4`,
+/// which paints only two columns.
+fn intern_argb32_neighbour(b: &mut KmsBackend, gs: u32, src_pic: u32) {
+    let scratch = b.create_pixmap(None, 32, 32, 4).expect("create_pixmap");
+    let scratch_xid = scratch.as_raw();
+    b.fill_rectangle(None, scratch_xid, GLYPH_DST_PIXEL, 0, 0, 32, 4)
+        .expect("fill_rectangle scratch");
+    let scratch_pic = b
+        .render_create_picture(None, AnyHandle::Pixmap(scratch), 0, 0, &[])
+        .expect("render_create_picture scratch")
+        .expect("Some(PictureHandle)");
+    // One element, two glyphs: ids 1 then 2, the pen advancing by
+    // `x_off`. Id bytes are padded to a 4-byte boundary.
+    let mut items: Vec<u8> = Vec::new();
+    items.extend_from_slice(&[2u8, 0, 0, 0]);
+    items.extend_from_slice(&i16::to_le_bytes(0));
+    items.extend_from_slice(&i16::to_le_bytes(0));
+    items.extend_from_slice(&[1u8, 2, 0, 0]);
+    b.render_composite_glyphs(
+        None,
+        23,
+        3,
+        src_pic,
+        scratch_pic.as_raw(),
+        0,
+        gs,
+        0,
+        0,
+        &items,
+        0,
+        0,
+    )
+    .expect("render_composite_glyphs warm-up");
+}
+
+/// Stamp glyph id 1 at dst (0, 0) from `src_pic` onto a fresh
+/// `16x4` background-filled pixmap and read the result back. The
+/// dst is twice the glyph's width so both "the glyph landed `4w`
+/// wide" and "the glyph landed `w / 4` wide" are visible as painted
+/// or unpainted columns rather than as clipping.
+///
+/// `mask_format = 0`, which is what Java sends.
+fn paint_ramp_glyph(b: &mut KmsBackend, gs: u32, src_pic: u32) -> Vec<u8> {
+    let dst_pix = b.create_pixmap(None, 32, 16, 4).expect("create_pixmap dst");
+    let dst_xid = dst_pix.as_raw();
+    b.fill_rectangle(None, dst_xid, GLYPH_DST_PIXEL, 0, 0, 16, 4)
+        .expect("fill_rectangle dst");
+    let dst_pic = b
+        .render_create_picture(None, AnyHandle::Pixmap(dst_pix), 0, 0, &[])
+        .expect("render_create_picture dst")
+        .expect("Some(PictureHandle)");
+
+    // One element, one glyph, pen at (0, 0) — same wire shape as
+    // `paint_one_glyph`.
+    let mut items: Vec<u8> = Vec::new();
+    items.extend_from_slice(&[1u8, 0, 0, 0]);
+    items.extend_from_slice(&i16::to_le_bytes(0));
+    items.extend_from_slice(&i16::to_le_bytes(0));
+    items.extend_from_slice(&[1u8, 0, 0, 0]);
+
+    b.render_composite_glyphs(
+        None,
+        23, // CompositeGlyphs8
+        3,  // Over
+        src_pic,
+        dst_pic.as_raw(),
+        0, // mask_format 0 — the per-glyph branch Java takes
+        gs,
+        0,
+        0,
+        &items,
+        0,
+        0,
+    )
+    .expect("render_composite_glyphs");
+
+    b.get_image_pixels_for_tests(dst_xid, 2, 0, 0, 16, 4, !0)
+        .expect("get_image")
+        .expect("Some(bytes)")
+}
+
+/// `Over` with an opaque premultiplied source through an A8
+/// coverage: `dst = src * cov + dst * (1 - cov)` per channel,
+/// rounded to nearest.
+fn over_at_coverage(src: u8, dst: u8, cov: u8) -> u8 {
+    let cov = u32::from(cov);
+    let n = u32::from(src) * cov + u32::from(dst) * (255 - cov);
+    u8::try_from((n + 127) / 255).expect("a weighted mean of two bytes is a byte")
+}
+
+/// Stage 3: an `ARGB32` glyphset paints **antialiased coverage at
+/// its logical width**, through the engine.
+///
+/// The three things asserted, in order:
+///
+/// 1. the painted columns show VARYING coverage — the regression
+///    guard, because reading the alpha byte again would paint a
+///    uniform block;
+/// 2. the glyph lands `w` pixels wide — not `4 * w` (the packed
+///    atlas footprint leaking into the geometry) and not `w / 4`
+///    (the converted length leaking into the width); the columns
+///    just past `w` must still be untouched background;
+/// 3. one column's exact bytes, computed from `(r + g + b + 1) / 3`
+///    and the source colour under `Over`, so the reduction is
+///    pinned end to end rather than merely "something varied".
+///
+/// The source is the asymmetric reference colour, so a channel
+/// mistake in the SOURCE path cannot hide a coverage mistake — and
+/// note the deliberate blue background: the glyph's blue coverage
+/// column is the one channel the background also has, so an R/B
+/// confusion anywhere moves a value.
+///
+/// Only an absent Vulkan ICD may skip; past that point every stage
+/// FAILS rather than skips.
+#[test]
+#[ignore = "needs live Vulkan ICD"]
+fn an_argb32_glyph_paints_varying_coverage_at_its_logical_width() {
+    let mut b = match KmsBackend::for_tests_with_vk() {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("skipping: missing capability — no live Vulkan ICD: {e}");
+            return;
+        }
+    };
+    let gs = argb32_ramp_glyphset(&mut b);
+    let (_, src) = repeating_pixmap_source(&mut b, 1, 1, GLYPH_SRC_PIXEL, 1);
+    intern_argb32_neighbour(&mut b, gs, src);
+    let out = paint_ramp_glyph(&mut b, gs, src);
+
+    let background = [
+        (GLYPH_DST_PIXEL & 0xff) as u8,
+        ((GLYPH_DST_PIXEL >> 8) & 0xff) as u8,
+        ((GLYPH_DST_PIXEL >> 16) & 0xff) as u8,
+        0xFF,
+    ];
+    let px = |x: usize, y: usize| -> [u8; 4] {
+        let off = (y * 16 + x) * 4;
+        [out[off], out[off + 1], out[off + 2], out[off + 3]]
+    };
+
+    // ── (3) the exact value, and every other column within the
+    // one-LSB slack a float blend rounded into UNORM8 may carry.
+    for y in 0..ARGB32_GLYPH_H as usize {
+        for (x, (_, cov)) in ARGB32_RAMP.iter().enumerate() {
+            let want = [
+                over_at_coverage(GLYPH_SRC_B, background[0], *cov),
+                over_at_coverage(GLYPH_SRC_G, background[1], *cov),
+                over_at_coverage(GLYPH_SRC_R, background[2], *cov),
+                0xFF,
+            ];
+            let got = px(x, y);
+            if x == ARGB32_EXACT_COL {
+                assert_eq!(
+                    got, want,
+                    "column {x} (coverage {cov:#04x}) must be exactly the \
+                     reduced-coverage Over result",
+                );
+                continue;
+            }
+            for (c, (g, w)) in got.iter().zip(want.iter()).enumerate() {
+                assert!(
+                    g.abs_diff(*w) <= 1,
+                    "({x},{y}) channel {c} is {g}, expected {w} for coverage \
+                     {cov:#04x} — whole pixel {got:?} vs {want:?}",
+                );
+            }
+        }
+    }
+
+    // ── (1) varying, not a block. The alpha byte is 255 on every
+    // pixel of this glyph, so reading it paints all 8 columns the
+    // full source colour: one distinct value, and equal to the
+    // source.
+    let mut distinct: Vec<[u8; 4]> = Vec::new();
+    for x in 0..ARGB32_GLYPH_W as usize {
+        let v = px(x, 0);
+        if !distinct.contains(&v) {
+            distinct.push(v);
+        }
+    }
+    assert!(
+        distinct.len() >= 6,
+        "the glyph painted only {} distinct values across {ARGB32_GLYPH_W} \
+         ramped columns ({distinct:?}) — a solid block means the glyph's \
+         ALPHA byte is being read again instead of its R, G, B coverage",
+        distinct.len(),
+    );
+    let full_source = [GLYPH_SRC_B, GLYPH_SRC_G, GLYPH_SRC_R, 0xFF];
+    for (x, (_, cov)) in ARGB32_RAMP
+        .iter()
+        .enumerate()
+        .take(ARGB32_RAMP.len() - 1)
+        .skip(1)
+    {
+        assert_ne!(
+            px(x, 0),
+            full_source,
+            "column {x} painted at FULL coverage; its ramped coverage is \
+             {cov:#04x}",
+        );
+    }
+
+    // ── (2) the extent is `w`, not `4 * w` and not `w / 4`.
+    //
+    // The last column is saturated coverage, so the glyph's right
+    // edge is the exact source colour: a `w / 4`-wide glyph would
+    // leave it at the background.
+    assert_eq!(
+        px(ARGB32_GLYPH_W as usize - 1, 0),
+        full_source,
+        "the glyph's last column must be painted at full coverage — a glyph \
+         laid down `w / 4` wide never reaches it",
+    );
+    // And nothing past `w` was touched: a glyph laid down `4 * w`
+    // wide, or one whose atlas UV span came from `packed_w`, paints
+    // into these columns.
+    for y in 0..ARGB32_GLYPH_H as usize {
+        for x in ARGB32_GLYPH_W as usize..16 {
+            assert_eq!(
+                px(x, y),
+                background,
+                "({x},{y}) is past the glyph's logical width and must be \
+                 untouched background",
+            );
+        }
+    }
+}
+
 /// Stage 3d v1-bug-fix gate (plan §3d): v1's
 /// `try_vk_render_composite_glyphs` reads but **ignores** the dst
 /// picture's clip (`kms::backend.rs:5313`); v2 must honour it via

--- a/crates/yserver/tests/render_acceptance.rs
+++ b/crates/yserver/tests/render_acceptance.rs
@@ -790,33 +790,36 @@ fn two_uniform_glyph_sources_at_the_same_content_version_keep_their_own_colours(
     );
 }
 
-// ── #137 stage 3: an ARGB32 (subpixel-AA) glyph, end to end ─────
+// ── #137: an ARGB32 (subpixel-AA) glyph, end to end ─────────────
 //
-// Two changes meet only here, at runtime:
+// This is where every part of the component-alpha path meets, at
+// runtime, and the only place several of them are observable at all:
 //
 //   * an `ARGB32` glyph keeps its four channels through
-//     `parse_add_glyphs`, and the engine reduces them to ONE A8
-//     coverage plane on the atlas-miss branch — the mean of logical
-//     R, G, B, `(r + g + b + 1) / 3`;
-//   * `AtlasEntry.w` was split into `packed_w` (the atlas
-//     footprint) and `logical_w` (the glyph's own size).
-//
-// `ARGB32` is the first format whose converted A8 length (`w * h`)
-// differs from its source length (`4 * w * h`) while both widths
-// are still assigned from the same variable, so it is the first
-// case where confusing the two is reachable at all.
-//
-// Neither existing proof crosses that seam: the reduction is
-// pinned as a pure function over wire bytes with no atlas and no
-// GPU, and the `packed_w` / `logical_w` split is pinned through
-// `image_text` over synthetic A8 entries. Nothing anywhere runs an
-// `ARGB32` glyphset through `render_composite_glyphs`.
+//     `parse_add_glyphs`, and the engine packs them as FOUR
+//     horizontally adjacent atlas coverage planes (logical R, G, B,
+//     A) at packed width `4 * w`;
+//   * the fragment shader fetches all four and emits the per-channel
+//     alpha factor to output INDEX 1, which the pipeline's `SRC1_*`
+//     dual-source blend factors consume;
+//   * `AtlasEntry.packed_w` (the atlas footprint) and `logical_w`
+//     (the glyph's own size) really differ here — this is the first
+//     and only path where they do, so it is the only place confusing
+//     them is reachable.
 //
 // The fixture mimics a real subpixel glyph as measured on OpenJDK
 // 25: **alpha 255 on every pixel**, all the coverage in R, G and B.
 // So a regression to reading the alpha byte paints every pixel of
 // the glyph box at full coverage — a solid block, which is exactly
 // the reported defect — and assertion 1 below fails.
+//
+// The channel values of a column are mutually distinct, which is
+// what separates a real component-alpha composite from a convincing
+// approximation of one: the grayscale reduction gives all three
+// channels the SAME coverage (their mean), so its result and this
+// one disagree on every column but the two flat ones. Assertion 3
+// checks the exact per-channel values and assertion 4 checks that
+// they are not the grayscale ones.
 
 /// The ARGB32 fixture glyph: 8 wide so `w / 4` (2) and `4 * w`
 /// (32) are both distinguishable from `w` in the painted extent,
@@ -825,17 +828,23 @@ const ARGB32_GLYPH_W: u16 = 8;
 const ARGB32_GLYPH_H: u16 = 4;
 
 /// One column of the fixture: wire `[B, G, R]` (alpha is 255 on
-/// every pixel) and the A8 coverage the reduction must produce.
+/// every pixel) and the A8 coverage the GRAYSCALE reduction would
+/// produce from it.
 ///
-/// The coverages are hand-computed from `(r + g + b + 1) / 3` and
-/// written out, not read back from the function under test — a
-/// table derived from the code it checks asserts nothing.
+/// Under component alpha the three wire bytes ARE the three
+/// channels' coverages — blue's coverage is `wire[0]`, green's
+/// `wire[1]`, red's `wire[2]` — and the trailing number is only used
+/// as the counter-oracle: the value the `dualSrcBlend`-less fallback
+/// would give all three channels instead. It is hand-computed from
+/// `(r + g + b + 1) / 3` and written out, not read back from the
+/// function under test — a table derived from the code it checks
+/// asserts nothing.
 ///
-/// The three channels of a column are mutually distinct, so taking
-/// any single channel, or the mean of wire bytes 1..=3 (`g, r, a` —
-/// the realistic off-by-one) disagrees with the expected coverage
-/// on most columns. Column 0 is fully zero and column 7 is
-/// saturated, so the ramp spans the whole range.
+/// The three channels of a column are mutually distinct, which is
+/// what makes an R↔B swap, a first-plane-only sample and a
+/// grayscale mean each land on a different answer. Column 0 is fully
+/// zero and column 7 is saturated, so the ramp spans the whole
+/// range.
 const ARGB32_RAMP: [([u8; 3], u8); 8] = [
     //  B     G     R      cov    r+g+b -> (sum + 1) / 3
     ([0x00, 0x00, 0x00], 0x00), //   0 ->   0
@@ -848,11 +857,15 @@ const ARGB32_RAMP: [([u8; 3], u8); 8] = [
     ([0xFE, 0xFF, 0xFF], 0xFF), // 764 -> 255
 ];
 
-/// The one column whose blended result is exactly representable, so
-/// it can be asserted byte-for-byte rather than within a rounding
-/// slack. At `cov = 120` each of `0xCC * 120`, `0x88 * 120` and
-/// `0x33 * 120` — and `0xFF * (255 - 120)` — is a whole multiple of
-/// 255, so the ideal `Over` result needs no rounding at all.
+/// The one column whose blended result is exactly representable on
+/// ALL THREE channels under component alpha, so it can be asserted
+/// byte-for-byte rather than within a rounding slack.
+///
+/// Column 3 is `B = 0x50 (80)`, `G = 0x78 (120)`, `R = 0xA0 (160)`.
+/// Each channel's `Over` numerator is a whole multiple of 255:
+/// blue's `204*80 + 255*175`, green's `136*120` (its `dst` is 0) and
+/// red's `51*160`. So the ideal result needs no rounding at all —
+/// 239, 64, 32.
 const ARGB32_EXACT_COL: usize = 3;
 
 /// A glyphset in `ARGB32` holding two `8x4` glyphs, both with alpha
@@ -1007,21 +1020,39 @@ fn over_at_coverage(src: u8, dst: u8, cov: u8) -> u8 {
     u8::try_from((n + 127) / 255).expect("a weighted mean of two bytes is a byte")
 }
 
-/// Stage 3: an `ARGB32` glyphset paints **antialiased coverage at
-/// its logical width**, through the engine.
+/// **The test the whole component-alpha step exists to pass.** An
+/// `ARGB32` glyphset paints **per-channel coverage at its logical
+/// width**, through the engine.
 ///
-/// The three things asserted, in order:
+/// Under X RENDER component alpha, with an opaque premultiplied
+/// source and `Over`, each channel blends with its OWN coverage:
 ///
-/// 1. the painted columns show VARYING coverage — the regression
-///    guard, because reading the alpha byte again would paint a
-///    uniform block;
+/// ```text
+/// dst.C = fg.C * cov.C + dst.C * (1 - fg.a * cov.C)
+/// ```
+///
+/// and `cov.C` is the wire byte of that channel — blue's from
+/// `wire[0]`, green's from `wire[1]`, red's from `wire[2]`, because
+/// `PICT_a8r8g8b8` is a little-endian CARD32 with blue in the LOW
+/// byte. The four things asserted, in order:
+///
+/// 1. the painted columns show VARYING coverage — the original
+///    regression guard, because reading the alpha byte again would
+///    paint a uniform block;
 /// 2. the glyph lands `w` pixels wide — not `4 * w` (the packed
-///    atlas footprint leaking into the geometry) and not `w / 4`
-///    (the converted length leaking into the width); the columns
-///    just past `w` must still be untouched background;
-/// 3. one column's exact bytes, computed from `(r + g + b + 1) / 3`
-///    and the source colour under `Over`, so the reduction is
-///    pinned end to end rather than merely "something varied".
+///    atlas footprint leaking into the geometry) and not `w / 4`;
+///    the columns just past `w` must still be untouched background;
+/// 3. **every column's exact per-channel bytes**, from the equation
+///    above. Not "the channels differ": a red/blue swap satisfies
+///    that, and it is the single most likely mistake in the pack. The
+///    one column whose ideal result needs no rounding at all is
+///    asserted byte-for-byte; the rest carry one LSB of slack for a
+///    float blend rounded into UNORM8.
+/// 4. and that the result is **not** what the grayscale reduction
+///    would give. A `dualSrcBlend`-less device paints all three
+///    channels with the mean of the three wire bytes; that is a
+///    perfectly plausible-looking antialiased glyph, and only this
+///    assertion separates it from a real subpixel composite.
 ///
 /// The source is the asymmetric reference colour, so a channel
 /// mistake in the SOURCE path cannot hide a coverage mistake — and
@@ -1057,34 +1088,81 @@ fn an_argb32_glyph_paints_varying_coverage_at_its_logical_width() {
         [out[off], out[off + 1], out[off + 2], out[off + 3]]
     };
 
-    // ── (3) the exact value, and every other column within the
-    // one-LSB slack a float blend rounded into UNORM8 may carry.
+    // ── (3) the exact per-channel values, and (4) that they are
+    // not the grayscale ones.
+    //
+    // `wire` is `[B, G, R]`; the readback is BGRA. So channel 0 gets
+    // the glyph's blue coverage, channel 1 its green and channel 2
+    // its red — a swap in the pack moves column 1's blue from 252 to
+    // 248 and its red from 10 to 3.
+    //
+    // The alpha channel stays 0xFF: this destination is opaque, so
+    // `cov_a + dst.a * (1 - cov_a)` is 1 whatever the glyph's alpha
+    // is. `cov_a` is pinned instead by
+    // `a_component_alpha_glyph_samples_all_four_planes_at_the_plane_stride`,
+    // over a TRANSPARENT destination where it survives the blend.
     for y in 0..ARGB32_GLYPH_H as usize {
-        for (x, (_, cov)) in ARGB32_RAMP.iter().enumerate() {
+        for (x, (wire, mean)) in ARGB32_RAMP.iter().enumerate() {
             let want = [
-                over_at_coverage(GLYPH_SRC_B, background[0], *cov),
-                over_at_coverage(GLYPH_SRC_G, background[1], *cov),
-                over_at_coverage(GLYPH_SRC_R, background[2], *cov),
+                over_at_coverage(GLYPH_SRC_B, background[0], wire[0]),
+                over_at_coverage(GLYPH_SRC_G, background[1], wire[1]),
+                over_at_coverage(GLYPH_SRC_R, background[2], wire[2]),
                 0xFF,
             ];
             let got = px(x, y);
             if x == ARGB32_EXACT_COL {
                 assert_eq!(
                     got, want,
-                    "column {x} (coverage {cov:#04x}) must be exactly the \
-                     reduced-coverage Over result",
+                    "column {x} (per-channel coverage {wire:02x?}) must be exactly \
+                     the component-alpha Over result",
                 );
-                continue;
+            } else {
+                for (c, (g, w)) in got.iter().zip(want.iter()).enumerate() {
+                    assert!(
+                        g.abs_diff(*w) <= 1,
+                        "({x},{y}) channel {c} is {g}, expected {w} for per-channel \
+                         coverage {wire:02x?} — whole pixel {got:?} vs {want:?}",
+                    );
+                }
             }
-            for (c, (g, w)) in got.iter().zip(want.iter()).enumerate() {
-                assert!(
-                    g.abs_diff(*w) <= 1,
-                    "({x},{y}) channel {c} is {g}, expected {w} for coverage \
-                     {cov:#04x} — whole pixel {got:?} vs {want:?}",
+
+            // (4) the counter-oracle. The `dualSrcBlend`-less
+            // fallback gives all three channels the MEAN of the
+            // three wire bytes; where that differs from the
+            // per-channel answer, the destination must not hold it.
+            let grayscale = [
+                over_at_coverage(GLYPH_SRC_B, background[0], *mean),
+                over_at_coverage(GLYPH_SRC_G, background[1], *mean),
+                over_at_coverage(GLYPH_SRC_R, background[2], *mean),
+                0xFF,
+            ];
+            if grayscale
+                .iter()
+                .zip(want.iter())
+                .any(|(g, w)| g.abs_diff(*w) > 1)
+            {
+                assert_ne!(
+                    got, grayscale,
+                    "({x},{y}) is the GRAYSCALE result {grayscale:?} — the three \
+                     channels were given one shared coverage (the mean {mean:#04x}) \
+                     instead of their own",
                 );
             }
         }
     }
+
+    // Teeth on (4): the two oracles really do disagree somewhere, so
+    // the assertion above is not vacuous on this fixture.
+    assert!(
+        ARGB32_RAMP.iter().any(|(wire, mean)| {
+            over_at_coverage(GLYPH_SRC_R, background[2], wire[2]).abs_diff(over_at_coverage(
+                GLYPH_SRC_R,
+                background[2],
+                *mean,
+            )) > 1
+        }),
+        "fixture: per-channel and grayscale coverage must differ on some column",
+    );
 
     // ── (1) varying, not a block. The alpha byte is 255 on every
     // pixel of this glyph, so reading it paints all 8 columns the
@@ -1105,7 +1183,7 @@ fn an_argb32_glyph_paints_varying_coverage_at_its_logical_width() {
         distinct.len(),
     );
     let full_source = [GLYPH_SRC_B, GLYPH_SRC_G, GLYPH_SRC_R, 0xFF];
-    for (x, (_, cov)) in ARGB32_RAMP
+    for (x, (wire, _)) in ARGB32_RAMP
         .iter()
         .enumerate()
         .take(ARGB32_RAMP.len() - 1)
@@ -1114,8 +1192,8 @@ fn an_argb32_glyph_paints_varying_coverage_at_its_logical_width() {
         assert_ne!(
             px(x, 0),
             full_source,
-            "column {x} painted at FULL coverage; its ramped coverage is \
-             {cov:#04x}",
+            "column {x} painted at FULL coverage; its ramped per-channel \
+             coverage is {wire:02x?}",
         );
     }
 
@@ -1140,6 +1218,536 @@ fn an_argb32_glyph_paints_varying_coverage_at_its_logical_width() {
                 background,
                 "({x},{y}) is past the glyph's logical width and must be \
                  untouched background",
+            );
+        }
+    }
+}
+
+// ── #137: the component-alpha COORDINATE path, in isolation ─────
+//
+// The sibling ramp test above proves the four planes are packed and
+// blended correctly, but it varies coverage along x, so a fetch that
+// lands one texel out is only ever one ramp step wrong. Here the four
+// planes hold four DISTINCT CONSTANTS instead, so each way of getting
+// the addressing wrong lands on its own recognisable answer:
+//
+//   * plane order R↔B swapped     → blue 120, red 5   (not 20, 30)
+//   * plane stride zeroed         → every plane reads R: 120, 80, 30, 150
+//   * local offset half a texel out → the rightmost column reads the
+//     NEXT plane (red 9) and the alpha plane reads the neighbour glyph
+//   * `4 * w` as the quad width   → columns 4..16 get painted
+//
+// The destination is **transparent**, which is what makes the fourth
+// plane observable at all: under `Over` onto an opaque destination
+// `cov_a + dst.a * (1 - cov_a)` is 1 whatever the glyph's alpha is,
+// so `cov_a` could be a hardcoded 1 and nothing would move. Onto a
+// transparent one the result alpha IS `cov_a`.
+
+/// Wire `[B, G, R, A]` of the constant-plane fixture glyph, and the
+/// exact `Over`-onto-transparent result each produces from the
+/// reference source colour.
+///
+/// Every coverage is chosen so `src.C * cov` is a whole multiple of
+/// 255 — blue needs `cov % 5 == 0`, green `cov % 15 == 0`, red
+/// `cov % 5 == 0` against `0xCC`, `0x88`, `0x33` — so the ideal
+/// result needs no rounding and can be asserted byte-for-byte. And
+/// the four coverages AND the four results are mutually distinct, so
+/// no permutation of the planes produces the right answer.
+const PLANE_CONST_WIRE: [u8; 4] = [25, 45, 150, 200];
+/// `[B, G, R, A]` of the painted pixel: `0xCC*25/255 = 20`,
+/// `0x88*45/255 = 24`, `0x33*150/255 = 30`, and alpha `= cov_a`.
+const PLANE_CONST_RESULT: [u8; 4] = [20, 24, 30, 200];
+const PLANE_CONST_W: u16 = 4;
+const PLANE_CONST_H: u16 = 2;
+
+/// An `ARGB32` glyphset holding three glyphs, all carrying
+/// `PLANE_CONST_WIRE` on every pixel:
+///
+/// * id 1 — the `4x2` constant-plane fixture;
+/// * id 2 — `4x2` saturated on every channel. It exists to be id 1's
+///   right-hand atlas neighbour, so a read past id 1's packed
+///   footprint lands on a known `0xFF` instead of on never-written
+///   atlas memory that would read as coverage 0 and look correct;
+/// * id 3 — **`1x1`**, i.e. plane stride 1, the tightest possible
+///   packing. Its four planes are four consecutive texels, so any
+///   off-by-one in the local offset immediately reads the next
+///   plane, and it is also the one-pixel-wide case nothing else in
+///   the suite exercises.
+fn plane_constant_glyphset(b: &mut KmsBackend) -> u32 {
+    let gs = b
+        .render_create_glyphset(None, yserver_protocol::x11::RENDER_FMT_ARGB32)
+        .expect("render_create_glyphset")
+        .expect("Some(GlyphSetHandle)");
+    let mut add_body: Vec<u8> = Vec::new();
+    add_body.extend_from_slice(&3_u32.to_le_bytes()); // n
+    add_body.extend_from_slice(&1_u32.to_le_bytes()); // id 1 — constants
+    add_body.extend_from_slice(&2_u32.to_le_bytes()); // id 2 — saturated
+    add_body.extend_from_slice(&3_u32.to_le_bytes()); // id 3 — 1x1
+    for (w, h) in [
+        (PLANE_CONST_W, PLANE_CONST_H),
+        (PLANE_CONST_W, PLANE_CONST_H),
+        (1, 1),
+    ] {
+        add_body.extend_from_slice(&u16::to_le_bytes(w));
+        add_body.extend_from_slice(&u16::to_le_bytes(h));
+        add_body.extend_from_slice(&i16::to_le_bytes(0)); // x bearing
+        add_body.extend_from_slice(&i16::to_le_bytes(0)); // y bearing
+        add_body.extend_from_slice(&i16::to_le_bytes(w as i16));
+        add_body.extend_from_slice(&i16::to_le_bytes(0));
+    }
+    // Glyph bodies, in id order. Rows are dense at `w * 4` bytes.
+    for _ in 0..PLANE_CONST_H {
+        for _ in 0..PLANE_CONST_W {
+            add_body.extend_from_slice(&PLANE_CONST_WIRE);
+        }
+    }
+    for _ in 0..PLANE_CONST_H {
+        for _ in 0..PLANE_CONST_W {
+            add_body.extend_from_slice(&[0xFF; 4]);
+        }
+    }
+    add_body.extend_from_slice(&PLANE_CONST_WIRE);
+    b.render_add_glyphs(None, gs.as_raw(), &add_body)
+        .expect("render_add_glyphs");
+    gs.as_raw()
+}
+
+/// Stamp `glyph_ids` at successive pen positions onto a fresh
+/// `16x4` pixmap pre-filled with `bg_pixel`, and read the result
+/// back. `mask_format = 0` — what Java sends.
+fn paint_glyphs_onto(
+    b: &mut KmsBackend,
+    gs: u32,
+    src_pic: u32,
+    bg_pixel: u32,
+    ids: &[u8],
+) -> Vec<u8> {
+    let dst_pix = b.create_pixmap(None, 32, 16, 4).expect("create_pixmap dst");
+    let dst_xid = dst_pix.as_raw();
+    b.fill_rectangle(None, dst_xid, bg_pixel, 0, 0, 16, 4)
+        .expect("fill_rectangle dst");
+    let dst_pic = b
+        .render_create_picture(None, AnyHandle::Pixmap(dst_pix), 0, 0, &[])
+        .expect("render_create_picture dst")
+        .expect("Some(PictureHandle)");
+
+    let mut items: Vec<u8> = Vec::new();
+    items.extend_from_slice(&[u8::try_from(ids.len()).expect("few glyphs"), 0, 0, 0]);
+    items.extend_from_slice(&i16::to_le_bytes(0));
+    items.extend_from_slice(&i16::to_le_bytes(0));
+    let mut payload = ids.to_vec();
+    while !payload.len().is_multiple_of(4) {
+        payload.push(0);
+    }
+    items.extend_from_slice(&payload);
+
+    b.render_composite_glyphs(
+        None,
+        23,
+        3,
+        src_pic,
+        dst_pic.as_raw(),
+        0,
+        gs,
+        0,
+        0,
+        &items,
+        0,
+        0,
+    )
+    .expect("render_composite_glyphs");
+
+    b.get_image_pixels_for_tests(dst_xid, 2, 0, 0, 16, 4, !0)
+        .expect("get_image")
+        .expect("Some(bytes)")
+}
+
+/// The coordinate path alone: four planes of four distinct constants,
+/// composited onto a **transparent** destination so all four —
+/// including the glyph's own alpha — survive to the readback.
+///
+/// Asserts the exact `[B, G, R, A]` of every pixel of the glyph box,
+/// and that nothing outside it moved. See the block comment above for
+/// what each addressing mistake produces instead.
+#[test]
+#[ignore = "needs live Vulkan ICD"]
+fn a_component_alpha_glyph_samples_all_four_planes_at_the_plane_stride() {
+    let mut b = match KmsBackend::for_tests_with_vk() {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("skipping: missing capability — no live Vulkan ICD: {e}");
+            return;
+        }
+    };
+    let gs = plane_constant_glyphset(&mut b);
+    let (_, src) = repeating_pixmap_source(&mut b, 1, 1, GLYPH_SRC_PIXEL, 1);
+    // Intern id 1 then id 2, so the saturated glyph lands immediately
+    // right of the fixture's 4-plane footprint in the shared atlas.
+    let _ = paint_glyphs_onto(&mut b, gs, src, GLYPH_DST_PIXEL, &[1, 2]);
+    // The real subject: id 1 alone, onto a fully transparent dst.
+    let out = paint_glyphs_onto(&mut b, gs, src, 0x0000_0000, &[1]);
+
+    let px = |x: usize, y: usize| -> [u8; 4] {
+        let off = (y * 16 + x) * 4;
+        [out[off], out[off + 1], out[off + 2], out[off + 3]]
+    };
+
+    // Sanity on the fixture's own design: nothing is accidentally
+    // equal, so no plane permutation and no shared-coverage answer
+    // can coincide with the right one.
+    let distinct = |mut v: Vec<u8>| {
+        v.sort_unstable();
+        v.dedup();
+        v.len()
+    };
+    assert_eq!(
+        distinct(PLANE_CONST_WIRE.to_vec()),
+        4,
+        "fixture: the four coverages must be distinct",
+    );
+    assert_eq!(
+        distinct(PLANE_CONST_RESULT.to_vec()),
+        4,
+        "fixture: the four results must be distinct",
+    );
+
+    for y in 0..PLANE_CONST_H as usize {
+        for x in 0..PLANE_CONST_W as usize {
+            assert_eq!(
+                px(x, y),
+                PLANE_CONST_RESULT,
+                "({x},{y}): each channel must carry its OWN plane's coverage. \
+                 Blue 120 / red 5 means the R and B planes are swapped; \
+                 [120, 80, 30, 150] means the plane stride is zero and every \
+                 fetch read the R plane; red 9 in the last column means the \
+                 local offset is half a texel out; alpha 255 means `cov_a` was \
+                 taken as a constant 1 instead of read from the fourth plane",
+            );
+        }
+    }
+
+    // Nothing outside the glyph's LOGICAL box moved. A quad laid down
+    // at the packed width (4 * 4 = 16) covers this whole readback.
+    for y in 0..4usize {
+        for x in 0..16usize {
+            if y < PLANE_CONST_H as usize && x < PLANE_CONST_W as usize {
+                continue;
+            }
+            assert_eq!(
+                px(x, y),
+                [0, 0, 0, 0],
+                "({x},{y}) is outside the glyph's logical {PLANE_CONST_W}x\
+                 {PLANE_CONST_H} box and must be untouched — a quad at the \
+                 packed width 4*w would paint it",
+            );
+        }
+    }
+
+    // ── the ONE-TEXEL-WIDE glyph, plane stride 1 ──
+    //
+    // Its four planes are four consecutive texels, which is the
+    // tightest packing there is: the R plane's only texel is at the
+    // atlas origin and the A plane's is three texels along. Nothing
+    // else in the suite draws a one-pixel-wide glyph at all, so a
+    // per-glyph path that silently skipped `logical_w == 1` — or a
+    // stride that collapsed at width 1 — would go unnoticed.
+    let tiny = paint_glyphs_onto(&mut b, gs, src, 0x0000_0000, &[3]);
+    let tiny_px = |x: usize, y: usize| -> [u8; 4] {
+        let off = (y * 16 + x) * 4;
+        [tiny[off], tiny[off + 1], tiny[off + 2], tiny[off + 3]]
+    };
+    assert_eq!(
+        tiny_px(0, 0),
+        PLANE_CONST_RESULT,
+        "a 1x1 component-alpha glyph must sample its four planes at stride 1 \
+         — and must be drawn at all",
+    );
+    for y in 0..4usize {
+        for x in 0..16usize {
+            if (x, y) == (0, 0) {
+                continue;
+            }
+            assert_eq!(
+                tiny_px(x, y),
+                [0, 0, 0, 0],
+                "({x},{y}) is outside the 1x1 glyph and must be untouched — a \
+                 quad at its packed width 4 would paint columns 1..4",
+            );
+        }
+    }
+}
+
+// ── #137 invariant 1: the A8 path does not move ─────────────────
+//
+// The overwhelmingly common path. Component alpha added two vertex
+// outputs, a fourth vertex attribute, a wider instance stride and a
+// second fragment output, all of which the A8 specialization also
+// carries — so "A8 is untouched" stopped being true by construction
+// and became something to assert.
+//
+// The existing A8 glyph tests all use FULLY OPAQUE glyphs, where any
+// coverage error above zero paints the same pixel; a ramp is what
+// makes a wrong coverage visible. The oracle is analytic — the `Over`
+// equation at a single shared coverage — rather than a captured
+// golden, so it also fails if the pre-change output was itself wrong.
+
+/// An `A8` glyphset holding one `8x4` glyph whose columns carry
+/// exactly the coverages `ARGB32_RAMP`'s grayscale column names — so
+/// this fixture is, pixel for pixel, what the `dualSrcBlend`-less
+/// fallback turns the component-alpha fixture into.
+fn a8_ramp_glyphset(b: &mut KmsBackend) -> u32 {
+    let gs = b
+        .render_create_glyphset(None, yserver_protocol::x11::RENDER_FMT_A8)
+        .expect("render_create_glyphset")
+        .expect("Some(GlyphSetHandle)");
+    let mut add_body: Vec<u8> = Vec::new();
+    add_body.extend_from_slice(&1_u32.to_le_bytes()); // n
+    add_body.extend_from_slice(&1_u32.to_le_bytes()); // id = 1
+    add_body.extend_from_slice(&u16::to_le_bytes(ARGB32_GLYPH_W));
+    add_body.extend_from_slice(&u16::to_le_bytes(ARGB32_GLYPH_H));
+    add_body.extend_from_slice(&i16::to_le_bytes(0)); // x bearing
+    add_body.extend_from_slice(&i16::to_le_bytes(0)); // y bearing
+    add_body.extend_from_slice(&i16::to_le_bytes(ARGB32_GLYPH_W as i16));
+    add_body.extend_from_slice(&i16::to_le_bytes(0));
+    // Dense A8 rows; X RENDER pads a glyph row to a 4-byte boundary
+    // and 8 already is one.
+    for _ in 0..ARGB32_GLYPH_H {
+        for (_, cov) in ARGB32_RAMP {
+            add_body.push(cov);
+        }
+    }
+    b.render_add_glyphs(None, gs.as_raw(), &add_body)
+        .expect("render_add_glyphs");
+    gs.as_raw()
+}
+
+/// An `A8` glyphset paints exactly what it always did: one shared
+/// coverage per pixel across all three channels, at the glyph's own
+/// width (design invariant 1).
+///
+/// Measured byte-identical on lavapipe against the pre-component-alpha
+/// parent (`0fb89fdf`) — the same 8 painted columns, BGRA:
+/// `[255,0,0] [249,17,6] [242,34,13] [231,64,24] [229,68,26]
+/// [223,85,32] [217,102,38] [204,136,51]`, alpha `0xFF` throughout,
+/// columns 8..16 untouched background. The assertions below are the
+/// analytic form of that, so they also fail if the pre-change output
+/// had itself been wrong.
+#[test]
+#[ignore = "needs live Vulkan ICD"]
+fn an_a8_glyphset_paints_byte_identical_single_plane_coverage() {
+    let mut b = match KmsBackend::for_tests_with_vk() {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("skipping: missing capability — no live Vulkan ICD: {e}");
+            return;
+        }
+    };
+    let gs = a8_ramp_glyphset(&mut b);
+    let (_, src) = repeating_pixmap_source(&mut b, 1, 1, GLYPH_SRC_PIXEL, 1);
+    let out = paint_glyphs_onto(&mut b, gs, src, GLYPH_DST_PIXEL, &[1]);
+
+    let background = [
+        (GLYPH_DST_PIXEL & 0xff) as u8,
+        ((GLYPH_DST_PIXEL >> 8) & 0xff) as u8,
+        ((GLYPH_DST_PIXEL >> 16) & 0xff) as u8,
+        0xFF,
+    ];
+    let px = |x: usize, y: usize| -> [u8; 4] {
+        let off = (y * 16 + x) * 4;
+        [out[off], out[off + 1], out[off + 2], out[off + 3]]
+    };
+
+    for y in 0..ARGB32_GLYPH_H as usize {
+        for (x, (_, cov)) in ARGB32_RAMP.iter().enumerate() {
+            // ONE coverage for all three channels — the A8 semantic.
+            // Component alpha's per-channel answer would differ on
+            // every column but the flat ones.
+            let want = [
+                over_at_coverage(GLYPH_SRC_B, background[0], *cov),
+                over_at_coverage(GLYPH_SRC_G, background[1], *cov),
+                over_at_coverage(GLYPH_SRC_R, background[2], *cov),
+                0xFF,
+            ];
+            let got = px(x, y);
+            for (c, (g, w)) in got.iter().zip(want.iter()).enumerate() {
+                assert!(
+                    g.abs_diff(*w) <= 1,
+                    "({x},{y}) channel {c} is {g}, expected {w} at A8 coverage \
+                     {cov:#04x} — whole pixel {got:?} vs {want:?}",
+                );
+            }
+        }
+        for x in ARGB32_GLYPH_W as usize..16 {
+            assert_eq!(
+                px(x, y),
+                background,
+                "({x},{y}) is past the A8 glyph's width and must be untouched",
+            );
+        }
+    }
+}
+
+/// One `CompositeGlyphs` request that mixes formats, end to end.
+///
+/// Reachable in production for the first time as of component alpha:
+/// before it, the upload reduced every ARGB32 glyph to one A8 plane, so
+/// every glyph of a mixed request had the same effective layout and the
+/// run splitter formed exactly one run. Now an A8 glyph and an ARGB32
+/// glyph in one request need two pipelines, so the request records two
+/// ops over one shared instance buffer — and each run must draw ITS
+/// OWN instance range with ITS OWN pipeline.
+///
+/// The stream switches glyphset mid-stream through the inline
+/// `count == 255` element, which is the only way a client can do this.
+/// Both glyphs are asserted against their own exact oracle: the A8 one
+/// gets one shared coverage on all three channels, the ARGB32 one gets
+/// its four planes. So a second run drawn with the first run's pipeline
+/// (or from the first run's instance range) lands on the wrong answer
+/// for one of them.
+///
+/// It also asserts the request-wide half of the contract: however many
+/// runs it split into, the client issued ONE request and gets ONE
+/// returned region back.
+#[test]
+#[ignore = "needs live Vulkan ICD"]
+fn one_request_mixing_a8_and_component_alpha_glyphs_paints_both() {
+    use yserver_core::backend::Backend;
+
+    let mut b = match KmsBackend::for_tests_with_vk() {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("skipping: missing capability — no live Vulkan ICD: {e}");
+            return;
+        }
+    };
+    let gs_a8 = a8_ramp_glyphset(&mut b);
+    let gs_ca = plane_constant_glyphset(&mut b);
+    let (_, src) = repeating_pixmap_source(&mut b, 1, 1, GLYPH_SRC_PIXEL, 1);
+
+    let dst_pix = b.create_pixmap(None, 32, 16, 4).expect("create_pixmap dst");
+    let dst_xid = dst_pix.as_raw();
+    b.fill_rectangle(None, dst_xid, GLYPH_DST_PIXEL, 0, 0, 16, 4)
+        .expect("fill_rectangle dst");
+    let dst_pic = b
+        .render_create_picture(None, AnyHandle::Pixmap(dst_pix), 0, 0, &[])
+        .expect("render_create_picture dst")
+        .expect("Some(PictureHandle)");
+
+    // Element 1: the A8 ramp glyph (id 1 of gs_a8) at pen 0. It is 8
+    // wide with x_off 8, so the pen lands at 8.
+    // Element 2: inline glyphset change to the ARGB32 set.
+    // Element 3: its constant-plane glyph (id 1 of gs_ca) at pen 8.
+    let mut items: Vec<u8> = Vec::new();
+    items.extend_from_slice(&[1u8, 0, 0, 0]);
+    items.extend_from_slice(&i16::to_le_bytes(0));
+    items.extend_from_slice(&i16::to_le_bytes(0));
+    items.extend_from_slice(&[1u8, 0, 0, 0]);
+    items.push(255);
+    items.extend_from_slice(&[0u8, 0, 0]);
+    items.extend_from_slice(&gs_ca.to_le_bytes());
+    items.extend_from_slice(&[1u8, 0, 0, 0]);
+    items.extend_from_slice(&i16::to_le_bytes(0));
+    items.extend_from_slice(&i16::to_le_bytes(0));
+    items.extend_from_slice(&[1u8, 0, 0, 0]);
+
+    let region = b
+        .render_composite_glyphs(
+            None,
+            23, // CompositeGlyphs8
+            3,  // Over
+            src,
+            dst_pic.as_raw(),
+            0, // mask_format 0 — the per-glyph branch Java takes
+            gs_a8,
+            0,
+            0,
+            &items,
+            0,
+            0,
+        )
+        .expect("render_composite_glyphs");
+
+    // ONE request, ONE region — whatever the run count. A per-run
+    // region looks harmless and breaks a compositor's damage tracking.
+    assert_eq!(
+        region.len(),
+        1,
+        "a split request must still return exactly one region: {region:?}",
+    );
+
+    let out = b
+        .get_image_pixels_for_tests(dst_xid, 2, 0, 0, 16, 4, !0)
+        .expect("get_image")
+        .expect("Some(bytes)");
+    let background = [
+        (GLYPH_DST_PIXEL & 0xff) as u8,
+        ((GLYPH_DST_PIXEL >> 8) & 0xff) as u8,
+        ((GLYPH_DST_PIXEL >> 16) & 0xff) as u8,
+        0xFF,
+    ];
+    let px = |x: usize, y: usize| -> [u8; 4] {
+        let off = (y * 16 + x) * 4;
+        [out[off], out[off + 1], out[off + 2], out[off + 3]]
+    };
+
+    // Run 1 — the A8 glyph, columns 0..8: ONE coverage for all three
+    // channels. The component-alpha pipeline would give each channel
+    // the wire byte of a plane that does not exist here.
+    for y in 0..ARGB32_GLYPH_H as usize {
+        for (x, (_, cov)) in ARGB32_RAMP.iter().enumerate() {
+            let want = [
+                over_at_coverage(GLYPH_SRC_B, background[0], *cov),
+                over_at_coverage(GLYPH_SRC_G, background[1], *cov),
+                over_at_coverage(GLYPH_SRC_R, background[2], *cov),
+                0xFF,
+            ];
+            let got = px(x, y);
+            for (c, (g, w)) in got.iter().zip(want.iter()).enumerate() {
+                assert!(
+                    g.abs_diff(*w) <= 1,
+                    "run 1 ({x},{y}) channel {c} is {g}, expected {w} at A8 \
+                     coverage {cov:#04x} — whole pixel {got:?} vs {want:?}",
+                );
+            }
+        }
+    }
+
+    // Run 2 — the component-alpha glyph at pen 8, columns 8..12: each
+    // channel from its own plane. A run drawn from run 1's instance
+    // range would paint the A8 glyph here instead, and a run drawn
+    // with run 1's pipeline would read only the R plane.
+    for y in 0..PLANE_CONST_H as usize {
+        for x in 0..PLANE_CONST_W as usize {
+            let want = [
+                over_at_coverage(GLYPH_SRC_B, background[0], PLANE_CONST_WIRE[0]),
+                over_at_coverage(GLYPH_SRC_G, background[1], PLANE_CONST_WIRE[1]),
+                over_at_coverage(GLYPH_SRC_R, background[2], PLANE_CONST_WIRE[2]),
+                0xFF,
+            ];
+            let got = px(8 + x, y);
+            for (c, (g, w)) in got.iter().zip(want.iter()).enumerate() {
+                assert!(
+                    g.abs_diff(*w) <= 1,
+                    "run 2 ({},{y}) channel {c} is {g}, expected {w} — whole \
+                     pixel {got:?} vs {want:?}",
+                    8 + x,
+                );
+            }
+        }
+    }
+
+    // Neither run painted outside its own box.
+    for y in 0..4usize {
+        for x in 0..16usize {
+            let in_a8 = y < ARGB32_GLYPH_H as usize && x < ARGB32_GLYPH_W as usize;
+            let in_ca = y < PLANE_CONST_H as usize && (8..8 + PLANE_CONST_W as usize).contains(&x);
+            if in_a8 || in_ca {
+                continue;
+            }
+            assert_eq!(
+                px(x, y),
+                background,
+                "({x},{y}) is outside both glyph boxes and must be untouched",
             );
         }
     }

--- a/docs/superpowers/plans/2026-09-10-component-alpha-glyphs-plan.md
+++ b/docs/superpowers/plans/2026-09-10-component-alpha-glyphs-plan.md
@@ -1,0 +1,314 @@
+# Component-alpha (subpixel) glyphs — implementation plan
+
+Implements `../specs/2026-09-10-component-alpha-glyphs-design.md` (agreed
+complete over five review rounds, `78e36738`). Read that first; this plan
+does not restate its reasoning.
+
+**Branch:** `fix/137-glyph-drawable-source` — the same branch, because this
+is the second half of making Java text actually render
+(`feedback_one_branch_per_issue`).
+
+**Deliverable:** on a subpixel-AA desktop (MATE's default), the reporter's
+Swing probe renders letterforms, not blocks, with subpixel fringing that
+matches Xorg's on the same scenario.
+
+## Ordering principle
+
+**Fix the pre-existing bug first, then make blocks legible, then make them
+correct.**
+
+Two things drive the order. The pin-ceiling off-by-one is a pre-existing
+defect that this work would otherwise sit on top of, so it lands alone where
+a regression is unambiguous. And the upload-time grayscale reduction — the
+spec's `dualSrcBlend` fallback — is a **complete, shippable fix for the
+blocks** on its own, needing no atlas, pipeline or shader change. Landing it
+third means the risky work (4-plane packing, a second shader path, run
+splitting, `first_instance`) all happens on top of a known-good, visually
+verified baseline that each later step can be A/B'd against.
+
+The alternative — keep ARGB32 glyphs as ARGB32 first — would take LCD text
+from blocks to *nothing* mid-branch, because `render_composite_glyphs`
+currently skips a stored `Argb32` glyph defensively
+(`render/backend.rs:23314`). Not acceptable even transiently.
+
+## Prerequisites
+
+- `cargo +nightly fmt -- --check`, `cargo clippy --all-targets -- -D
+  warnings`, `cargo test --workspace` clean before each commit — exactly
+  CI's lines (`.github/workflows/ci.yml:31-38`). A clippy run without the
+  deny only *looks* clean.
+- The live suite on lavapipe:
+  `VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.json cargo test -p
+  yserver --test render_acceptance -- --ignored`. Baseline is **144/145**;
+  `window_storage_init_covers_the_whole_allocation` fails on this branch and
+  on `a06cf0e0` alike (known uninit-storage defect). Do not re-derive that.
+- The reproducer:
+  `tools/vng-shot.sh --scenario tools/vng-scenarios/java-xrender-text.sh
+  --env YS_JAVA_AA=lcd`, and the same with `--server xorg` for the oracle.
+  `YS_JAVA_AA=gasp` is the A8 control that must never change.
+- lavapipe and RADV both report `dualSrcBlend = true`, so CI exercises the
+  real component-alpha path. The reduction path is pure and unit-tested; do
+  not add a switch to force it (`feedback_no_feature_kill_switches`).
+- Hardware for step 6 only.
+
+---
+
+## Step 1 — the pin-ceiling reservation (pre-existing bug, alone)
+
+Reserve the instance buffer's pin so a frame cannot end above
+`max_pinned_resources_per_frame()`. Four edits, all in
+`render/engine.rs`, and the same rule in **both** glyph paths:
+
+- pre-pass `:6430` → `pending + prospective_misses + 1 > ceiling`;
+- `note_pin_ceiling_hit_once` `:6436` → reports that same reserved total;
+- single-call overflow `:6488` → `prospective_misses + 1 > ceiling`;
+- per-glyph admission `:6567` (and `image_text`'s identical `:5954`) →
+  `new_uploads.len() + 1 + pending + 1 > ceiling`, dropping uploads to
+  leave room for the draw.
+
+Nothing about component-alpha yet.
+
+**Proof.** Red first is legitimate here and the oracle is not a hypothesis:
+the ceiling is a limit the code itself declares, so "a frame's `pins.len()`
+never exceeds `max_pinned_resources_per_frame()`" is read off the existing
+contract, not guessed (`feedback_red_first_needs_verified_oracle`). Write
+that assertion at a lowered ceiling against a call that exactly fills it,
+watch it fail on today's code, then fix. One test per path — the
+`composite_glyphs` and `image_text` holes are separate code.
+
+Assert the **count**, never "it rendered": the off-by-one renders fine.
+
+**Expected behaviour change:** a call that exactly fills the ceiling now
+drops one more glyph than before. That is the correct trade — see the spec.
+`stats.glyphs_dropped` moves by one in that case and nowhere else.
+
+## Step 2 — `AtlasEntry`: rename the width, add the layout
+
+Pure refactor, behaviour-neutral by construction:
+
+- `AtlasEntry.w` → `packed_w` **and** `logical_w`, both equal today;
+- add `layout: GlyphLayout` (`A8` | `ComponentAlpha`), always `A8` today;
+- visit every consumer the compiler surfaces. The upload copy region
+  (`:6661`) takes `packed_w`; the damage extent (`:6629`) and the instance
+  data (`:6637`) take `logical_w`. `RecordedTextGlyph.w` and
+  `RecordedGlyphUpload.w` (`render/frame_builder.rs:457`) are separate
+  copies and each takes the one it means.
+
+The rename is the point: a field added beside `w` would leave every existing
+use silently keeping whichever meaning it had, and half of them would be
+wrong.
+
+**Proof.** The existing suite cannot carry this step. While
+`packed_w == logical_w`, **either field produces identical pixels**, so a
+green suite and a green 144/145 say nothing about whether each consumer took
+the field it means — which is the entire reason for the rename.
+
+So: a targeted test with **deliberately asymmetric synthetic widths** on an
+`AtlasEntry`, asserting that
+
+- `RecordedGlyphUpload` receives `packed_w`;
+- `RecordedTextGlyph`, the damage extent and the instance geometry all
+  receive `logical_w`.
+
+That proves the rename's premise directly, and it is the test that makes
+step 5 safe — step 5 is the first step where the two widths differ, and by
+then this must already be pinned. Run the full and live suites too, but as
+a regression net rather than as the proof.
+
+**Carry-forward, found while implementing this step.** The `logical_w` half
+is assertable here, through production, by shrinking a cached entry's
+`logical_w` under a live draw. The **`packed_w` half is not**: production
+constructs `packed_w == logical_w` from the same variable at every upload
+site, so no real call path can produce an asymmetric *upload* until step 5's
+`pack(4 * logical_w, h)` exists. That is a structural limit, not a
+Vulkan-availability one.
+
+So **step 5 must carry the missing assertion**: that `RecordedGlyphUpload`
+receives `packed_w` and not `logical_w`. It is the first step where that is
+reachable, and it is the half whose failure mode is an upload copying a
+quarter of the glyph.
+
+## Step 3 — make the blocks legible: reduce at upload
+
+The spec's stage 3, landed here as the **universal** behaviour so it is a
+shippable fix on its own. `parse_add_glyphs` stops rewriting an `ARGB32`
+glyph's `stored_format` to `A8`; the engine's upload path reduces the four
+channels to one A8 coverage plane — the mean of logical R, G, B — at logical
+width `w`. The existing single-output shader and pipeline serve it unchanged.
+
+Wire order is `[B, G, R, A]`; the reduction reads logical R, G and B. The
+mean is `(r + g + b + 1) / 3` — rounded to nearest, fixed here so step 5's
+fallback cannot quietly disagree.
+
+After this step **LCD text renders as grayscale-antialiased letterforms**.
+Blocks are gone. Step 5 narrows this code's condition to
+`!component_alpha_supported` rather than replacing it.
+
+**Proof.**
+
+- **Pure:** the reduction over a glyph with four mutually distinct
+  asymmetric channels (`B=0x20 G=0x60 R=0xA0 A=0xE0`), asserting the exact
+  expected coverage.
+
+  **But be honest about what this fixture can and cannot catch.** The mean
+  is *symmetric in its arguments*, so an R↔B transposition is
+  mathematically undetectable at this step — no fixture can catch it, this
+  one included. What it does catch, and what the realistic form of the trap
+  is here, is the **off-by-one**: reading bytes `1..=3` as if they were
+  R, G, B, which includes alpha and drops blue. Verify that by mutation
+  rather than assertion — replace the reduction with the old alpha read and
+  with the `1..=3` mean, and confirm each fails.
+
+  Channel **order** only becomes observable in step 5, where the exact
+  packed-texel assertion `[0xA0, 0x60, 0x20, 0xE0]` does pin it. So the
+  guard against a swap is real, one step later than this.
+- **Pure:** the real measured Java glyph as a second fixture (alpha constant
+  255, `max(rgb)` spanning 28 distinct values), so a regression to the alpha
+  byte fails loudly instead of producing a plausible solid block.
+- **vng:** `YS_JAVA_AA=lcd` — letterforms, and the Czech accented line
+  legible. `YS_JAVA_AA=gasp` unchanged.
+- **Live suite** still 144/145.
+
+## Step 4a — `first_instance`, end to end, with one run
+
+Plumb the field before anything depends on it:
+`RecordedCompositeGlyphs` gains `first_instance`
+(`render/frame_builder.rs:463`), emit passes it through
+(`render/engine.rs:9089-9103`), and `record_text_run_scissored` uses it in
+`cmd_draw`'s fourth argument instead of the hardcoded `0`
+(`vk/ops/text.rs:212`).
+
+Also switch to one shared instance buffer with per-run ranges, still with
+exactly one run per call. Behaviour-neutral.
+
+**This step needs a seam, or its proof is unreachable.** Before step 4b,
+`composite_glyphs_via_frame_builder` forms exactly one run, so "record it as
+two runs" is not something a test can ask for. Introduce the run-recording
+helper here: a small internal function taking `(first_instance, count)`
+ranges over the shared buffer, called by production with a single range and
+by the test with two. It must be the **same** function production uses for
+the one-run case — a test-only parallel path would prove nothing about the
+code that ships, and step 4b consumes this helper anyway, so it is a seam
+rather than scaffolding.
+
+**Proof.** An all-A8 stream recorded as **two ranges** through that helper
+renders identically to the same stream as one range. A `first_instance` left
+at zero draws run 0's glyphs twice, which this catches and which no later
+test would distinguish from a splitter bug.
+
+Complement it with a direct unit test of `record_text_run_scissored`
+(`vk/ops/text.rs:212`) at a nonzero `first_instance`, so the draw-call
+argument is pinned at its own level rather than only through the helper.
+
+## Step 4b — the run splitter
+
+The backend parser tags each `CompositeGlyphInput` with the glyph's **source
+format** — protocol state, read from the glyphset. The **engine** derives
+the **effective `GlyphLayout`** from it, because that mapping depends on
+`component_alpha_supported`, which is device state the backend should not be
+reading. That keeps the fallback decision alongside atlas allocation and
+pipeline choice, where it cannot drift from either.
+
+Runs are then formed over the effective layout in
+`composite_glyphs_via_frame_builder`, in request order, through the step-4a
+helper. One clip region, one damage union, one `mark_contents_modified` per
+request; close+reopen stays before the per-glyph walk; the engine routine is
+entered once per request.
+
+Inert in production at this point — step 3 reduces everything, so every
+glyph has the same effective layout and there is exactly one run.
+
+**Proof.** Pure, and it must assert **order**:
+
+- an items stream that switches glyphsets mid-element via the `count == 255`
+  inline form, alternating formats, yields runs that are homogeneous, **in
+  the original glyph order**, with no glyph lost or duplicated at a
+  boundary. A test that checks only homogeneity passes a splitter that
+  regroups — the wrong answer for every op but `Add`.
+- with the reduction in force, that same alternating stream yields **one**
+  run.
+
+## Step 5 — the real component-alpha path
+
+The payload. These are mutually dependent and land together:
+
+- `packed_w = 4 * logical_w` and `layout = ComponentAlpha` when
+  `component_alpha_supported`; the upload writes four planes in logical
+  R, G, B, A order.
+- `text.frag.glsl` gains `COMPONENT_ALPHA`, four `texelFetch`es at
+  `atlas_origin + ivec2(local.x + k*stride, local.y)`, `local` from a
+  `v_local` varying via `ivec2(floor(v_local))`, and a second output
+  declared `layout(location = 0, index = 1)` — the second **index** of
+  attachment 0, as `render.frag.glsl:66` does. A `location = 1` output is a
+  second attachment and will not link.
+- instance data carries `logical_w` and an explicit `flat` plane stride;
+  the `4w` allocation width never reaches the shader.
+- `text_pipeline.rs:350` stops passing `false` and keys its cache on
+  `component_alpha`, deriving blend state from the shared
+  `PictOp::blend_factors`.
+- step 3's reduction narrows to `!component_alpha_supported`.
+
+Read `text.frag.glsl` and `render.frag.glsl:257-263` side by side while
+writing this; the two then carry one equation in two places.
+
+**Proof.**
+
+- **Live, `#[ignore]`:** per-channel coverage — seed known asymmetric
+  per-channel coverage and assert the destination's R, G and B against
+  **exact expected values** from the component-alpha equation. Not "they
+  differ": a red/blue swap satisfies that. A grayscale result has
+  `r == g == b`, so this separates a real component-alpha composite from a
+  convincing approximation *and* pins the mapping.
+- **Live, `#[ignore]`:** the coordinate path alone — four planes holding
+  four distinct constants, so a stretched `atlas_wh`, a first-plane-only
+  sample and a half-texel offset each produce a different recognisable
+  wrong answer.
+- **Live, `#[ignore]`:** a mixed-format request — one A8 and one ARGB32
+  glyph in ONE `CompositeGlyphs`, **overlapping** quads, non-commutative
+  op, so a regrouping splitter fails.
+- **Live, `#[ignore]`:** a split request still reports **one** damage union
+  and **one** returned region. Assert the region, not just the pixels: a
+  per-run region looks harmless and breaks compositor damage tracking.
+- **Live, `#[ignore]`:** an A8 run interns single-plane entries only, and
+  the core-font / glyphset atlas key namespaces do not overlap.
+- **Live, lowered ceiling:** the alternating stream's `pins.len()` still
+  within the limit, now that runs and 4× uploads both exist.
+- **vng A/B:** `YS_JAVA_AA=lcd` on yserver vs `--server xorg`, same guest.
+  Fringing present on both.
+- **Live suite** 144/145 throughout.
+
+## Step 6 — hardware
+
+- MATE (subpixel AA is its default) plus the reporter's Swing probe: all
+  five sample strings, the Czech accented line, the `Graphics2D.drawString()`
+  panel. Blocks gone; fringing present.
+- A drawables dump (`Ctrl+Alt+F12`) so the probe's own storage can be read
+  independently of compositing, as the diagnosis run did.
+- `glyphs_dropped_atlas_full` and the per-`CompositeGlyphs` draw count from
+  the telemetry rollup: component-alpha glyphs are 4× the area and runs can
+  multiply draws, and those are the two counters that would show either
+  going wrong.
+- xts `Xlib9` A/B, zero PASS→FAIL
+  (`feedback_xts_ab_gates_pixel_changes`) — this changes pixels on the text
+  path. vng is **not** valid for the xts gate (`reference_xts`).
+
+## Hazards
+
+- **Renaming `AtlasEntry.w` in step 2 is where a silent wrong-field pick can
+  enter**, because every consumer moves at once and the compiler accepts
+  either field — and while the two widths are equal, so do the pixels. Only
+  the asymmetric-metadata test catches it, and it must exist before step 5
+  makes the widths differ.
+- **The coordinate path fails as wrong-coloured fringes**, which read as
+  "subpixel AA looks a bit off" rather than as a bug. A screenshot of
+  correct-looking text is not evidence; the per-channel assertion is.
+- **A half-texel error appears on some glyphs and not others**, depending on
+  quad alignment — so a single-glyph test can pass while text is wrong.
+- **Step 3 is a shippable stopping point.** If step 5 proves harder than
+  expected, stopping after step 3 leaves legible grayscale text rather than
+  a half-built component-alpha path. Say so rather than pressing on.
+- **Do not regroup glyphs by format** for a draw-count win. It is the
+  obvious optimisation and it is wrong for every op but `Add`.
+- **`image_text` shares the atlas and the recorded op**, not the input type.
+  Those two surfaces are where a component-alpha change can leak into core
+  X11 text.

--- a/docs/superpowers/plans/2026-09-10-component-alpha-glyphs-plan.md
+++ b/docs/superpowers/plans/2026-09-10-component-alpha-glyphs-plan.md
@@ -200,6 +200,35 @@ Complement it with a direct unit test of `record_text_run_scissored`
 (`vk/ops/text.rs:212`) at a nonzero `first_instance`, so the draw-call
 argument is pinned at its own level rather than only through the helper.
 
+**Carry-forward from 4a — a latent trap already fixed, but untested.** Runs
+after the first must record `SHADER_READ_ONLY_OPTIMAL` as `dst_old_layout`,
+not the request's pre-op layout: that is where the previous run leaves the
+image, since `record_text_run_scissored` ends there. Carrying the pre-op
+layout on run 2+ declares a wrong `oldLayout` in its barrier, and a pre-op
+`UNDEFINED` would license the driver to **discard the earlier runs' pixels**.
+
+4a fixed it inside the seam but could not test it: it is inert with one run,
+and an `UNDEFINED` `oldLayout` is *permitted* to preserve contents, so a test
+on lavapipe would be a coin flip rather than an oracle. **4b is the first
+place it is assertable**, because multi-run becomes reachable through
+production. The seam it needs is a way to force a
+non-`SHADER_READ_ONLY_OPTIMAL` pre-frame layout on a destination that then
+takes two runs.
+
+**Correction to an earlier note here:** step 2's `RecordedGlyphUpload` /
+`packed_w` assertion is **step 5's** carry-forward, not 4b's — `packed_w`
+only diverges from `logical_w` when the 4-plane packing lands. 4b owns the
+layout trap above and nothing else inherited.
+
+**And the oracle for it is white-box, not pixels.** 4a declined to test it
+because an `UNDEFINED` `oldLayout` is *permitted* to preserve contents, so a
+pixel assertion on lavapipe passes whether the barrier is right or wrong.
+Assert the **recorded value** instead: drive `record_glyph_runs` with two
+runs and assert that run 2's `RecordedCompositeGlyphs.dst_old_layout` is
+`SHADER_READ_ONLY_OPTIMAL` while run 1's carries the request's pre-op layout.
+That oracle is exact and driver-independent, and it is reachable now through
+the seam rather than waiting for production multi-run.
+
 ## Step 4b — the run splitter
 
 The backend parser tags each `CompositeGlyphInput` with the glyph's **source
@@ -227,6 +256,40 @@ glyph has the same effective layout and there is exactly one run.
   regroups — the wrong answer for every op but `Add`.
 - with the reduction in force, that same alternating stream yields **one**
   run.
+
+**Carry-forwards into step 5 — three, all earned by earlier steps.**
+
+1. **`effective_glyph_layout` must gain the device parameter, here and
+   nowhere else.** 4b placed the derivation in the engine as designed, but
+   deliberately did **not** thread `component_alpha_supported` into it,
+   because it cannot yet mean anything: step 3's reduction is unconditional,
+   so answering `ComponentAlpha` would tag entries with a layout the
+   single-plane upload does not produce, and would break 4b's own inertness
+   proof. Threading an unused parameter, or hedging behind a constant-`true`
+   flag, would have been a kill-switch in disguise. Step 5 is where that
+   function starts answering `ComponentAlpha`, and its doc comment names the
+   insertion point.
+2. **Assert `RecordedGlyphUpload` receives `packed_w`, not `logical_w`**
+   (step 2's carry-forward). Step 5 is the first step where the two widths
+   differ, so it is the first step where this is reachable. The failure mode
+   is an upload copying a quarter of the glyph.
+3. **Fold in a simplification 4b identified:** `CompositeGlyphInput.source_format`
+   is structurally redundant with the `GlyphPixels` variant — the mapping is
+   total and 1:1. 4b built both from a single `match` so they cannot drift,
+   but a `GlyphPixels::source_format()` accessor would remove the field
+   outright with no behaviour change. Step 5 already touches this area.
+
+**Two coverage gaps 4b reported honestly, to be closed here or explicitly
+accepted.**
+
+- A mutation **survived**: making the `draw_layouts` push conditional on
+  `logical_w != 1` breaks nothing, because no live test uses a one-pixel-wide
+  glyph. The lockstep between `glyphs_to_draw` and `draw_layouts` is
+  otherwise guarded only by a `debug_assert`.
+- The pre-existing test `composite_glyphs_inline_glyphset_change_parsed`
+  **survives** a parse that ignores the inline `count == 255` glyphset
+  change — i.e. it does not test what its name claims. 4b's new tests do
+  catch it. Worth fixing or renaming while nearby.
 
 ## Step 5 — the real component-alpha path
 

--- a/docs/superpowers/plans/2026-09-10-glyph-drawable-source-plan.md
+++ b/docs/superpowers/plans/2026-09-10-glyph-drawable-source-plan.md
@@ -11,10 +11,11 @@ Read that first; this plan does not restate its reasoning.
 > | 2 read | `4c50ad2b` — Java text paints |
 > | 3 staleness regression | `e9c6f057` |
 > | 4 loud remaining drops | `08fa79f8` |
-> | 5 measure, then cache | measured in vng (below); the DECISION is open and is jos's |
+> | 5 measure, then cache | **DONE** — jos decided to build it 2026-09-10; cache + hit/miss counters landed |
 > | 6 hardware | Swing probe passes in vng; real hardware + xts `Xlib9` A/B still owed |
 >
-> **No cache exists yet, by design** (step 5 measures first). The
+> **The cache now exists** (jos's call, 2026-09-10 — see the decision note
+> below for what settled it). The
 > readback is attributed to `GetImageSite::GlyphSource`, which prints as
 > `get_image_by_site/s[… glyphsrc=N]`, so the measurement is a matter of
 > reading one field of the per-second telemetry line.
@@ -79,6 +80,45 @@ Read that first; this plan does not restate its reasoning.
 > stops us racing Java's recolouring — so this is a real tension and needs
 > a decision, not a patch. Absolute timings still need real hardware; the
 > counts and the close-reason split do not.
+>
+> **Step 5 — DECIDED and BUILT, 2026-09-10.** The procedure below went
+> through two revisions and then a better argument overtook it. Kept because
+> the reasoning is what matters, not the conclusion.
+>
+> v1 said "measure a representative Java app". jos punctured it: *"what is a
+> representative java app :D"* — there is no good answer and v1 rested
+> entirely on it. v2 said measure the *discriminator* instead: how often the
+> client recolours the 1x1 source between consecutive requests, which is the
+> hit rate, measurable without building the cache.
+>
+> **What actually settled it** was noticing the measurement we already had
+> pointed at a different prize. The readback *copy* is trivial — 1.5 ms/s.
+> But `close_reasons[sync_wait=179]` out of 238 closes/s means **~75% of all
+> frame closes are this readback's sync-wait**, and `ops/frame_avg` collapses
+> to 1.6. A cache *hit* skips `get_image` and therefore skips the frame
+> close, so the cache's value is **restoring the frame batching**, not saving
+> a copy. That is worth having even where nobody notices the read.
+>
+> Two further corrections, both from jos:
+> - Colour cannot change *within* a run: Java's pipeline flushes its glyph
+>   list on a colour change, so **every `CompositeGlyphs` is one colour by
+>   construction**. The read is therefore already amortised over a whole run
+>   — 21 reads for a window of text, not one per glyph. "Per-draw readback on
+>   the hottest RENDER path" overstates it, and this plan said so repeatedly.
+> - Hit rate is `1 - (colour changes / requests)`, a property of the paint
+>   rather than the text. ~5 colours across 21 requests in a deliberately
+>   varied panel; much higher for anything text-heavy.
+>
+> The churn probe remains the one workload guaranteed to misrepresent this:
+> it was built to break the correlation between repaint rate and colour
+> stability, which in real UIs runs the other way. The hit/miss counters
+> shipped alongside the cache are what makes a client that defeats it
+> visible.
+>
+> **The cache and the ordering work are not competing levers** — a later
+> change that avoids closing the frame per read is still open, and the cache
+> does not foreclose it. Absolute timings still need real hardware; nothing
+> here was measured outside lavapipe.
 >
 > **Colour correctness across 32 concurrent colours.** In one churn frame
 > all 32 lines have distinct ink colours (32/32), the green channel is

--- a/docs/superpowers/plans/2026-09-10-glyph-drawable-source-plan.md
+++ b/docs/superpowers/plans/2026-09-10-glyph-drawable-source-plan.md
@@ -1,0 +1,268 @@
+# CompositeGlyphs with a drawable source — implementation plan (tier 1)
+
+Implements tier 1 of `../specs/2026-09-10-glyph-drawable-source-design.md`.
+Read that first; this plan does not restate its reasoning.
+
+> **Status 2026-09-10 — steps 1-4 landed; 5 and 6 need hardware.**
+>
+> | step | state |
+> |---|---|
+> | 1 recognise | `49b84374` |
+> | 2 read | `4c50ad2b` — Java text paints |
+> | 3 staleness regression | `e9c6f057` |
+> | 4 loud remaining drops | `08fa79f8` |
+> | 5 measure, then cache | measured in vng (below); the DECISION is open and is jos's |
+> | 6 hardware | Swing probe passes in vng; real hardware + xts `Xlib9` A/B still owed |
+>
+> **No cache exists yet, by design** (step 5 measures first). The
+> readback is attributed to `GetImageSite::GlyphSource`, which prints as
+> `get_image_by_site/s[… glyphsrc=N]`, so the measurement is a matter of
+> reading one field of the per-second telemetry line.
+>
+> Gates run so far: `cargo +nightly fmt --check`, `cargo clippy
+> --all-targets -- -D warnings`, `cargo test --workspace`, and the full
+> live acceptance suite on lavapipe — 144 of 145 pass, and the one
+> failure (`window_storage_init_covers_the_whole_allocation`) fails
+> identically with the branch's changes stashed. It is the known
+> uninit-storage defect, not this work.
+>
+> Step 2's live proof was checked for vacuity: with recognition forced
+> off, `uniform_drawable_glyph_source_paints_like_a_solid_fill` fails
+> with the destination still at its background colour, and the byte
+> order in that diff is what pins the channel order.
+>
+> **vng A/B, 2026-09-10 — the fix works; step 6's visual deliverable is
+> met in a guest, not on hardware.** `tools/vng-scenarios/java-xrender-text.sh`
+> runs the reporter's Swing probe under `tools/vng-shot.sh`, with no WM so
+> every glyph on screen came from Java. Same scenario, same 21 requests,
+> only the binary differs (`49b84374` = recognise-but-drop, i.e.
+> behaviourally pre-fix):
+>
+> | | pre-fix | fixed |
+> |---|---|---|
+> | `CompositeGlyphs32` dispatches | 21 | 21 |
+> | painted rects | 21 x **0** | 21 x **1** |
+> | `composite_glyphs gap` lines | 21 | **0** |
+>
+> Pre-fix the window, its borders and its Close button all paint and not
+> one glyph appears; fixed, every sample string renders including the
+> accented Czech line and the `Graphics2D.drawString()` panel. The
+> `xrender=false` control is correct on both, so the core-X11 text path is
+> untouched. Step 1's recognition log names the source exactly as the spec
+> predicted: `repeat=Normal mask_fmt=0 domain: None` over a 1x1 storage.
+>
+> **This is a guest, not hardware.** Pixel behaviour in vng has been
+> faithful before (it reproduced the wezterm white band bit-for-bit), so
+> the visual result should hold; timings must not be read across.
+>
+> **Step 5 input — the cost is the frame close, not the readback.** The
+> churn scenario (32 strings recoloured every 10ms, the worst case for a
+> per-draw read) gives, per second:
+>
+> - `glyphsrc=122..255` readbacks, and it is the ONLY `get_image` site
+>   firing;
+> - phase split `drain=104..274ms` vs `wait=17..57ms` vs `copyout=1.5ms` —
+>   the drain is 4-8x the fence wait;
+> - `frame_builder_opens=237 closes=238` with
+>   `close_reasons[sync_wait=179]`: **~75% of all frame closes are this
+>   readback's sync-wait**, and `ops/frame_avg=1.6` (max 5). The batching
+>   `composite_glyphs_via_frame_builder` exists to provide is gone.
+>
+> That reframes the step 5 decision rather than settling it, and the
+> reframing is the part worth keeping. A cache keyed
+> `(DrawableId, content_version, offset)` **misses by construction**
+> whenever the client recolours the 1x1 pixmap per string — which is
+> exactly what Java does — so it would buy nothing in this workload and
+> would only help a client painting many runs in one colour. The
+> alternative lever is the ordering itself: not closing the frame per
+> read. The spec requires `get_image`'s ordering for a reason — it is what
+> stops us racing Java's recolouring — so this is a real tension and needs
+> a decision, not a patch. Absolute timings still need real hardware; the
+> counts and the close-reason split do not.
+>
+> **Colour correctness across 32 concurrent colours.** In one churn frame
+> all 32 lines have distinct ink colours (32/32), the green channel is
+> bit-identical within each group of four and steps 31 per group exactly
+> as the probe's formula requires, and red/blue step 20/100 per line to
+> within the ±1 of sampling an antialiased pixel. A stale colour would
+> show as two lines sharing one; none do. Byte exactness stays pinned by
+> the unit tests, not by this.
+
+**Branch:** `fix/137-glyph-drawable-source`, off master. Closes #137.
+
+**Scope:** tier 1 only — a source whose *sampled domain* is one pixel under a
+repeat that covers the plane. Tier 2 (general drawable sources) is future
+work and must not be started here; the spec says why routing through the
+existing batch API does not survive contact.
+
+**Deliverable:** the reporter's Swing probe run with
+`-Dsun.java2d.xrender=true` shows every sample string, including the accented
+Czech line and the direct `Graphics2D.drawString()` panel.
+
+## Ordering principle
+
+**Recognise, then read, then prove, then measure, then optimise.**
+
+Recognition is pure and testable with no GPU. The read is the part with
+ordering and coordinate-space hazards, and is worth landing alone so a
+failure is unambiguous. The staleness test comes before any caching, so the
+cache is added against a test that already fails when it goes wrong. Caching
+is last and only on evidence — the spec requires measuring first.
+
+## Prerequisites
+
+- `cargo +nightly fmt`, `cargo clippy --all-targets -- -D warnings`,
+  `cargo test` clean before each commit. The clippy line must be exactly
+  CI's (`.github/workflows/ci.yml:35`, and AGENTS.md says so): CI fails on
+  any warning, and a run without `-D warnings` only *looks* clean.
+- Hardware for steps 5 and 6 only.
+- The instrumentation from `3af701db` stays: each step's evidence comes from
+  those log lines, and step 4 asserts against the drop counter.
+
+---
+
+## Step 1 — recognise an admissible source
+
+A predicate over `(SourceDrawable, Repeat, storage extent)`, no I/O:
+
+- **`mask_format == 0`.** Tier 1 is exact for Java's direct per-glyph
+  route, which is what `mask_format == 0` selects in Xorg
+  (`../xserver/render/glyph.c`). For `mask_format != 0` Xorg accumulates an
+  A8 mask and composites once; we do not — `render_composite_glyphs` takes
+  the parameter as **`_mask_fmt`** and ignores it, always taking the
+  per-glyph shortcut. That is a known deviation, and admitting a new class
+  of source into it would broaden incorrect behaviour rather than fix
+  anything. Keep dropping non-zero mask formats with a drawable source.
+- Sampled domain = `SourceDrawable::domain()` when `Some`, else the storage
+  extent. Admissible only when it is exactly 1×1.
+- Repeat ∈ `{Normal, Pad, Reflect}` — all three map one pixel onto the
+  plane. `None` is **not** admissible and must keep dropping.
+
+Nothing else changes yet: an admissible source still falls through to the
+existing drop, so this step is behaviour-neutral by construction.
+
+**Proof.** Table test over the cross product of {1×1, 1×2, 2×1, larger} ×
+{None, Normal, Pad, Reflect} × {mask_format 0, non-zero}, plus the
+redirected shape the spec calls out:
+a `SourceDrawable::content(id, offset, 1×1)` whose *storage* is much larger
+must be admitted, and a `whole()` over a 1×1 storage must be admitted. A test
+that only exercises `whole()` would pass while the window case stays broken.
+
+## Step 2 — read the pixel, ordered and in backing space
+
+Replace the drop for an admissible source with a read:
+
+- `RenderEngine::get_image(store, platform, Src::server_internal(backing_id),
+  rect, out_depth)` where `rect` is 1×1 at `SourceDrawable::offset()`.
+- `Src::server_internal` (`target.rs:108`), never a client-bounded `Src` —
+  the offset is already resolved and a bounded handle would reapply a
+  coordinate space.
+- `get_image` (`engine.rs:5486`) for the flush/close/wait ordering, never a
+  direct map.
+
+Convert the returned pixel to the `ResolvedSource::Solid([f32; 4])`
+convention: **premultiplied** RGBA. Two conversions to get right, and both
+are silent when wrong:
+
+- `get_image` packs to wire format via `pack_from_storage` keyed on
+  `out_depth`. Verify the channel order it produces rather than assuming
+  BGRA; a swap turns blue text red and nothing errors.
+- A depth-24 source has no alpha and must yield `a = 1.0`. Taking the stored
+  byte would give `a = 0` and paint nothing — the same symptom as the bug
+  being fixed, which would be maximally confusing.
+
+**Proof, in two parts** — the recording backend cannot serve this. `get_image`
+is a Vulkan synchronisation and readback path, so a recording-backend test
+would assert nothing about the thing most likely to be wrong.
+
+- **Pure, no GPU:** the byte→premultiplied-`[f32; 4]` conversion, as a free
+  function over a pixel buffer. Depth-32 and depth-24 (which must yield
+  `a = 1.0`), and a non-grey colour so a channel swap cannot pass. This is
+  where the two silent conversions above are actually pinned.
+- **Live Vulkan, `#[ignore]`:** the real ordered readback — a 1×1
+  `repeat=Normal` drawable source paints pixels identical to the equivalent
+  `CreateSolidFill`. **Only an absent required capability may skip**, and it
+  must say which one. Once the ICD is up and the capability is present,
+  every subsequent stage — seed allocation, painting, readback, the
+  assertions — must **fail**, never skip. Skipping on any error is how a
+  live proof becomes vacuous, and CI runs the ignored tests on lavapipe, so
+  the distinction is load-bearing rather than theoretical. Negative
+  cases belong here too: `repeat=None` at 1×1 still drops, a 2×2 source
+  still drops, and a non-zero `mask_format` still drops — under tier 1 none
+  of those may paint.
+
+## Step 3 — the staleness regression
+
+Java repaints the same 1×1 pixmap to change colour and reuses the picture.
+Write this test **before** any caching exists, so the cache in step 5 is
+added against a test that already fails when it is wrong.
+
+**Proof.** Paint text; repaint the source drawable a different colour; paint
+text again; assert the second run uses the new colour. With no cache this
+passes trivially — that is the point: it must be in place and green before a
+cache can make it fail.
+
+## Step 4 — make the remaining drops loud
+
+The spec's visibility note. A `CompositeGlyphs` that still cannot be served
+— `repeat=None`, a domain larger than 1×1, or a non-zero `mask_format` —
+logs at `warn!` on its **first** occurrence, then reverts to debug so a
+pathological client cannot flood the log.
+
+**Once per process, explicitly** — not "per generation". A bare backend
+flag does not reset itself at a generation boundary, and wiring one into the
+reset lifecycle means depending on the #121 reset work, which is unmerged
+and parked. Say once-per-process in the code comment so nobody reads
+per-generation intent into a flag that does not implement it; revisit if and
+when reset lands.
+
+**Proof.** One unsupported request warns; a hundred more do not. Assert the
+existing `composite_glyphs_dropped_unsupported` counter still advances on
+every one of them — the log is rate-limited, the counter is not.
+
+## Step 5 — measure, then cache only if the measurement says so
+
+A per-draw readback sits on the hottest RENDER path we have. Measure before
+deciding:
+
+- `yserver-mate-hw-telemetry` on a text-heavy workload, comparing glyph-path
+  cost before and after step 2. The spec's own risk section flags this; do
+  not skip to caching because it "obviously" needs it, and do not skip
+  caching because one run looked fine.
+
+If the numbers justify a cache, key it on **`(DrawableId, content_version,
+offset)`** — never `content_version` alone, which collides across drawables
+and across offsets into one backing. Populate only *after* the ordered read
+of step 2, never at `CreatePicture`.
+
+**Proof.** Step 3 stays green. Plus: two different drawables at the same
+`content_version` do not share an entry, and two different offsets into one
+backing do not share an entry. Both are the collisions the key exists to
+prevent, and neither is visible without an explicit test.
+
+## Step 6 — hardware
+
+- The reporter's Swing probe (`target/diag137/`), `-Dsun.java2d.xrender=true`:
+  all five sample strings, the accented Czech line, the
+  `Graphics2D.drawString()` panel. `xrender=false` must remain correct.
+- Confirm from the log that the gap no longer fires for the Java client and
+  that its requests now report a nonzero painted-rect count.
+- xts `Xlib9` A/B per `feedback_xts_ab_gates_pixel_changes`, zero PASS→FAIL,
+  since this changes pixels on the text path.
+
+## Hazards
+
+- **Testing the storage extent instead of the sampled domain** rejects the
+  redirected window case, which is the one that looks fine in a naive test.
+  Step 1's proof exists specifically to catch it.
+- **Reading at the storage origin instead of `offset()`** samples the wrong
+  pixel of a larger backing, and only in the redirected case — so it will
+  look correct in every simple test and wrong on a real desktop.
+- **Alpha and channel order** (step 2) both fail silently: wrong alpha paints
+  nothing, wrong order paints the wrong colour.
+- **Caching before measuring** is the temptation the spec explicitly guards
+  against; caching wrongly turns a total failure into an intermittent
+  wrong-colour one, which is harder to notice and harder to report than the
+  bug being fixed.
+- **Do not touch the `CreateSolidFill` fast path.** It serves every other
+  client on the desktop; tier 1 adds a branch beside it, not through it.

--- a/docs/superpowers/specs/2026-09-10-component-alpha-glyphs-design.md
+++ b/docs/superpowers/specs/2026-09-10-component-alpha-glyphs-design.md
@@ -398,7 +398,8 @@ budgets prospective glyph *uploads* only —
 `pending_pins_before_call + prospective_misses > ceiling` forces a
 close+reopen before anything is allocated (`render/engine.rs:6429-6436`) —
 and the instance buffer is pinned **afterwards**, one `pin_staging` per
-call (`render/engine.rs:6762`). One instance pin per call is invisible in
+call (`render/engine.rs:6762` before 4a; since 4a that pin lives inside
+`record_glyph_runs`, which pins once regardless of run count). One instance pin per call is invisible in
 that arithmetic today because it is always exactly one. With N runs it is N,
 taken after the check, so a request that splits can exceed a ceiling the
 pre-pass has already declared satisfied.
@@ -660,6 +661,59 @@ switch to force the fallback at runtime (`feedback_no_feature_kill_switches`).
   glyph's width changes which glyphs share a shelf and how much of each
   shelf is wasted. Not a correctness risk, but it is why the pressure above
   cannot be predicted from the 4× factor alone.
+
+## Corrections from the implementation (2026-09-10)
+
+Three things this design got wrong, found by mutation-testing step 5 rather
+than by review.
+
+**Invariant 9 is not assertable by any pixel test.** The proof list expected
+a live test to catch "a stretched `atlas_wh`". It cannot: the component-alpha
+path never *reads* `atlas_wh` — that is precisely what invariant 9 says — so
+passing `4w` there changes nothing observable. Mutation-verified: it survives
+every pixel test and dies only to a pure assertion on the instance struct. A
+property about what the shader does not read can only be pinned structurally.
+
+Relatedly, `atlas_wh` is now **dead weight on the component-alpha path** —
+written and never read. Kept so one instance layout serves both
+specialisations; a second vertex-input description would buy nothing.
+
+**The two live oracles need opposite destinations, and neither alone
+suffices.** `cov_a` read as a constant 1 is invisible on an *opaque*
+destination, because `cov_a + dst.a*(1 - cov_a) == 1` regardless — it is only
+catchable on a transparent one. Conversely a wrong `out_color1.rgb`, or blend
+state derived without component-alpha while the shader emits per-channel, is
+invisible on a *transparent* destination, because the `1 - SRC1` term is
+multiplied by `dst == 0`. So the per-channel test and the coordinate test are
+**complementary, not redundant**, and consolidating them would silently drop
+coverage.
+
+**The pipeline build belongs after the per-glyph walk, not before it.** Stage
+2's wording implies it stays where it was. Deriving the required pipelines
+from the inputs' *protocol tags* leaves emit able to look up a pipeline
+nobody built: the atlas has no eviction, so a glyphset xid reused across
+formats can return a stale entry whose layout disagrees with the tag, and
+emit then fails with `NoVk`. It must be derived from the recorded glyphs'
+**atlas entries** — the thing the run actually binds. Invariant 7c is
+unaffected: the close+reopen decision does not move, and building a pipeline
+is not a frame op.
+
+## Residual, explicitly accepted
+
+Two live proofs this design asks for are **not** implemented, and neither is
+covered by an equivalent:
+
+- the mixed-format test with **overlapping quads under a non-commutative
+  op**. Order preservation is covered purely, and pixel-identity of a
+  two-range recording is covered by 4a's
+  `a_glyph_run_split_into_two_ranges_renders_as_one_range`, but the
+  combination that would catch a regrouping splitter *in pixels* is absent.
+- a live assertion that a split request produces **one damage union**. The
+  mixed-format test asserts the one returned *region*; the damage event is
+  unasserted.
+
+Both are cheap and both are real gaps. Recorded here rather than quietly
+dropped.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-09-10-component-alpha-glyphs-design.md
+++ b/docs/superpowers/specs/2026-09-10-component-alpha-glyphs-design.md
@@ -1,0 +1,679 @@
+# Component-alpha (subpixel) glyphs — design
+
+**Found by:** #137. Java AWT/Swing text became visible when tier 1 admitted
+a drawable glyph source, and most of it renders as **solid blocks** — one
+filled rectangle per glyph, correctly positioned and advanced, with no
+letterform. Reproduced on hardware (silence, MATE) and in a vng guest.
+
+**Not a regression from #137.** `parse_add_glyphs`, the glyph atlas and the
+mask path are byte-identical to `a06cf0e0` on that branch. The blocks were
+always there; nothing painted at all before, so nobody could see them.
+
+## The defect
+
+`parse_add_glyphs` (`kms/backend.rs:1063`) reduces an `ARGB32` glyph to its
+**alpha byte** and records the stored glyph as `A8`:
+
+```rust
+GlyphSetFormat::Argb32 => {
+    // memory order [B, G, R, A]
+    pixels[row * w + col] = wire[row_off + col * 4 + 3];
+    (pixels, GlyphSetFormat::A8)
+}
+```
+
+Measured on OpenJDK 25's LCD glyphs (temporary instrumentation, one vng run):
+
+```
+argb32 glyph 0x1  9x9: alpha distinct=1  [(255, 81)]   max(rgb) distinct=28
+argb32 glyph 0x2 11x9: alpha distinct=1  [(255, 99)]   max(rgb) distinct=34
+argb32 glyph 0x6  9x9: alpha distinct=1  [(255, 81)]   max(rgb) distinct=46
+```
+
+**Alpha is 255 across the entire glyph box** — one distinct value covering
+all 81 pixels of a 9×9 glyph. The coverage lives in R, G and B, one channel
+per subpixel. So the extracted "A8" glyph is a solid `0xFF` rectangle, which
+is exactly what lands on screen.
+
+**The discriminator is the glyphset format, not the source kind.** Java
+creates two glyphsets and picks by the desktop's text-antialiasing setting:
+
+```
+create_glyphset 0x400012 ynest_format=2 -> A8       (grayscale AA)
+create_glyphset 0x400013 ynest_format=4 -> Argb32   (subpixel AA)
+```
+
+`-Dawt.useSystemAAFontSettings=lcd` reproduces the blocks; `gasp` renders
+correctly. That is why the first vng runs looked perfect while hardware did
+not: a bare guest has no settings daemon, so its default was grayscale.
+`tools/vng-scenarios/java-xrender-text.sh` takes `YS_JAVA_AA` to force it.
+
+**Xorg is the oracle and it renders this correctly**, with visible subpixel
+fringing, from the identical scenario under `vng-shot --server xorg`.
+
+Affects every toolkit that asks for subpixel AA, not just Java — which is
+the default on MATE, GNOME and KDE.
+
+## What Xorg does
+
+```c
+/* render/render.c:996 */
+#define NeedsComponent(f) (PICT_FORMAT_A(f) != 0 && PICT_FORMAT_RGB(f) != 0)
+```
+
+At `AddGlyphs` (`render/render.c:1031`) Xorg computes
+`component_alpha = NeedsComponent(glyphSet->format->format)` **once per
+glyphset**, and creates every glyph's picture with `CPComponentAlpha`
+(`render/render.c:1133-1136`). Any format carrying both alpha and RGB —
+`ARGB32` — is therefore a component-alpha picture, per glyph, always.
+
+Then, for `maskFormat == 0` (Java's case), `render/glyph.c:653` composites
+each glyph as the **mask**:
+
+```c
+CompositePicture(op, pSrc, pPicture /* the glyph */, pDst, ...);
+```
+
+A component-alpha mask contributes its R, G and B as **per-channel**
+coverage; a normal mask contributes only its alpha. Same source picture,
+same op — the whole difference is that one flag on the mask.
+
+For `maskFormat != 0` (`render/glyph.c:610`) Xorg derives component-alpha
+from the *mask* format, accumulates every glyph into an `ARGB32` mask
+picture with `PictOpAdd`, and issues one component-alpha composite. That is
+cairo/Pango's subpixel route. **Out of scope here — see the last section.**
+
+Component-alpha semantics, per channel:
+
+```
+result.C = src.C * mask.C + dst.C * (1 - src.A * mask.C)
+```
+
+## What we already have
+
+Most of this is built. The gap is entirely on the glyph side.
+
+- **The blend state.** `PictOp::blend_factors`
+  (`vk/render_pipeline.rs:257-275`) already swaps the `SRC_ALPHA` family for
+  `SRC1_COLOR` / `ONE_MINUS_SRC1_COLOR` when `component_alpha` is set, and
+  it is `pub(crate)` *specifically* so the text pipeline derives from the
+  same table — its own doc comment says so. Nothing there needs to change.
+- **The maths.** `shaders/render.frag.glsl:257-263` already implements the
+  semantics above, including the per-channel Disjoint/Conjoint variant:
+  ```glsl
+  s          = vec4(src.rgb * mask_sample.rgb, src.a * mask_sample.a);
+  src_alpha  = vec4(src.a   * mask_sample.rgb, src.a * mask_sample.a);
+  ```
+  with `src_alpha` emitted to output location 1 for the `SRC1_*` factors.
+- **The capability and its fallback are already declared.**
+  `vk/device.rs:482-506`: `dualSrcBlend` is an optional Vulkan 1.0 feature
+  (Broadcom V3D ships without it), the device layer enables only what is
+  supported, and it already warns that "a missing dualSrcBlend degrades
+  component-alpha (subpixel text AA) to grayscale AA". That promise is
+  currently unimplemented for glyphs — today it degrades to *blocks*.
+- **The sampler is already exact for this.** The glyph sampler is `NEAREST`
+  with `CLAMP_TO_EDGE` (`vk/text_pipeline.rs:207-215`) and glyphs are 1:1
+  with the destination, so no filtering can smear across packed channels.
+
+What is missing:
+
+| where | today |
+|---|---|
+| `kms/backend.rs:1063` | throws R, G, B away at the wire |
+| `vk/glyph.rs:46,130` | atlas is a fixed 4096² **`R8_UNORM`**, alpha-only by construction |
+| `vk/text_pipeline.rs:350` | hardcodes `component_alpha = false`, "glyph path has no dual-source output" |
+| `shaders/text.frag.glsl` | samples `.r` only, one output |
+
+## Design
+
+### Stage 0 — stop destroying the information
+
+An `ARGB32` glyph stays `ARGB32` in `StoredGlyph`. Today `parse_add_glyphs`
+rewrites `stored_format` to `A8`; that line is the bug's origin. `A8` and
+`A1` are untouched, and `GlyphSetFormat::Argb32` stops being unreachable in
+`render_composite_glyphs` (`render/backend.rs:23314` currently treats it as
+a defensive "cannot happen" and skips the glyph).
+
+### Stage 1 — where the four coverages live
+
+**The decision this spec exists to make.** Three options:
+
+- **(a) A second atlas image**, `R8G8B8A8_UNORM`, allocated lazily on the
+  first component-alpha glyph, with its own view and descriptor. Clean
+  separation; conventional. Costs a second descriptor binding (or a second
+  set) and a second residency/eviction budget. At the current 4096² an RGBA
+  atlas is 64 MiB, so it also needs a size decision the A8 atlas never had
+  to make.
+- **(b) Pack the four channels as four horizontally adjacent texels in the
+  existing R8 atlas** — a `w × h` glyph occupies `4w × h`. No new image, no
+  new descriptor, no new memory budget. The shelf packer already takes an
+  arbitrary `(w, h)` (`vk/glyph.rs:338`), so the pack call site is a
+  one-line change, and the `NEAREST` sampler makes four `texelFetch`es
+  exact.
+- **(c) One `RGBA` atlas for everything.** Simplest shader — one sample —
+  but 4× the memory for the overwhelmingly common A8 case and a rewrite of
+  the existing upload path for no benefit to it.
+
+**Four channels, not three.** An earlier draft of this section packed only
+R, G and B, on the grounds that Java's alpha byte is 255 and therefore
+carries nothing. That is wrong twice over: stage 2 below needs `cov_a` for
+the alpha channel's own blend factor, and Xorg's rule
+(`NeedsComponent`) applies component-alpha to **every** `ARGB32` glyphset,
+not only to the ones whose alpha happens to be constant. Dropping alpha
+would work for this JVM and break on the next client. The cost of a
+component-alpha glyph is therefore **4×** its area, not 3×.
+
+**Recommend (b), at `4w`.** It reuses the atlas, its packer, its residency
+discipline, its eviction and its single descriptor, and the glyph path never
+filters so the packing is lossless. Note honestly that at four channels its
+*memory* advantage over (a) is gone — both cost 4 bytes per glyph pixel —
+and what remains is that no second image, view, descriptor binding or
+residency budget has to exist, and that A8 glyphs keep byte-identical
+behaviour in the atlas they already live in. (c) is rejected: it taxes every
+A8 glyph for a minority case.
+
+**Channel order is part of the contract.** Incoming `ARGB32` wire bytes are
+`[B, G, R, A]` (little-endian CARD32, alpha at bits 24-31 — the order
+`parse_add_glyphs` already assumes at `kms/backend.rs:1065`). The packed
+atlas texels must hold **logical R, G, B, A in that order**. State it in the
+code at both the upload and the sample site: this is the same trap that cost
+a round in #137 — a channel swap paints plausible-looking text in the wrong
+colour and nothing errors.
+
+`AtlasEntry` (`vk/glyph.rs:66`) then needs to carry the **logical** width
+alongside the packed width — the dst quad is `w` wide while the atlas
+footprint is `4w`. Store them separately rather than deriving one from a
+`channels` count: a derived value invites one of the two call sites to use
+the wrong one, and the failure mode is a subtly misaligned glyph rather than
+an error.
+
+**Rename both fields; do not add one beside `w`.** `AtlasEntry.w` currently
+drives *both* meanings, a few lines apart in the same loop: the upload's
+copy region (`render/engine.rs:6661`) wants the **packed** width, while the
+damage extent and the instance data (`render/engine.rs:6629`, `:6637`) want
+the **logical** one. Leaving the name `w` and adding a second field means
+every existing use silently keeps whichever meaning it had, and half of them
+would be wrong. Rename to `packed_w` and `logical_w` so that each existing
+consumer has to be visited and misuse either fails to compile or reads as
+obviously wrong. `RecordedTextGlyph.w` and `RecordedGlyphUpload.w`
+(`render/frame_builder.rs:457`) are separate copies of the same value and
+each must take the correct one of the two.
+
+Audit every consumer of the field as part of this, not afterwards. There is
+**no active eviction or LRU path** in the atlas today, so there is no
+eviction-side footprint question to answer — worth writing down so nobody
+goes looking for one.
+
+Alongside the two widths, `AtlasEntry` carries a **layout enum** —
+`A8` | `ComponentAlpha`. That is sufficient, and a separate channel-count
+field is **not** wanted: the layout is what selects the pipeline and what
+tells the shader whether the explicit plane stride is meaningful, and a
+count beside it would be a second encoding of the same fact, free to
+disagree with it.
+
+`GlyphKey` is `{font_xid, codepoint}` (`vk/glyph.rs:55`) and `font_xid` is
+the glyphset xid, so an A8 and an ARGB32 glyph can never collide on a key.
+No key change is needed — but the entry must record which layout it has, or
+the shader cannot know how to sample it.
+
+**One caveat on that key.** The same field carries a *core font* host xid
+when the glyph came from `image_text` and a *glyphset* host xid when it came
+from `composite_glyphs`; both paths share this one atlas. Until now a
+collision between the two namespaces would have been merely a wrong glyph
+image. Once entries carry a layout, a collision means a core-text glyph
+sampling a 4-plane entry as if it were 1-plane. Confirm the two host-xid
+namespaces cannot collide (single allocator ⇒ they cannot) and assert it,
+rather than leaving it as a property nobody has written down.
+
+### Stage 1b — the coordinate path
+
+Underspecified in the first draft, and the failure modes are silent in both
+directions. `text.vert.glsl:46` interpolates **one** atlas rectangle across
+the destination quad:
+
+```glsl
+v_uv = (atlas_xy + quad * atlas_wh) / pc.atlas_extent;
+```
+
+So for a `4w × h` allocation:
+
+- passing `4w` as `atlas_wh` **stretches one glyph across all four planes**;
+- passing `w` with no further information **samples only the first plane**.
+
+The contract:
+
+- `atlas_wh` stays the **logical** `(w, h)`. The A8 path's vertex and
+  fragment maths then does not change at all, which is invariant 1.
+- The **packed allocation width `4w` never reaches the shader.** It exists
+  only in the packer (`vk/glyph.rs:338`) and the uploader. `AtlasEntry`
+  carries both; only the logical one goes into instance data.
+- Add a per-instance **plane stride** in texels and the glyph's **atlas
+  origin** in texels, both delivered `flat` to the fragment shader. The
+  fragment shader for `COMPONENT_ALPHA` then fetches
+  `atlas_origin + ivec2(local.x + k * stride, local.y)` for `k` in `0..4`.
+- **The local offset must be spelled out, not gestured at.** `quad *
+  dst_size` is integral *at the vertices only* — it is interpolated before
+  the fragment shader ever sees it, so "use the integral quantity" is not an
+  instruction anyone can implement. Concretely: emit it as a varying
+  `v_local` (`quad * dst_size`, so `0..w` × `0..h` across the quad) and take
+  `ivec2(floor(v_local))` in the fragment shader. That is exact because the
+  quad is pixel-aligned — `dst_origin` and `dst_size` are whole pixels — so
+  fragment centres sample `v_local` at `i + 0.5` and `floor` recovers `i`.
+  The alternative is a `flat` `dst_origin` plus
+  `ivec2(gl_FragCoord.xy) - dst_origin`, which `render.frag.glsl:281`
+  already does in spirit for its dst readback; either is fine, but the spec
+  picks one and the code comments why.
+- What must **not** happen is recovering the offset by multiplying `v_uv`
+  back up by `atlas_extent`. That round trip through a normalised divide and
+  back lands half a texel out at glyph edges, and the symptom is a
+  one-pixel colour fringe on some glyphs and not others.
+- Carry the stride explicitly even though it currently equals `dst_size.x`.
+  That identity holds only because glyph blitting is 1:1; deriving from it
+  couples the sampling to an unrelated invariant, and the failure mode is a
+  glyph sampling its neighbour's plane.
+
+This changes the vertex input description and the instance buffer stride.
+`TextPushConsts` has compile-time asserts locking its size and field offsets
+(`text.vert.glsl:19-23` documents them); the instance layout deserves the
+same treatment rather than an unchecked `repr(C)`.
+
+### Stage 2 — the pipeline and the shader
+
+`text.frag.glsl` gains a `COMPONENT_ALPHA` specialization constant. When
+set, it gathers the **four** packed coverages — logical R, G, B, A from four
+adjacent texels — and emits **exactly what `render.frag.glsl:262-263`
+emits**, with the packed coverage standing in for `mask_sample`:
+
+```glsl
+// Dual-source: SECOND INDEX of location 0, not a second location —
+// exactly as render.frag.glsl:66 declares it. The SRC1_* blend
+// factors reference index 1 of attachment 0; a `location = 1`
+// output is a second attachment and would not link.
+layout(location = 0)          out vec4 out_color;
+layout(location = 0, index = 1) out vec4 out_color1;
+
+// cov.rgb = logical R,G,B coverage; cov_a = the glyph's own alpha
+out_color  = vec4(fg.rgb * cov.rgb, fg.a * cov_a);
+out_color1 = vec4(fg.a   * cov.rgb, fg.a * cov_a);
+```
+
+Sampling is by `texelFetch` at `atlas_x + k*w + u` for `k` in `0..4`, not by
+UV interpolation across the packed run: the four planes are distinct images
+that happen to be adjacent, and any filtering between them is meaningless.
+The sampler is already `NEAREST` (`vk/text_pipeline.rs:207-215`), so this is
+belt-and-braces rather than a change, but it should be `texelFetch` so the
+intent survives a future sampler change.
+
+The two shaders must be read side by side when this is written; a divergence
+here is a per-channel blend that is subtly wrong on one path only.
+
+`text_pipeline.rs` stops passing `false` and keys its pipeline cache on
+`component_alpha`, as `RenderPipelineCache` already does
+(`render_pipeline.rs:438`). Because both derive from `blend_factors`, the
+two paths then agree on blend state by construction rather than by review.
+
+### Stage 2b — one request can mix both glyph formats
+
+**The gap that would have broken this in the field.** A single
+`CompositeGlyphs` request may switch glyphsets mid-stream: the items parser
+tracks a mutable `active_gs_xid` that the inline `count == 255` element
+rewrites (`render/backend.rs:23270-23274`). Different glyphsets may have
+different formats. So **one request can interleave A8 and ARGB32 glyphs.**
+
+Pipeline state is immutable, and it is chosen **once per recorded glyph
+op** — `text_pipelines.get(&(cg.op, format, dst_has_alpha))`
+(`render/engine.rs:9089-9091`), after which a single `vkCmdDraw` covers all
+`cg.instance_count` instances. Adding `component_alpha` to that key makes a
+run homogeneous by construction, which means the mixed request must be
+**split**.
+
+**Split into contiguous runs in request order**, each recorded as its own op
+with its own pipeline.
+
+**The split belongs in the engine, not the parser.** The runs are formed in
+`composite_glyphs_via_frame_builder`, which already owns pipeline
+construction, the instance buffer, frame ordering and pin accounting.
+Splitting in `render_composite_glyphs` would push all four of those up into
+the backend for no gain.
+
+**Ownership of the two facts is split, deliberately.** The backend parser
+tags each `CompositeGlyphInput` with the glyph's **source format** — that is
+protocol state, read from the glyphset. The **engine** derives the
+**effective `GlyphLayout`** from it, because that mapping depends on
+`component_alpha_supported`, which is device state the backend has no
+business consulting. Keeping the derivation in the engine puts the fallback
+decision in the same place as atlas allocation and pipeline choice, so the
+three cannot disagree.
+
+What must stay **request-wide**, one per request, not one per run:
+
+- the returned clip region the backend computes and hands back
+  (`render/backend.rs:23438` — one `composite_glyphs` call, one region);
+- the append-time damage union (`render/engine.rs:6698`, computed from
+  `damage_min/max` over the whole call);
+- the single `mark_contents_modified`.
+
+A client sees one request; it must see one damage event and one region for
+it, however many draws we happened to issue.
+
+**`first_instance` does not exist yet and must be plumbed end to end.**
+`RecordedCompositeGlyphs` carries only `instance_pin` and `instance_count`
+(`render/frame_builder.rs:463`), and `record_text_run_scissored` hardcodes
+the draw's `firstInstance` to zero — `cmd_draw(cb, 4, instance_count, 0, 0)`
+(`vk/ops/text.rs:212`). Three sites, all of which must change together:
+the recorded op gains the field, emit passes it through
+(`render/engine.rs:9089-9103`), and the draw call uses it. A partial job
+here draws run 0's glyphs for every run, which looks like duplicated text
+rather than like an unplumbed parameter.
+
+**Split on the EFFECTIVE layout, not the glyphset format.** Where
+`dualSrcBlend` is absent, stage 3 reduces ARGB32 to A8 at upload — those
+glyphs are then genuinely A8 in the atlas and belong in an A8 run. Keying
+the splitter on the original glyphset format would manufacture runs that
+differ in nothing, splitting draws for no reason. It also gives the fallback
+a clean property worth stating: on a device without `dualSrcBlend` every
+glyph has the same effective layout, so there is exactly **one** run and the
+splitter is inert.
+
+**Do not regroup all the A8 glyphs together.** Grouping by format is the
+obvious optimisation and it is wrong: PictOps are not commutative in
+general, so reordering changes pixels wherever glyph quads overlap — and
+overlap is ordinary, not exotic (kerning, italics, combining marks). The
+existing comment at the head of `render_composite_glyphs` already makes the
+same point from the other side: the per-glyph and accumulate forms differ
+precisely for *overlapping* glyph quads, and are identical only for the
+associative `Add`.
+
+The cost is bounded and worth stating: a stream that alternates format every
+glyph degrades to one draw per glyph. That is exactly what Xorg does anyway
+on this path — `render/glyph.c:653` issues one `CompositePicture` per glyph
+for `maskFormat == 0` — so our worst case is Xorg's normal case. Real
+clients switch glyphsets per font or AA change, so the common case stays a
+single run.
+
+### Stage 2c — the run split must be inside the pin ceiling
+
+**A hard ceiling that the split can walk straight through.** The pre-pass
+budgets prospective glyph *uploads* only —
+`pending_pins_before_call + prospective_misses > ceiling` forces a
+close+reopen before anything is allocated (`render/engine.rs:6429-6436`) —
+and the instance buffer is pinned **afterwards**, one `pin_staging` per
+call (`render/engine.rs:6762`). One instance pin per call is invisible in
+that arithmetic today because it is always exactly one. With N runs it is N,
+taken after the check, so a request that splits can exceed a ceiling the
+pre-pass has already declared satisfied.
+
+**One shared instance buffer, per-run ranges.** All runs' instance data goes
+into a single allocation; each recorded op carries a
+`(first_instance, count)` range into it. That keeps the pin count at exactly
+one per call regardless of how many runs there are, which is the property
+the rest of this section depends on. The alternative — budget `run_count`
+pins — needs the run count *before* the pre-pass, so the pre-pass would have
+to move or run twice.
+
+**But "one pin per call, arithmetic unchanged" is not a fix.** An earlier
+draft of this section stopped there, and that was wrong: the arithmetic is
+already off by one, so preserving it preserves a ceiling violation. The
+pre-pass compares `pending_pins_before_call + prospective_misses` against
+the ceiling and the per-glyph rule compares
+`new_uploads.len() + 1 + pending_pins_before_call` — **neither reserves
+anything for the instance buffer**, which is then pinned unconditionally.
+A call that exactly fills the ceiling with uploads therefore ends the frame
+at `ceiling + 1` pins. It is invisible today only because nobody has looked;
+the run split does not cause it, but a design that adds draws next to it
+must not leave it.
+
+**Reserve the draw buffer's pin in both places.** One pin, budgeted:
+
+- the pre-pass becomes
+  `pending_pins_before_call + prospective_misses + 1 > ceiling`;
+- the single-call overflow branch (`render/engine.rs:6488`) becomes
+  `prospective_misses + 1 > ceiling`;
+- the per-glyph admission rule (`render/engine.rs:6567`) becomes
+  `new_uploads.len() + 1 + pending_pins_before_call + 1 > ceiling`, i.e.
+  when uploads and the draw buffer cannot both fit, **drop uploads to leave
+  room for the draw**. Dropping a glyph loses one glyph; losing the draw
+  loses the whole run.
+- and `note_pin_ceiling_hit_once` (`render/engine.rs:6436`) reports the
+  **reserved** total, `pending_pins_before_call + prospective_misses + 1`.
+  Its argument is the attempted pin count; leaving it at the unreserved sum
+  would have the one diagnostic that exists for this ceiling understate the
+  very number the new rule is there to make truthful.
+
+**`image_text` has the identical hole** (`render/engine.rs:5954`, same rule,
+same unconditional instance pin) and takes the same reservation. Fixing only
+the glyph path would leave core text able to exceed the same ceiling, which
+is a worse state to be in than the current uniform bug: two paths that look
+alike and behave differently.
+
+**Test the pin count, not the outcome.** A low ceiling plus an alternating
+A8/ARGB32 stream, asserting the frame's **actual** `pins.len()` never
+exceeds `max_pinned_resources_per_frame()`. "It rendered" passes under the
+off-by-one; only counting the pins distinguishes budgeted from lucky.
+
+`cov_a` is the glyph's own alpha, read from the fourth packed texel — the
+one place the alpha byte is still used, deliberately. Xorg uses `mask.a` for
+the alpha channel's factor and `mask.rgb` for the colour channels' factors
+(`render.frag.glsl:262-263` reproduces exactly that), so `cov_a` must come
+from the glyph and must **not** be assumed to be 1. It is 1 for this JVM;
+that is a property of this client, not of the format.
+
+### Stage 3 — the no-`dualSrcBlend` fallback
+
+Not optional: `device.rs` already promises grayscale AA there, and today it
+delivers blocks.
+
+**The reduction happens at upload, not in the shader.** When
+`component_alpha_supported` is false, `ARGB32` glyph wire bytes are reduced
+to a single A8 plane — coverage = the mean of logical R, G and B,
+`(r + g + b + 1) / 3`, rounded to nearest — and packed at **logical width
+`w`**, exactly like a real A8 glyph. The existing single-output shader and
+pipeline then serve it unchanged.
+
+Note that the mean is **symmetric in its arguments**, so no test of the
+reduction can detect an R↔B transposition; only the packed path's
+exact-texel assertion can. Do not claim otherwise in the reduction's own
+tests — the mistake they actually guard against is reading bytes `1..=3`
+(including alpha, dropping blue).
+
+Saying "the shader computes the mean" would not have worked, and this is the
+hole the first draft left: with `COMPONENT_ALPHA = 0` the existing shader
+samples **one** R8 texel, so against a 4-wide packed glyph it would read the
+R plane alone and silently render red-channel-only coverage — not a mean, and
+not obviously wrong on screen.
+
+Deciding at upload is also the right shape for what the capability *is*:
+`component_alpha_supported` is fixed for the life of the device
+(`vk/device.rs:502`), so there is never mixed state in the atlas, and the
+reduction is a pure function of the wire bytes — which is what lets it be
+tested directly instead of behind a runtime switch
+(`feedback_no_feature_kill_switches`).
+
+The consequence is named: no colour fringing, and stroke weight very
+slightly different from a true grayscale-AA rasterisation, because the
+client rasterised for subpixel geometry. It is a large improvement on blocks
+and it is what the device layer already tells the user we do.
+
+Reducing at upload also keeps `image_text` structurally out of this: on a
+device without `dualSrcBlend` nothing in the atlas is ever 4-plane, so the
+core-text path cannot encounter one.
+
+### Stage 3b — the `image_text` boundary
+
+`image_text` takes `&[PreparedGlyph]` (`engine.rs:8798`), not
+`CompositeGlyphInput` — `PreparedGlyph.pixels` is a `Vec<u8>` the server
+rasterised itself from a core font, always A8. The two paths are *not*
+coupled through the input type.
+
+What they **do** share is the glyph atlas and the recorded text-run op, and
+that is where the boundary has to be asserted:
+
+- an `image_text` glyph must always intern as a **single-plane A8** entry;
+- the atlas key namespaces must not collide (stage 1's caveat);
+- `image_text` must never select a component-alpha pipeline.
+
+State it and test it. `CompositeGlyphInput`'s own doc comment currently
+promises "dense A8 (native a8 / ARGB32-preconverted) or raw A1 wire"
+(`engine.rs:8807-8815`) — that sentence becomes false under this design and
+is the natural place to record the new rule.
+
+Both lavapipe and RADV report `dualSrcBlend = true`, so CI exercises the
+**real** path, not the fallback — the fallback needs its own coverage. Make
+the reduction a pure function and unit-test it directly; do **not** add a
+switch to force the fallback at runtime (`feedback_no_feature_kill_switches`).
+
+## Invariants
+
+1. An `A8` or `A1` glyphset renders **byte-identically** before and after.
+   That is the overwhelmingly common path and it must not move.
+2. **Colour** coverage for a component-alpha glyphset comes from R, G and B,
+   never from the alpha byte. Reading the alpha byte for coverage *is* the
+   current defect, and on Java's glyphs it is 255 everywhere, so the failure
+   is silent and total.
+3. The glyph's alpha is nonetheless preserved and used, for the alpha
+   channel's own blend factor. A client whose `ARGB32` glyphs carry a real
+   alpha must render correctly; that Java's is constant 255 is a property of
+   Java, not of the format.
+4. Channel order is fixed and stated at both ends: wire `[B, G, R, A]` →
+   packed texels **logical R, G, B, A**. A swap here paints wrong-coloured
+   text and errors nothing.
+5. `PictOp::blend_factors` stays the single source of blend state for both
+   the render and the text pipeline.
+6. Where `dualSrcBlend` is absent the result is grayscale-antialiased
+   letterforms — never blocks, never nothing, and never one channel
+   mistaken for a mean.
+7. A recorded glyph run is homogeneous in **effective** layout, and runs
+   preserve **request order**. Glyphs are never regrouped by format:
+   PictOps are not commutative and glyph quads overlap.
+7a. One request produces one clip region, one damage union and one
+    `mark_contents_modified`, however many runs it split into. The client
+    issued one request and must observe one.
+7b. One instance-buffer pin per call, **and that pin is budgeted** — in the
+    pre-pass, in the single-call overflow branch and in the per-glyph
+    admission rule. A frame never ends above
+    `max_pinned_resources_per_frame()`. When uploads and the draw cannot
+    both fit, uploads are dropped.
+7c. The close+reopen decision stays **before** the per-glyph walk, exactly
+    where it is now. The engine routine is entered once per request and
+    forms runs internally; it is never invoked once per run. That is what
+    keeps 7a true and the frame ordering intact.
+8. `image_text` only ever forms A8/A1 glyphs and only ever interns
+   single-plane atlas entries. It shares the atlas and the recorded text-run
+   op with `composite_glyphs`, so this is a boundary to assert, not a
+   property to assume.
+9. The packed allocation width never reaches the shader. Instance data
+   carries the logical width and an explicit plane stride.
+10. Xorg is the oracle for pixels, run from the same scenario in the same
+    guest, not from a reading of the spec
+    (`feedback_check_xorg_fb_impl_for_render_conventions`).
+
+## Proof
+
+- **Pure, no GPU:** the wire → packed-atlas conversion, over a glyph with
+  **four mutually distinct, asymmetric channel values** (say
+  `B=0x20 G=0x60 R=0xA0 A=0xE0`), asserting the packed texels are exactly
+  `[0xA0, 0x60, 0x20, 0xE0]`. Deliberately not a `r != g != b` style check:
+  that passes with red and blue reversed, which is the single most likely
+  mistake here. A real measured Java glyph goes in alongside as a second
+  fixture (alpha constant 255, `max(rgb)` spanning 28 distinct values), so a
+  regression to the alpha byte fails loudly instead of producing a
+  plausible-looking solid block.
+- **Pure:** the stage-3 upload-time reduction — mean of logical R, G, B, at
+  logical width `w` — and that a component-alpha glyph and an A8 glyph each
+  take their own path and never the other's.
+- **Pure, and this one is the new gap:** the run splitter. Feed an items
+  stream that switches glyphsets mid-element via the `count == 255` inline
+  form, alternating A8 and ARGB32, and assert the resulting runs are
+  (a) homogeneous, (b) **in the original glyph order**, and (c) that no
+  glyph is lost or duplicated at a boundary. A test that only checks
+  homogeneity would pass a splitter that regroups, which is the wrong
+  answer for every op but `Add`.
+- **Pure:** the splitter keys on effective layout — with the
+  no-`dualSrcBlend` reduction in force, an alternating stream yields
+  **one** run, not many.
+- **Live Vulkan, `#[ignore]`, at a lowered pin ceiling:** an alternating
+  A8/ARGB32 stream, asserting the frame's **actual `pins.len()`** never
+  exceeds `max_pinned_resources_per_frame()`. Assert the count, not that it
+  rendered — "it rendered" passes under the current off-by-one, so only the
+  count distinguishes budgeted from lucky. A case that exactly fills the
+  ceiling with uploads is the one that catches the missing reservation.
+- **The same test for `image_text`**, which carries the identical rule and
+  the identical hole.
+- **Live Vulkan, `#[ignore]`:** a split request still reports **one**
+  damage union and **one** returned region. Assert the region, not just
+  the pixels — a per-run region is the kind of change that looks harmless
+  and breaks a compositor's damage tracking.
+- **Live Vulkan, `#[ignore]`:** the mixed-format request end to end — an A8
+  glyph and an ARGB32 glyph in ONE `CompositeGlyphs`, with **overlapping**
+  quads and a non-commutative op, so a regrouping splitter produces
+  visibly different pixels and fails.
+- **Live Vulkan, `#[ignore]`:** the coordinate path in isolation — a
+  component-alpha glyph whose four planes hold four distinct constants, so
+  a stretched `atlas_wh`, a first-plane-only sample and a half-texel offset
+  each produce a different, recognisable wrong answer.
+- **Pure or live:** an `image_text` run interns single-plane entries only,
+  and the core-font / glyphset atlas key namespaces do not overlap.
+- **Live Vulkan, `#[ignore]`:** an ARGB32 component-alpha glyphset paints
+  per-channel coverage. Seed the glyph with known asymmetric per-channel
+  coverage and assert the destination's R, G and B against **exact expected
+  values** derived from the component-alpha equation — not merely that they
+  differ, which a red/blue swap satisfies. A grayscale result has
+  `r == g == b`, so this assertion separates a real component-alpha
+  composite from a convincing approximation of one *and* pins the mapping.
+  Only an absent ICD may skip.
+- **Live Vulkan, `#[ignore]`:** an A8 glyphset is byte-identical to its
+  pre-change output (invariant 1).
+- **vng A/B:** `java-xrender-text.sh` with `YS_JAVA_AA=lcd`, yserver vs
+  `--server xorg`, in the same guest.
+- **Hardware:** MATE, whose default is subpixel AA, plus the reporter's
+  probe. Blocks must be gone and the accented line must be legible.
+- **No regression:** xts `Xlib9` A/B, zero PASS→FAIL
+  (`feedback_xts_ab_gates_pixel_changes`) — this changes pixels on the text
+  path.
+
+## Risks
+
+- **The pack/UV arithmetic of option (b) fails as wrong-coloured fringes**,
+  which reads as "subpixel AA looks a bit off" rather than as a bug. The
+  per-channel live assertion above exists because an eyeball will not catch
+  it; a screenshot of correct-looking text is not evidence here.
+- **Two shaders implementing one equation.** `text.frag.glsl` and
+  `render.frag.glsl` would both carry component-alpha maths. They cannot
+  share code today, so they must be reviewed against each other explicitly.
+- **`image_text` shares the atlas and the recorded text-run op** with
+  `composite_glyphs` (not the input type — see stage 3b). Core X11 text is
+  A8 and must stay on the untouched path; those two shared surfaces are
+  where a component-alpha change can leak into core text.
+- **Run splitting turns one draw into several**, which interacts with the
+  glyph draw-batching work the text pipeline exists to serve. The bound is
+  known (one draw per glyph, i.e. Xorg's own behaviour) but the telemetry
+  worth watching on the first hardware run is the draw count per
+  `CompositeGlyphs`, not just the pixels.
+- **Atlas pressure.** Component-alpha glyphs are **4×** the area. A desktop
+  where every client uses subpixel AA — which is the default on MATE, GNOME
+  and KDE — fills the atlas ~4× faster, and `glyphs_dropped_atlas_full` is
+  the counter that would show it. Worth watching on the first hardware run
+  rather than assuming 4096² still suffices; a glyph dropped for a full
+  atlas is invisible text again, i.e. #137's symptom by another route.
+- **A 4-wide glyph shelf-packs differently.** The packer is width-first
+  within a shelf (`vk/glyph.rs:343-345`); quadrupling every component-alpha
+  glyph's width changes which glyphs share a shelf and how much of each
+  shelf is wasted. Not a correctness risk, but it is why the pressure above
+  cannot be predicted from the 4× factor alone.
+
+## Out of scope
+
+- **`mask_format != 0`** — cairo/Pango's subpixel route, where Xorg
+  accumulates glyphs into an `ARGB32` mask with `PictOpAdd` and composites
+  once (`render/glyph.c:600-624`). We ignore `mask_format` entirely today
+  (`render_composite_glyphs` takes it as `_mask_fmt`), so this needs the
+  real temporary-target lifecycle that the #137 design already named as
+  future work for masks. Java does not need it: all 21 requests carried
+  `mask_format = 0`, measured in **both** AA modes.
+- **Colour (emoji) glyphs.** `NeedsComponent` makes Xorg treat *any* A+RGB
+  glyphset as component-alpha, so a colour-emoji glyphset gets the same
+  treatment there — which is why colour emoji through RENDER glyphs is a
+  known mess everywhere. This design follows Xorg rather than trying to
+  detect intent, and says so; a real colour-glyph path is separate work.
+- **Tier 2 of #137** (general drawable glyph sources) is unrelated and
+  stays where its own spec left it.

--- a/docs/superpowers/specs/2026-09-10-glyph-drawable-source-design.md
+++ b/docs/superpowers/specs/2026-09-10-glyph-drawable-source-design.md
@@ -1,0 +1,209 @@
+# CompositeGlyphs with a drawable source — design
+
+**Issue:** #137 — Java AWT/Swing text is invisible under yserver, cured by
+`-Dsun.java2d.xrender=false`. Reported by kaaduu on an AMD 780M; reproduced
+on silence (RX 6800) with the reporter's standalone Swing probe.
+
+## The defect
+
+`KmsBackend::render_composite_glyphs` accepts only two kinds of source
+picture. Anything else is dropped:
+
+```rust
+ResolvedSource::Drawable(_) | ResolvedSource::None => {
+    log::debug!("render composite_glyphs gap: src 0x{host_src:x} is not
+                 SolidFill / Gradient (plan §3d v1-parity scope)");
+    self.telemetry.record_composite_glyphs_dropped_unsupported();
+    return Ok(Vec::new());
+}
+```
+
+Java2D's XRender pipeline paints text through `XRSolidSrcPict`, which is a
+**1×1 pixmap picture with `repeat=Normal`** — not `CreateSolidFill`. So it
+resolves to `ResolvedSource::Drawable` and every text draw is discarded.
+Nothing is painted, no error is returned, and the client cannot tell.
+
+Measured on the failing run: 32 `CompositeGlyphs` requests from the Java
+client, 32 gap hits, all naming the same source picture, and zero rectangles
+painted. No other client on the desktop trips it — cairo/pango and the MATE
+stack use `CreateSolidFill`, which resolves to `ResolvedSource::Solid`.
+
+**A correlation to discard:** Java uses `CompositeGlyphs32` exclusively, and
+in the log 8/16 were 3429/3429 healthy while 32 was 33/33 dead. That is
+coincidence — the 32-bit id path decodes correctly. The discriminator is the
+**source picture kind**, not the glyph-id width. Do not "fix" the 32-bit
+path.
+
+## What Xorg does
+
+`miGlyphs` (`../xserver/render/glyph.c:575`) never collapses the source to a
+colour. It has two branches, and the source is a sampled picture in both:
+
+- **`maskFormat != 0`** — allocate a mask pixmap over the glyph extents,
+  accumulate every glyph into it with `PictOpAdd`, then issue a single
+  `Composite(op, pSrc, pMask, pDst, ...)`.
+- **`maskFormat == 0`** — no intermediate. Composite each glyph directly as
+  `Composite(op, pSrc, glyphPicture, pDst, ...)`: the glyph is the mask and
+  the source is sampled per glyph.
+
+**Java sends `mask_format = 0`**, so the reference behaviour for this bug is
+the second branch. Our own path is shaped like neither: it reduces the source
+to `foreground_rgba: [f32; 4]` and multiplies the glyph coverage by it
+(`RenderEngine::composite_glyphs`, `engine.rs:6183`). That is a valid
+optimisation *only* when the source really is one colour.
+
+## Design
+
+Two tiers. Tier 1 fixes #137 exactly and is not a workaround; tier 2 closes
+the stub.
+
+### Tier 1 — a uniform source is a colour, and may be treated as one
+
+A picture whose **sampled domain** is a single pixel, repeated, is by
+definition a constant colour over the whole destination. Collapsing it to
+`foreground_rgba` is then **exact**, not an approximation — the same answer
+Xorg computes, by a cheaper route.
+
+Admit a `ResolvedSource::Drawable` when its sampled domain is 1×1 and the
+repeat makes that pixel cover the plane. Read that pixel, convert to
+premultiplied f32 in the engine's existing convention, and proceed down the
+current path unchanged.
+
+**"1×1" means the sampled domain, not the backing storage.**
+`SourceDrawable` (`engine.rs:8244`) is `{ id, offset, domain:
+Option<Extent2D> }`: `whole()` samples the storage from its origin, while
+`content()` carries a content origin *inside* a larger storage plus the
+window's own extent. A window picture can therefore resolve to a 1×1 logical
+domain sitting inside a much larger redirected backing. The test must be on
+the logical domain — `domain` when present, the storage extent when it is
+`None` — and the pixel must be read at `SourceDrawable::offset()`, not at
+(0,0). Testing the storage extent instead would reject the redirected case,
+and reading at the origin would sample the wrong pixel of the backing.
+Resolution happens in `resolve_picture_for_render` (`backend.rs:6126`).
+
+**Which repeats qualify.** `Normal`, `Pad` and `Reflect` all map a one-pixel
+domain onto the whole plane, so all three are exact. `Repeat::None` is
+**not** admissible even at 1×1: outside the single pixel the source reads as
+transparent, so the correct result paints only the glyph area overlapping
+that pixel. Collapsing it to a colour would paint every glyph. Keep dropping
+`None`.
+
+**The read must be X11-ordered, and taken in backing space.** Use
+`RenderEngine::get_image` (`engine.rs:5486`), the synchronous readback path,
+which performs the flush/close/wait sequence and so observes a repaint of the
+source pixmap the client submitted just before the text. A direct image map
+or raw read offers no such guarantee and would race Java's own recolouring.
+
+Read through **`Src::server_internal(backing_id)`** (`target.rs:108`) with a
+1×1 rectangle at `SourceDrawable::offset()`. That handle is the privileged,
+unclipped, backing-space read. A client-bounded `Src` carries its own
+`bounds` and would reapply a coordinate space on top of the offset we have
+already resolved — sampling the wrong pixel precisely in the redirected case
+this section exists to get right.
+
+**Caching, if measurement shows it is needed.** A per-draw readback sits on
+the hottest RENDER path we have, so the plan must measure it before
+accepting the naive form.
+
+The key is **`(DrawableId, content_version, offset)`** — identity plus
+version plus sampled origin, following the shape the clip-mask cache already
+uses. `content_version` (`store.rs:702`, bumped by `mark_contents_modified`)
+is *not* sufficient alone: versions are local to an allocation, so they
+collide across drawables, and the same backing can legitimately be sampled at
+several content offsets at the same version. Entries are populated only
+*after* the ordered readback above, never at `CreatePicture` time. Java repaints the same 1×1 pixmap to change text
+colour and reuses the picture, so a value cached at creation renders every
+subsequent run of text in the previous colour. That converts a total,
+obvious failure into an intermittent wrong-colour one, which is strictly
+worse.
+
+### Tier 2 — general drawable sources (FUTURE WORK, not part of #137)
+
+Deliberately **not** designed here, and not to be attempted alongside tier 1.
+Sketching it is useful only to show tier 1 does not paint us into a corner.
+
+The obvious move — "just route glyphs through
+`RenderEngine::try_append_render_batch` (`engine.rs:4789`), which already
+takes `src: ResolvedSource` with `src_repeat`" — does not survive contact.
+That API expects the **mask** to be a `SourceDrawable` too, whereas glyph
+coverage lives in the glyph atlas, in atlas coordinates. Closing the stub
+therefore requires designing, at minimum:
+
+- an adapter presenting atlas-resident glyph coverage as a maskable source,
+  including the atlas-to-destination coordinate mapping; and
+- for `mask_format != 0`, a real temporary A8 target with a defined
+  lifecycle and ownership — Xorg allocates and frees a mask pixmap per call
+  — rather than a batch entry.
+
+Both are engine-interface changes with blast radius beyond #137, since
+`composite_glyphs` is shared with `image_text`. A separate spec.
+
+## Invariants
+
+1. A source that is genuinely one colour renders identically before and
+   after, by whichever tier handles it. Tier 1 must not regress the
+   overwhelmingly common `CreateSolidFill` path, which stays on the existing
+   fast route untouched.
+2. No `CompositeGlyphs` is ever discarded silently. If a case remains
+   unsupported it must log *and* count; see the visibility note below.
+3. The glyph-id width (8/16/32) has no bearing on which source kinds are
+   supported. The two are independent and must stay so.
+4. Colour is read per composite, never cached across a repaint of the source
+   drawable. Any cache is keyed on `content_version` and filled only after
+   the ordered readback.
+5. "1×1" is always the sampled *domain* at its *offset*, never the backing
+   storage extent at its origin. The pixel is read in backing space through
+   a server-internal handle, so no second coordinate space is applied.
+6. Any cache is keyed on `(DrawableId, content_version, offset)`. Version
+   alone collides across drawables and across offsets into one backing.
+
+## Why this hid for so long
+
+The path was already instrumented: it logs at debug and bumps
+`composite_glyphs_dropped_unsupported`. Nobody looked, because nothing
+surfaces the counter and the debug line sits in `yserver::kms::render::backend`,
+which the usual `RUST_LOG` filters exclude. An entire class of client — every
+Java/AWT application — rendered no text at all, and the server's own
+telemetry knew.
+
+Worth doing alongside the fix, cheaply: promote a *first* occurrence of any
+`composite_glyphs` drop to `warn!`, so a silently-unsupported paint path
+announces itself once rather than never.
+
+## Proof
+
+**Tier 1, this change.**
+
+- A 1×1 `repeat=Normal` drawable source paints the same pixels as the
+  equivalent `CreateSolidFill`. Same for `Pad` and `Reflect`.
+- **Negative:** `repeat=None` at 1×1 still drops, and a drawable source
+  whose sampled domain is larger than 1×1 **still drops** — tier 1 does not
+  make it paint, and a test asserting otherwise would be asserting tier 2.
+- **Domain, not storage:** a window picture with a 1×1 content domain inside
+  a larger redirected backing is admitted, and samples the pixel at the
+  content offset — not the backing's (0,0).
+- **Ordering / staleness:** repaint the source pixmap, then draw text, and
+  assert the new colour is used. This is the trap in invariant 4, asserted
+  rather than assumed.
+- **Hardware:** the reporter's Swing probe with `-Dsun.java2d.xrender=true`
+  shows all five sample strings, the accented Czech line, and the direct
+  `Graphics2D.drawString()` panel. `xrender=false` must remain correct.
+- **No regression** in ordinary desktop text: xts `Xlib9` A/B per
+  `feedback_xts_ab_gates_pixel_changes`, zero PASS→FAIL.
+
+**Tier 2, when it happens.** A non-1×1 drawable source paints, sampled per
+pixel, matching Xorg for both `mask_format == 0` and `!= 0`. Not a gate on
+this change.
+
+## Risks
+
+- **Readback cost on the hottest path.** Tier 1 adds a GPU read to every
+  glyph draw unless cached. Measure before committing to the naive form.
+- **Stale colour** if the read is cached wrongly — see invariant 4. This
+  turns a total failure into an intermittent wrong-colour one, which is
+  harder to notice and harder to report.
+- **Tier 2 is unscoped on purpose.** It needs an atlas-to-maskable-source
+  adapter and, for `mask_format != 0`, a temporary A8 target with a real
+  lifecycle. Both change the engine's glyph interface, which `image_text`
+  shares. Treating it as "route through the existing batch API" would
+  understate it — see the tier 2 section.

--- a/tools/vng-scenarios/JavaTextChurn.java
+++ b/tools/vng-scenarios/JavaTextChurn.java
@@ -1,0 +1,60 @@
+// Text churn for #137 step 5: how often does the glyph path actually run,
+// and therefore how often does the tier-1 one-pixel readback happen?
+//
+// The reporter's probe is static -- it paints its text once and sits there,
+// which proves the fix but sizes nothing. This repaints a panel full of
+// strings as fast as Swing will let it, in a NEW colour each frame, so
+// Java2D cannot reuse a source picture and every frame goes down the
+// XRSolidSrcPict route. That is the worst case for a per-draw readback.
+//
+// The colour also changes on purpose: a stale cache would show as the text
+// lagging a frame behind the colour, and the frame counter in the corner
+// gives a run's total to divide the telemetry counters by.
+import java.awt.*;
+import javax.swing.*;
+
+public final class JavaTextChurn {
+    private static final String[] LINES = {
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz 0123456789",
+        "Prilis zlutoucky kun upel dabelske ody",
+        "The quick brown fox jumps over the lazy dog.",
+        "Glyphs: @ # $ % & * () [] {} <> /\\ | ~ + = ",
+    };
+    static int frame;
+
+    public static void main(String[] args) {
+        SwingUtilities.invokeLater(() -> {
+            JFrame f = new JFrame("Java text churn");
+            f.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+            JPanel p = new JPanel() {
+                @Override
+                protected void paintComponent(Graphics g) {
+                    super.paintComponent(g);
+                    Graphics2D g2 = (Graphics2D) g;
+                    g2.setColor(Color.WHITE);
+                    g2.fillRect(0, 0, getWidth(), getHeight());
+                    g2.setFont(g2.getFont().deriveFont(Font.PLAIN, 14f));
+                    int y = 24;
+                    for (int rep = 0; rep < 8; rep++) {
+                        // A different colour per line per frame, so no two
+                        // draws can share a source picture.
+                        for (String s : LINES) {
+                            g2.setColor(new Color((frame * 7 + y) & 0xFF,
+                                                  (frame * 13 + rep * 31) & 0xFF,
+                                                  (y * 5 + rep) & 0xFF));
+                            g2.drawString(s, 12, y);
+                            y += 20;
+                        }
+                    }
+                    g2.setColor(Color.BLACK);
+                    g2.drawString("frame " + frame, 12, y + 10);
+                }
+            };
+            p.setPreferredSize(new Dimension(900, 720));
+            f.setContentPane(p);
+            f.pack();
+            f.setVisible(true);
+            new Timer(10, e -> { frame++; p.repaint(); }).start();
+        });
+    }
+}

--- a/tools/vng-scenarios/java-text-churn.sh
+++ b/tools/vng-scenarios/java-text-churn.sh
@@ -1,0 +1,51 @@
+# Sourced by tools/vng-shot.sh INSIDE the guest (DISPLAY=:7, cwd = artifacts).
+#
+# #137 step 5 -- size the tier-1 one-pixel readback. The reporter's probe
+# paints its text once, which proves the fix but measures nothing. This runs
+# JavaTextChurn, which repaints 32 strings in fresh colours every 10ms so
+# Java2D cannot reuse a source picture: every string is a CompositeGlyphs
+# with its own XRSolidSrcPict, i.e. the worst case for a per-draw readback.
+#
+# Run with --env YSERVER_LOOP_TELEMETRY=1 and read the per-second rollups:
+#
+#   grep 'loop telemetry' yserver.log   # get_image_by_site/s[... glyphsrc=N]
+#
+# glyphsrc/s is the readback rate. Its COUNT is hardware-independent (one per
+# admitted CompositeGlyphs); its COST is not, so a cache decision still needs
+# a real GPU.
+set -u
+: "${YS_XRENDER:=true}"
+: "${YS_CHURN_SECS:=20}"
+src=$(dirname "$0")/JavaTextChurn.java
+[ -r "$src" ] || src=/home/jos/Projects/yserver/tools/vng-scenarios/JavaTextChurn.java
+javac -d . "$src" > javac.log 2>&1 || cat javac.log >&2
+
+# The JVM sometimes dies with SIGILL in C1-compiled code in this guest
+# (hs_err in `Module.ensureNativeAccess`) — a JIT/guest-CPU interaction,
+# nothing to do with the X server. Retry rather than tolerate it: a run whose
+# window never mapped leaves a bare backdrop, which is easy to misread as a
+# rendering failure.
+attempt=0
+while [ "$attempt" -lt 3 ]; do
+    attempt=$((attempt + 1))
+    java -Dsun.java2d.xrender="$YS_XRENDER" -cp . JavaTextChurn \
+        > "java-$attempt.log" 2>&1 &
+    java_pid=$!
+    sleep 10
+    if xwininfo -root -tree 2>/dev/null | grep -q 'Java text churn'; then
+        echo "attempt $attempt: mapped" > window-mapped.txt
+        cp "java-$attempt.log" java.log 2>/dev/null || true
+        break
+    fi
+    echo "attempt $attempt: churn window never mapped" >> window-missing.txt
+    kill -9 "$java_pid" 2>/dev/null || true
+    rm -f hs_err_pid*.log
+    sleep 2
+done
+sleep "$YS_CHURN_SECS"
+xwininfo -root -tree > tree.txt 2>&1 || true
+# Also capture through the X protocol, which is the only route available under
+# `--server xorg` (on a non-composited X server the root window IS the
+# framebuffer). Harmless on yserver, and it makes the two servers directly
+# comparable on the same scenario.
+import -window root screen.png 2>&1 | head -3 > import.log || true

--- a/tools/vng-scenarios/java-xrender-text.sh
+++ b/tools/vng-scenarios/java-xrender-text.sh
@@ -1,0 +1,81 @@
+# Sourced by tools/vng-shot.sh INSIDE the guest (DISPLAY=:7, cwd = artifacts).
+#
+# Issue #137 (kaaduu): Java AWT/Swing text is invisible, and
+# `-Dsun.java2d.xrender=false` cures it. Java2D's XRender pipeline paints
+# every glyph through `XRSolidSrcPict` — a 1x1 pixmap picture with
+# `repeat=Normal` — and the glyph path accepted only SolidFill and Gradient
+# sources, so every text draw was discarded.
+#
+# No window manager on purpose. The probe is a single Swing toplevel that
+# centres itself, and a WM would add its own text (titlebar, panel) to the
+# scanout — which is cairo/pango text through CreateSolidFill, i.e. the path
+# that always worked. Keeping the screen to just the probe means anything
+# non-background in the dump came from Java.
+#
+# YS_XRENDER selects the pipeline, and is the whole experiment: `true` is the
+# broken-before/fixed-after case, `false` is the in-run control that must look
+# the same either way (it takes the core-X11 text path, which this change does
+# not touch). Run it both ways and compare.
+set -u
+: "${YS_XRENDER:=true}"
+# kaaduu's probe, compiled to a gitignored directory (gist
+# 0d4ee5b733a623c64c37e948263fcc1a). The guest shares the host rootfs, so the
+# host's build is right there.
+: "${YS_PROBE_CP:=/home/jos/Projects/yserver/target/diag137}"
+# YS_JAVA_AA picks the text antialiasing, which selects the GLYPH format and
+# is a second, independent axis from the source-picture kind that #137 is
+# about. `gasp`/`on` give grayscale AA and Java uploads A8 glyphs; `lcd` gives
+# subpixel AA and Java uploads ARGB32 component-alpha glyphs, which
+# `render_composite_glyphs` reduces to their alpha channel alone. There is no
+# settings daemon in this guest, so the desktop default here is NOT what a
+# MATE/GNOME session gives you -- forcing it is the only way to reach the LCD
+# path from a bare guest.
+: "${YS_JAVA_AA:=gasp}"
+
+# The JVM sometimes dies with SIGILL in C1-compiled code in this guest
+# (hs_err in `Module.ensureNativeAccess`) — a JIT/guest-CPU interaction,
+# nothing to do with the X server. It has to be retried rather than tolerated:
+# a run whose probe never mapped leaves a bare backdrop, and on the PRE-FIX
+# side of an A/B that is easy to misread as "the bug". The window-mapped
+# marker below is what separates the two.
+attempt=0
+while [ "$attempt" -lt 3 ]; do
+    attempt=$((attempt + 1))
+    if [ ! -r "$YS_PROBE_CP/XRenderTextProbe.class" ]; then
+        echo "no XRenderTextProbe.class under $YS_PROBE_CP" > java-missing.txt
+        break
+    fi
+    java -Dsun.java2d.xrender="$YS_XRENDER" \
+        -Dawt.useSystemAAFontSettings="$YS_JAVA_AA" -cp "$YS_PROBE_CP" \
+        XRenderTextProbe > "java-$attempt.log" 2>&1 &
+    java_pid=$!
+    # The JVM starting, laying out Swing and mapping its first frame is much
+    # slower than an X client; 12s is what it takes here with room to spare.
+    sleep 12
+    # The probe's toplevel is 900x620 and it is the only client, so its
+    # presence in the tree is the whole test of "the run is valid at all".
+    if xwininfo -root -tree 2>/dev/null | grep -q 'Java XRender text probe'; then
+        echo "attempt $attempt: mapped" > window-mapped.txt
+        cp "java-$attempt.log" java.log 2>/dev/null || true
+        break
+    fi
+    echo "attempt $attempt: probe never mapped" >> window-missing.txt
+    kill -9 "$java_pid" 2>/dev/null || true
+    rm -f hs_err_pid*.log
+    sleep 2
+done
+
+# Where the probe actually landed, so a region measurement in the dump is
+# checked against a number rather than eyeballed.
+xwininfo -root -tree > tree.txt 2>&1 || true
+xdotool getdisplaygeometry > geometry.txt 2>&1 || true
+{
+    echo "sun.java2d.xrender=$YS_XRENDER"
+    echo "awt.useSystemAAFontSettings=$YS_JAVA_AA"
+    java -version 2>&1
+} > java-config.txt
+# Also capture through the X protocol: it is the only route under
+# `--server xorg` (there the root window IS the framebuffer), which is how
+# the Xorg control for the glyph-format question gets its pixels.
+import -window root screen.png 2>&1 | head -3 > import.log || true
+sleep 1


### PR DESCRIPTION
Two user-visible rendering defects on the X RENDER glyph path, the second
found while verifying the first.

### Java/AWT and Swing text was invisible (#137)

Every Java application rendered no text at all — no error, nothing painted.
The glyph paint path accepted only `SolidFill` and `Gradient` source
pictures and silently dropped everything else, and Java2D paints text
through `XRSolidSrcPict`: a 1×1 pixmap picture with `repeat=Normal`.

A picture whose sampled domain is a single pixel under a repeat that covers
the plane is a constant colour, so collapsing it to a foreground colour is
exact rather than approximate — the same answer Xorg computes, by a cheaper
route. Reported by @kaaduu.

### Subpixel-antialiased text rendered as solid blocks

With the above fixed, text from any toolkit requesting subpixel (LCD)
antialiasing — the default on MATE, GNOME and KDE — painted one filled
rectangle per glyph: correctly positioned and spaced, with no letterform.

`AddGlyphs` reduced an `ARGB32` glyph to its alpha byte, but a subpixel
client puts one coverage value per LCD subpixel in R, G and B and sets alpha
to 255 across the whole glyph box. Glyphs now render per-channel, as Xorg
does, with a grayscale-antialiased fallback on devices lacking
`dualSrcBlend`.

### Also

A pre-existing off-by-one in the frame pin ceiling, found while designing
the above: the budget counted glyph uploads but not the instance buffer
pinned immediately afterwards, so a call that exactly filled the ceiling
exceeded it by one. Fixed alone, in both glyph paths.

### Verification

- The reporter's Swing probe under MATE. The same scenario on Xorg renders
  identically.
- A/B in a virtme-ng guest against both this server and Xorg, with the
  scenarios added here (`tools/vng-scenarios/`). Before: 21 CompositeGlyphs
  requests painting 0 rects. After: 21 painting 1 each.
- 152 of 153 live acceptance tests pass on lavapipe; the one failure is a
  known pre-existing defect unrelated to this work (window storage is not
  cleared on allocation).

Design and implementation notes are in `docs/superpowers/specs/` and
`plans/`. The branch is eight topical commits and fast-forwards onto master.

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)
