### PR TITLE
fix: restore window content on unredirect, and stop painting background-None windows white

### DIFF
--- a/crates/yserver-core/src/core_loop/process_request.rs
+++ b/crates/yserver-core/src/core_loop/process_request.rs
@@ -20567,9 +20567,24 @@ fn handle_create_window(
         };
         let local = state.resources.window(window_id);
         let resolved_bg = state.resources.window_resolved_background(window_id);
-        let host_bg_pixel = resolved_bg
-            .map(|bg| bg.background_pixel)
-            .or_else(|| local.map(|w| w.background_pixel));
+        // `window_resolved_background` returning None is MEANINGFUL: it
+        // says this window has no background, so the server paints
+        // nothing (X11 §CreateWindow — background-pixmap defaults to
+        // None). It returns None in exactly four cases, and a stored
+        // pixel is the wrong answer in all of them: a ParentRelative
+        // cycle; the window absent from the map (then `local` is None
+        // too); a ParentRelative chain that resolved to no background;
+        // and `background_none` itself.
+        //
+        // So DO NOT fall back to `w.background_pixel` here. For a
+        // background-None window that field holds the 0x00ffffff
+        // PLACEHOLDER `create_window` stores when the request carries no
+        // background attribute, and passing it on painted every such
+        // window's fresh storage WHITE — the storage half of
+        // `window_storage_init_covers_the_whole_allocation`, and the
+        // reason `default_window_init_color`'s None branch was dead for
+        // client windows. None reaches that safe default instead.
+        let host_bg_pixel = resolved_bg.map(|bg| bg.background_pixel);
         let host_bg_pixmap = resolved_bg
             .and_then(|bg| bg.background_pixmap_host_xid)
             .map(|h| h.as_raw())

--- a/crates/yserver-core/src/core_loop/setup_thread.rs
+++ b/crates/yserver-core/src/core_loop/setup_thread.rs
@@ -224,7 +224,7 @@ fn run_setup(
                 max_installed_maps: 1,
                 root_visual: ROOT_VISUAL,
                 argb_visual: ARGB_VISUAL,
-                root_depth: 24,
+                root_depth: crate::resources::ROOT_DEPTH,
             },
         },
     )?;

--- a/crates/yserver-core/src/resources.rs
+++ b/crates/yserver-core/src/resources.rs
@@ -41,6 +41,16 @@ pub const COMPOSITE_OVERLAY_WINDOW: ResourceId = ResourceId(0x103);
 pub const ARGB_VISUAL: ResourceId = ResourceId(0x103);
 pub const ARGB_COLORMAP: ResourceId = ResourceId(0x104);
 
+/// The X11 depth of the root window, as advertised in the setup reply.
+///
+/// This is a CLIENT-VISIBLE protocol constant, not a storage property. Our
+/// scanout and root readback storage is 32-bit BGRA, but the root DRAWABLE is
+/// depth 24, and every reply that names a depth — `GetImage`, `GetGeometry`,
+/// plane-mask truncation — has to say 24. Reading the storage's depth instead
+/// makes the server claim depth 32 for the root, which is what
+/// `tools/depth32-bg-probe.c` measured against Xorg 21.1.24's 24.
+pub const ROOT_DEPTH: u8 = 24;
+
 /// X11 visual class codes (subset we care about). The setup reply
 /// advertises these per-visual; clients pass a visual ID into
 /// `CreateWindow`, `CreateColormap`, and RENDER `CreatePicture`.

--- a/crates/yserver/src/kms/render/backend.rs
+++ b/crates/yserver/src/kms/render/backend.rs
@@ -3633,6 +3633,171 @@ impl KmsBackend {
         self.sync_window_leaf_storage(host_xid, LeafContent::Discard);
     }
 
+    /// Un-redirecting a window must leave its content where the
+    /// compositor had it. Xorg gets that for free: `compSetParentPixmap`
+    /// (`composite/compalloc.c:649`) points the window back at the
+    /// SCREEN pixmap, which already holds the pixels the compositor
+    /// painted, so it copies nothing at all. The copy lives on the
+    /// REDIRECT side there — `compNewPixmap` seeds the new backing from
+    /// the parent with `CopyArea(…, IncludeInferiors)`
+    /// (`composite/compalloc.c:556`) — and the invariant both halves
+    /// keep is that a window's pixels stay CONTINUOUS with the screen
+    /// across either transition.
+    ///
+    /// yserver keeps a private per-window leaf, so that continuity has
+    /// to be re-established by hand: B holds every paint the client made
+    /// while redirected, and W's leaf has been stale since the route was
+    /// installed — `process_request.rs` says so while (correctly)
+    /// declining the copy in the OTHER direction: "W's storage which
+    /// under Manual is empty". Without this restore, the caller has just
+    /// re-initialised that leaf from the background, and the window goes
+    /// blank the instant a compositor lets go.
+    ///
+    /// Measured on HW (bee, sonicDE/KWin, 2026-09-11): mpv going
+    /// fullscreen sets `_NET_WM_BYPASS_COMPOSITOR`, KWin suspends
+    /// compositing screen-wide, and every window blanked to its leaf's
+    /// init colour. Covered by
+    /// `unredirect_restores_the_window_leaf_from_the_backing`.
+    ///
+    /// `OP_SRC`, never a blend: this reproduces a `CopyArea`, which
+    /// REPLACES the destination and has no notion of alpha. `PictOpOver`
+    /// here would make a depth-32 window with α = 0 a no-op and leave
+    /// the background showing through — the same trap the
+    /// backing-reconstruct walk fell into.
+    fn restore_leaves_from_backing(&mut self, w_xid: u32, b_id: DrawableId) {
+        use crate::kms::{
+            render::engine::{ResolvedSource, SourceDrawable},
+            vk::ops::render::CompositeRect,
+        };
+
+        // The SEED plan, read backwards. `plan_backing_inferiors` walks
+        // W and its whole mapped subtree and yields, per leaf, that
+        // leaf's rect in leaf-local coords (`src`) paired with where it
+        // sits in B (`dst`). Seeding copies leaf → B; restoring copies
+        // B → leaf, i.e. the identical plan with the two swapped.
+        //
+        // Walking the SUBTREE is the whole point, and a per-window copy
+        // is not enough: a compositor redirects with
+        // `RedirectSubwindows(root)`, so the redirected windows are the
+        // WM's FRAMES, and the client's own window is reparented inside
+        // one — a grandchild, whose pixels live in the frame's B at an
+        // offset while its own leaf goes stale. Restoring only the
+        // frame's leaf brought the decorations back and left the client
+        // window black (measured on HW, bee/sonicDE, 2026-09-11:
+        // dolphin still blanked, and repainted in full on hover — the
+        // client could rebuild content the server had lost).
+        //
+        // Any child holding its OWN `redirected_target` is pruned by
+        // the planner, which stays right here: its pixels are in its
+        // own backing and come back when THAT backing is released.
+        let plan = self.plan_backing_inferiors(w_xid, b_id);
+        if plan.is_empty() {
+            return;
+        }
+        // Coverage diagnostic. The restore can only hand back what B
+        // holds, so a leaf whose storage is TALLER or WIDER than the
+        // rect the plan gives it comes back part-painted, the
+        // remainder still showing the background re-init — measured on
+        // HW as a Plasma panel restored to its top half only, which
+        // corrected itself after a few redirect cycles. Log the three
+        // extents that decide it rather than guess which one is stale.
+        if log::log_enabled!(log::Level::Debug) {
+            let b_extent = self.store.get(b_id).map(|d| d.storage.extent);
+            for d in &plan {
+                let leaf_extent = self.store.get(d.leaf_id).map(|s| s.storage.extent);
+                let short = leaf_extent.is_some_and(|e| {
+                    let avail_w = e
+                        .width
+                        .saturating_sub(u32::try_from(d.src_x.max(0)).unwrap_or(0));
+                    let avail_h = e
+                        .height
+                        .saturating_sub(u32::try_from(d.src_y.max(0)).unwrap_or(0));
+                    d.width < avail_w || d.height < avail_h
+                });
+                log::debug!(
+                    "render restore_leaves_from_backing: W=0x{w_xid:x} leaf={} \
+                     leaf_extent={leaf_extent:?} b_extent={b_extent:?} \
+                     rect=src_in_b({},{}) dst_in_leaf({},{}) {}x{}{}",
+                    d.leaf_id.as_u64(),
+                    d.dst_x,
+                    d.dst_y,
+                    d.src_x,
+                    d.src_y,
+                    d.width,
+                    d.height,
+                    if short { "  SHORT-OF-LEAF" } else { "" },
+                );
+            }
+        }
+        // `OP_SRC`, never a blend: this reproduces a `CopyArea`, which
+        // REPLACES the destination and has no notion of alpha.
+        // `PictOpOver` here would make a depth-32 window with α = 0 a
+        // no-op and leave the re-initialised background showing
+        // through — the same trap `overlay_backing_inferiors` fell into
+        // until 2026-09-11.
+        //
+        // Occluded regions come back holding the OCCLUDER's pixels,
+        // because B only ever held the composited result. That matches
+        // Xorg, where an occluded window's pixels are not stored
+        // anywhere either (shared screen storage is why X has Expose in
+        // the first place); the visible region of every leaf is exact,
+        // and uncovering one Exposes it through the normal path.
+        const OP_SRC: u8 = 1;
+        for d in plan {
+            // Skip leaves with no realized view — no GPU storage to
+            // copy into. Same liveness check the seed walk makes.
+            if self
+                .store
+                .get(d.leaf_id)
+                .is_none_or(|s| s.storage.image_view == ash::vk::ImageView::null())
+            {
+                continue;
+            }
+            let rects = [CompositeRect {
+                // Inverted against the seed: the plan's backing-local
+                // `dst` is this copy's SOURCE, and its leaf-local `src`
+                // is this copy's DESTINATION.
+                src_x: d.dst_x,
+                src_y: d.dst_y,
+                mask_x: 0,
+                mask_y: 0,
+                dst_x: d.src_x,
+                dst_y: d.src_y,
+                width: d.width,
+                height: d.height,
+            }];
+            match self.engine.render_composite(
+                &mut self.store,
+                &mut self.platform,
+                OP_SRC,
+                ResolvedSource::Drawable(SourceDrawable::whole(b_id)),
+                ResolvedSource::None,
+                Dst::server_internal(d.leaf_id),
+                &rects,
+                None,
+                Repeat::None,
+                Repeat::None,
+                None,
+                None,
+                false,
+                // Synthesized restore; no Picture context — the engine
+                // falls back to the depth heuristic (→ `sample_view`).
+                0,
+                0,
+                0,
+            ) {
+                Ok(st) if st.recorded_draws > 0 => {
+                    self.telemetry.record_paint_submit();
+                    self.trace_simple(SubmitKind::RenderComposite, d.leaf_id, st.recorded_draws);
+                }
+                Ok(_) => {}
+                Err(e) => log::warn!(
+                    "render restore_leaves_from_backing: copy B→leaf failed for W 0x{w_xid:x}: {e:?}"
+                ),
+            }
+        }
+    }
+
     /// #133 step 6 (P8) — a **border-width** change: reallocate only if
     /// the bordered extent actually moved (6.1), relocate the content
     /// whenever the CONTENT OFFSET moved whether or not it did (6.2),
@@ -20374,6 +20539,11 @@ impl Backend for KmsBackend {
                     self.store.set_redirected_target(w_id, None);
                 }
                 self.sync_window_leaf_storage_to_geometry(w_xid);
+                // ...which just re-initialised the leaf from the
+                // background. Put the compositor's content back on top
+                // of it, BEFORE the `decref`/`free_pixmap` below can
+                // retire B.
+                self.restore_leaves_from_backing(w_xid, b_id);
             }
             // Stage 4c.4 round-3 finding: drop B's scene_participating
             // flag here so the protocol handler doesn't need a

--- a/crates/yserver/src/kms/render/backend.rs
+++ b/crates/yserver/src/kms/render/backend.rs
@@ -7326,10 +7326,31 @@ impl KmsBackend {
         if plan.is_empty() {
             return;
         }
-        // PictOpOver — alpha children blend over the parent base;
-        // depth-24 leaves sample with α=1 (engine `sample_view`
-        // swizzle) so they fully replace the base where opaque.
-        const OP_OVER: u8 = 3;
+        // RAW COPY, not a composite. Xorg's `compNewPixmap` seeds the
+        // new backing with `CopyArea(parent, …, IncludeInferiors)`
+        // (`composite/compalloc.c:562`), and CopyArea replaces the
+        // destination — it has no notion of alpha at all. This walk
+        // exists only because yserver keeps a separate per-window leaf,
+        // so it must reproduce the same REPLACEMENT that a single
+        // shared-storage CopyArea would have performed, one leaf at a
+        // time in bottom-to-top stack order.
+        //
+        // This was `PictOpOver` until 2026-09-11, on the reasoning that
+        // "alpha children blend over the parent base". They must not: a
+        // depth-32 child with α = 0 then blends as a NO-OP and the
+        // parent's seed shows through its background. Measured — a
+        // window asking for `background-pixel = 0x00000000` kept the
+        // root's red and read back `00ff0000` where Xorg 21.1.24 gives
+        // `00000000` (`tools/depth32-bg-probe.c`, transparent-zero
+        // A-root, vng 2026-09-11).
+        //
+        // Shape and stacking are unaffected: `push_inferior_rects`
+        // already intersects each leaf with its `shape_bounding` and
+        // `collect_backing_inferiors` walks in `stack_rank` order, so
+        // only the blend equation changes here. Depth-24 leaves still
+        // land opaque — `sample_view` gives them α = 1 — so the one
+        // behaviour that changes is the one that was wrong.
+        const OP_SRC: u8 = 1;
         for d in plan {
             // Skip leaves whose storage has no realized view (no GPU
             // backing yet) — the planner left the liveness check here.
@@ -7353,7 +7374,7 @@ impl KmsBackend {
             match self.engine.render_composite(
                 &mut self.store,
                 &mut self.platform,
-                OP_OVER,
+                OP_SRC,
                 // The planner already put this leaf's CONTENT origin
                 // into `src_x`/`src_y` (`push_inferior_rects`), so the
                 // source is addressed in raw leaf-storage coordinates

--- a/crates/yserver/src/kms/render/backend.rs
+++ b/crates/yserver/src/kms/render/backend.rs
@@ -7344,6 +7344,12 @@ impl KmsBackend {
         // `00000000` (`tools/depth32-bg-probe.c`, transparent-zero
         // A-root, vng 2026-09-11).
         //
+        // The same probe shows the replacement model is what Xorg
+        // actually stores: on 21.1.24 a depth-24 frame's redirected
+        // pixmap reads `00ffffff` under an ARGB child whose background
+        // is transparent white — the child's own bits, alpha and all,
+        // stamped into the parent's pixmap rather than blended with it.
+        //
         // Shape and stacking are unaffected: `push_inferior_rects`
         // already intersects each leaf with its `shape_bounding` and
         // `collect_backing_inferiors` walks in `stack_rank` order, so
@@ -22236,18 +22242,48 @@ impl Backend for KmsBackend {
     ) -> io::Result<Option<Vec<u8>>> {
         // Stage 4a — resolve through redirect routing per spec Risk 1
         // ("GetImage reads what the X server considers W's content,
-        // which under redirect is B"). Depth comes from the
-        // resolved target's drawable (backing is allocated to match
-        // W's depth, so v1 / v2 see the same wire shape).
+        // which under redirect is B").
+        //
+        // THE INVARIANT (2026-09-11): the reply's depth and plane-mask
+        // semantics come from the REQUESTED DRAWABLE, never from the
+        // redirected backing or the scanout storage. Where the pixels
+        // are read from and what depth the drawable is are two
+        // different questions, and only the first one follows the
+        // redirect routing.
+        //
+        // The comment this replaces assumed "backing is allocated to
+        // match W's depth, so v1 / v2 see the same wire shape". Both
+        // halves of that are false in the field:
+        //
+        //   root       the root DRAWABLE is depth 24
+        //              (`resources::ROOT_DEPTH`), while its readback
+        //              storage is 32-bit BGRA — we replied depth 32.
+        //   routed     a depth-32 child of a redirected depth-24 frame
+        //   child      paints into the FRAME's depth-24 backing, so the
+        //              backing depth is 24 while the drawable is 32 —
+        //              we replied depth 24.
+        //
+        // Measured against Xorg 21.1.24, which answers 24 and 32
+        // respectively (`tools/depth32-bg-probe.c`, reply-depth line).
+        //
+        // This is a reply-header and plane-mask fix ONLY. The stored
+        // CONTENT needs no reconstruction: the same probe, reading raw
+        // image bytes rather than XGetPixel, shows our stored words are
+        // already byte-identical to Xorg's for all six background cases
+        // including the routed depth-32 child, whose alpha survives in
+        // the depth-24 frame backing exactly as it does on Xorg.
         if host_xid == self.core.window_id {
             let Some(root_id) = self.store.lookup(self.core.window_id) else {
                 self.log_render_gap("get_image_root_unknown_root");
                 return Ok(None);
             };
-            let depth = match self.store.get(root_id) {
-                Some(d) => d.depth,
-                None => return Ok(None),
-            };
+            // The drawable is the ROOT WINDOW, whose X11 depth is a
+            // protocol constant; `root_id`'s storage is the 32-bit
+            // scanout readback buffer and says nothing about it.
+            if self.store.get(root_id).is_none() {
+                return Ok(None);
+            }
+            let depth = yserver_core::resources::ROOT_DEPTH;
             let mask = plane_mask & depth_plane_mask(depth);
             if format == GET_IMAGE_FORMAT_XY_PIXMAP && mask == 0 {
                 return Ok(Some(wrap_get_image_reply(depth, Vec::new())));
@@ -22307,10 +22343,15 @@ impl Backend for KmsBackend {
             self.log_render_gap("get_image_unknown_xid");
             return Ok(None);
         };
-        let (depth, storage_extent) = match self.store.get(target.backing_id()) {
-            Some(d) => (d.depth, d.storage.extent),
+        // `x11_depth()` is the depth of the drawable the CLIENT named;
+        // `store.get(backing).depth` is the depth of whatever storage the
+        // redirect routing landed on. The extent must come from the
+        // storage (that is what is being read); the depth must not.
+        let storage_extent = match self.store.get(target.backing_id()) {
+            Some(d) => d.storage.extent,
             None => return Ok(None),
         };
+        let depth = target.x11_depth();
         let mask = plane_mask & depth_plane_mask(depth);
         if format == GET_IMAGE_FORMAT_XY_PIXMAP && mask == 0 {
             // No planes requested: Xorg replies with zero data. This

--- a/crates/yserver/tests/render_acceptance.rs
+++ b/crates/yserver/tests/render_acceptance.rs
@@ -13871,10 +13871,9 @@ fn the_awesome_wezterm_grow_keeps_the_client_below_the_titlebar() {
 /// #133 investigation — the initial clear of window storage created with
 /// NO background attribute.
 ///
-/// **This test currently FAILS, and that is the point: it is the
-/// reproduction of a defect, not a regression guard.** It is `#[ignore]`d
-/// with the rest of the Vk-gated suite, so `cargo test` stays green;
-/// run it with `--ignored` to see the finding.
+/// Wrote the defect down as a failing test on 2026-09-11 and fixed it
+/// the same day; it is a regression guard now. Kept `#[ignore]`d with
+/// the rest of the Vk-gated suite, so `cargo test` stays green.
 ///
 /// Measured, on this box, for a fresh window that is mapped and never
 /// painted:
@@ -13887,13 +13886,28 @@ fn the_awesome_wezterm_grow_keeps_the_client_below_the_titlebar() {
 /// | `background-pixel = 0x00ff0000` | 32 | `0000ff00` | `0000ff00` ✓ |
 /// | `background-pixel = 0xff00ff00` | 32 | `00ff00ff` | `00ff00ff` ✓ |
 ///
-/// Note `bg_pixel = Some(0)` and `bg_pixel = None` at depth 32 hand
-/// `fill_rect` the **identical** `[0.0, 0.0, 0.0, 0.0]`
-/// (`default_window_init_color`, `decode_x11_pixel_for_storage`), and
-/// only one of them lands — so the colour is not the discriminator, the
-/// code path is. In both failing rows RGB is `0xFF` (the fresh
-/// allocation) while ALPHA is exactly the init colour's alpha, i.e.
-/// something writes the alpha channel and leaves RGB untouched.
+/// The CAUSE, measured by logging the colour that actually reached the
+/// fill: `bg_pixel` arrived as `Some(0x00ff_ffff)` — WHITE — for both
+/// failing rows, and the fill landed all four channels faithfully.
+/// `create_window` stores `0x00ff_ffff` as a PLACEHOLDER when a request
+/// carries no background attribute (`resources.rs`), records the real
+/// state separately in `background_none`, and
+/// `window_resolved_background` honours it by returning `None` — but
+/// the CreateWindow path then defeated that with
+/// `.or_else(|| local.map(|w| w.background_pixel))`, resurrecting the
+/// placeholder. `default_window_init_color`'s `None` branch was
+/// therefore dead for every client window.
+///
+/// Two earlier readings of the same numbers were WRONG, and the trap is
+/// worth keeping on file. Alpha looked meaningful — exactly the init
+/// colour's alpha in both rows, suggesting "something writes alpha and
+/// leaves RGB untouched", and a write-mask hunt followed. It is an
+/// artifact of the placeholder: `decode_x11_pixel_for_storage` takes
+/// alpha from the pixel's top byte, so `0x00ff_ffff` gives `ffffffff` at
+/// depth 24 and `ffffff00` at depth 32 in one pass. And `bg_pixel =
+/// Some(0)` vs `None` at depth 32 do NOT hand `fill_rect` the same
+/// colour, as this comment used to claim: `Some(0)` gives
+/// `[0.0, 0.0, 0.0, 0.0]`, `None` gave white.
 ///
 /// Why it shows as WHITE rather than as transparency: the scene draws
 /// windows with `alpha_passthrough = false`, whose shader forces

--- a/crates/yserver/tests/render_acceptance.rs
+++ b/crates/yserver/tests/render_acceptance.rs
@@ -3523,6 +3523,184 @@ fn set_redirected_target_routes_fill_to_backing() {
     );
 }
 
+/// Xorg's unredirect points the window back at the SCREEN pixmap
+/// (`compSetParentPixmap`, `composite/compalloc.c:649`) and copies
+/// NOTHING — it does not need to, because the pixels the compositor
+/// was showing are already in that pixmap. The redirect direction is
+/// the one that copies (`compNewPixmap` seeds the new backing with
+/// `CopyArea(parent, …, IncludeInferiors)`, `compalloc.c:556`), so
+/// Xorg's invariant is that a window's pixels stay CONTINUOUS with
+/// the screen across both transitions.
+///
+/// yserver keeps a private per-window leaf instead, which has been
+/// stale since the redirect — `process_request.rs:889` says so
+/// outright while declining a copy in the other direction: "W's
+/// storage which under Manual is empty". `release_redirected_backing`
+/// then ran `sync_window_leaf_storage_to_geometry`, re-initialising
+/// that leaf from the background. So every window a compositor
+/// unredirected lost its content.
+///
+/// Measured on HW (bee, sonicDE/KWin, 2026-09-11): mpv going
+/// fullscreen sets `_NET_WM_BYPASS_COMPOSITOR`, KWin suspends
+/// compositing for the whole screen, and dolphin's content blanked.
+/// The blank tracked the LEAF's init colour — white before the
+/// `background_none` fix, black after — which is what proves the
+/// blank is this leaf and not a missing Expose.
+/// `mpv --x11-bypass-compositor=no` suppressed it entirely, and
+/// totem never triggered it because it does not set the property.
+#[test]
+#[ignore = "needs live Vulkan ICD"]
+fn unredirect_restores_the_window_leaf_from_the_backing() {
+    use yserver_core::{backend::WindowHandle, host_x11::HostSubwindowVisual};
+
+    let mut b = match KmsBackend::for_tests_with_vk() {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("skipping: no Vk: {e}");
+            return;
+        }
+    };
+    let root = WindowHandle::from_raw(1).expect("root");
+    let w = b
+        .create_subwindow(
+            None,
+            root,
+            0,
+            0,
+            16,
+            16,
+            0,
+            HostSubwindowVisual::Explicit {
+                depth: 32,
+                visual_xid: 0,
+                colormap_xid: 0,
+            },
+            // Background None — dolphin's shape, and the largest
+            // category in the KWin trace (37 windows).
+            None,
+            None,
+        )
+        .expect("create W");
+    let w_xid = w.as_raw();
+    // The restore walks the plan `plan_backing_inferiors` builds, and
+    // that walk prunes unmapped subtrees (X11: an unmapped window is
+    // invisible), so W has to be mapped for any of this to be reached.
+    b.map_subwindow(None, w_xid).expect("map W");
+
+    // Redirect through the production path: allocates the backing,
+    // seeds it parent → B and installs the route.
+    let backing = b
+        .allocate_redirected_backing(None, w, 16, 16, 32)
+        .expect("allocate backing");
+
+    // The client paints green. Under redirect this lands in the
+    // BACKING, not in W's leaf — that is what the route is for, and
+    // precisely why the leaf is stale when the compositor lets go.
+    b.fill_rectangle(None, w_xid, 0xFF00FF00, 0, 0, 16, 16)
+        .expect("redirected fill");
+
+    // Unredirect. Both `UnredirectSubwindows` and a compositor crash
+    // reach here via `teardown_redirect_for_window`.
+    b.release_redirected_backing(None, backing)
+        .expect("release backing");
+
+    // The route is gone, so this reads W's own leaf. Xorg would still
+    // be showing the green, because the window is back to reading the
+    // screen pixmap the compositor had been painting.
+    let leaf = b
+        .get_image_pixels_for_tests(w_xid, 2, 0, 0, 16, 16, !0)
+        .expect("get_image W")
+        .expect("Some W bytes");
+    let mut distinct = std::collections::BTreeMap::<[u8; 4], usize>::new();
+    for px in leaf.chunks_exact(4) {
+        *distinct.entry([px[0], px[1], px[2], px[3]]).or_default() += 1;
+    }
+    assert_eq!(
+        distinct.keys().copied().collect::<Vec<_>>(),
+        vec![[0x00, 0xFF, 0x00, 0xFF]],
+        "after unredirect W's leaf must hold the content the compositor \
+         was showing (green, BGRA), not a background re-init: {distinct:?}",
+    );
+}
+
+/// The HW case the per-window restore missed. A compositor redirects
+/// with `RedirectSubwindows(root)`, so the windows that own a backing
+/// are the WM's FRAMES; the client's own window is reparented inside
+/// one and is a GRANDCHILD of root. Its pixels live in the frame's
+/// backing at an offset, and its own leaf is stale from the moment the
+/// route is installed.
+///
+/// Measured on HW (bee, sonicDE/KWin, 2026-09-11): restoring only the
+/// redirected window's leaf brought the frame back and left dolphin's
+/// content black — and it repainted in full on hover, i.e. the client
+/// could rebuild exactly what the server had dropped. So the restore
+/// has to walk the subtree, which is what seeding already does in the
+/// other direction (`overlay_backing_inferiors`).
+#[test]
+#[ignore = "needs live Vulkan ICD"]
+fn unredirect_restores_a_reparented_child_leaf_not_just_the_frame() {
+    use yserver_core::{backend::WindowHandle, host_x11::HostSubwindowVisual};
+
+    let mut b = match KmsBackend::for_tests_with_vk() {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("skipping: no Vk: {e}");
+            return;
+        }
+    };
+    let root = WindowHandle::from_raw(1).expect("root");
+    let visual = HostSubwindowVisual::Explicit {
+        depth: 32,
+        visual_xid: 0,
+        colormap_xid: 0,
+    };
+    // The frame, as a WM would create it under root.
+    let frame = b
+        .create_subwindow(None, root, 0, 0, 16, 16, 0, visual, None, None)
+        .expect("create frame");
+    let frame_xid = frame.as_raw();
+    b.map_subwindow(None, frame_xid).expect("map frame");
+    // The client's window, reparented inside the frame at (2, 3) —
+    // background None, dolphin's shape.
+    let client = b
+        .create_subwindow(None, frame, 2, 3, 8, 8, 0, visual, None, None)
+        .expect("create client");
+    let client_xid = client.as_raw();
+    b.map_subwindow(None, client_xid).expect("map client");
+
+    // The compositor redirects the FRAME, not the client window.
+    let backing = b
+        .allocate_redirected_backing(None, frame, 16, 16, 32)
+        .expect("allocate backing");
+
+    // The client paints itself green. This resolves through the
+    // frame's route into the backing at (2, 3) — never into the
+    // client's own leaf.
+    b.fill_rectangle(None, client_xid, 0xFF00FF00, 0, 0, 8, 8)
+        .expect("redirected child fill");
+
+    b.release_redirected_backing(None, backing)
+        .expect("release backing");
+
+    // The client window's OWN leaf must now hold the green. Before the
+    // subtree walk this read transparent black across all 64 px, which
+    // is the dolphin symptom exactly.
+    let leaf = b
+        .get_image_pixels_for_tests(client_xid, 2, 0, 0, 8, 8, !0)
+        .expect("get_image client")
+        .expect("Some client bytes");
+    let mut distinct = std::collections::BTreeMap::<[u8; 4], usize>::new();
+    for px in leaf.chunks_exact(4) {
+        *distinct.entry([px[0], px[1], px[2], px[3]]).or_default() += 1;
+    }
+    assert_eq!(
+        distinct.keys().copied().collect::<Vec<_>>(),
+        vec![[0x00, 0xFF, 0x00, 0xFF]],
+        "after unredirect the reparented child's leaf must hold its own \
+         content (green, BGRA), not a stale/blank leaf: {distinct:?}",
+    );
+}
+
 /// Set up parent-W with a sub-child C at position (2, 3). Redirect
 /// W to backing B. A fill rect at (1, 1, 4, 4) against C's xid must
 /// land at (3, 4, 4, 4) in B — the C-relative offset accumulated

--- a/docs/status.md
+++ b/docs/status.md
@@ -6948,6 +6948,9 @@ itself.
   single pre-existing `window_storage_init_covers_the_whole_allocation`
   failure (documented at `render_acceptance.rs:13890`, fails identically on
   master — baseline re-measured, not assumed).
+  **Superseded later the same day** — that failure was a real bug, it is
+  fixed, and the suite is now 155/155. See "RESOLVED — the white content,
+  end to end" at the end of this section.
 
 ### Three things that are REFUTED — do not revive them
 
@@ -7073,6 +7076,14 @@ desktop other than Plasma and Cinnamon was exercised.
 
 ### LEAD — window content goes WHITE with compositing off, and Xorg does not
 
+> **CONFIRMED AND FIXED** the same day. This subsection is kept as written
+> because its reasoning held up; read it, then read "RESOLVED — the white
+> content, end to end" at the end for what the measurements actually said.
+> Two details below are wrong and are corrected there: the symptom's
+> trigger is `_NET_WM_BYPASS_COMPOSITOR`, not compositing-off in general,
+> and the storage bug's cause is not the alpha-channel write this text
+> infers from `window_storage_init_covers_the_whole_allocation`.
+
 Reported 2026-09-11 after the exoneration above, and **narrower than the
 symptom that was exonerated**. With compositing off, the window CONTENT of
 specific KDE apps (dolphin, systemsettings) turns white. Unlike the
@@ -7150,12 +7161,129 @@ tools/vng-shot.sh --name ur-ys --dump scanout \
 
 It has never been run. Commit it only once it produces a real difference.
 
+### RESOLVED — the white content, end to end (2026-09-11, evening)
+
+The lead above was right that the leaf was the culprit and right to demand
+an A/B before a fix. What the A/B turned out to be was better than the
+planned probe: two controlled changes on the real desktop, each of which
+moved the symptom.
+
+**The chain, measured link by link:**
+
+1. mpv going fullscreen sets `_NET_WM_BYPASS_COMPOSITOR` (its
+   `--x11-bypass-compositor` default is `fs-only`). KWin honours it by
+   suspending compositing screen-wide — which is the same global
+   unredirect the trace comparison earlier in this section caught, and
+   why the Plasma blocks and this symptom share one trigger while only
+   one of them is ours.
+2. That unredirect releases each redirect backing and falls back to a
+   per-window leaf. `mpv --x11-bypass-compositor=no` suppresses the whole
+   thing with compositing left up (focus glow intact), and **totem never
+   triggers it at all** because it does not set the property. That is the
+   negative control.
+3. The leaf was WHITE because `background-None` windows were being
+   initialised from a white PLACEHOLDER, not because of the alpha-channel
+   write the test's doc comment inferred. Fixing that turned the symptom
+   BLACK — the leaf's new init colour. That is the positive control, and
+   it is what proves the on-screen pixels ARE the leaf: nothing about a
+   missing Expose would track an init colour.
+4. Restoring each leaf from the backing on unredirect fixed dolphin on HW.
+
+**Fix 1 — the white placeholder.** `create_window` stores
+`background_pixel: 0x00ff_ffff` as a placeholder when a request carries no
+background attribute, records the truth in `background_none`, and
+`window_resolved_background` honours it by returning `None`. The
+CreateWindow path then defeated that with
+`.or_else(|| local.map(|w| w.background_pixel))`. There is no input for
+which that fallback can produce a correct `Some` — `window_resolved_background`
+returns `None` only for a cycle, an absent window (where `local` is `None`
+too), a ParentRelative chain that resolved to no background, or
+`background_none` — so it is deleted rather than filtered. A
+`!background_none` filter would have kept the bug for a ParentRelative
+child of a background-None parent, which is worth knowing if anyone
+re-derives this.
+
+**Fix 2 — the unredirect restore.** Xorg needs no restore because
+`compSetParentPixmap` (`composite/compalloc.c:649`) points the window back
+at the SCREEN pixmap, which already holds what the compositor painted. The
+copy is on the REDIRECT side there — `compNewPixmap` seeds the new backing
+from the parent with `CopyArea(…, IncludeInferiors)` (`compalloc.c:556`).
+The invariant both halves keep is that a window's pixels stay CONTINUOUS
+with the screen across either transition, and yserver's private per-window
+leaf breaks the unredirect half. `release_redirected_backing` now copies
+B → leaf with `OP_SRC` before the backing can retire.
+
+It must walk the SUBTREE, and the first attempt did not — that is the one
+thing here that took a second HW round. A compositor redirects with
+`RedirectSubwindows(root)`, so the windows that own a backing are the WM's
+FRAMES; the client's window is reparented inside one, its pixels live in
+the frame's backing at an offset, and its own leaf is stale. Restoring only
+the frame's leaf brought decorations back and left dolphin's content black
+— and it repainted in full on hover, i.e. the client could rebuild exactly
+what the server had dropped. The restore now reuses
+`plan_backing_inferiors` with src/dst swapped, which is literally the seed
+plan read backwards.
+
+Occluded regions come back holding the OCCLUDER's pixels, because B only
+ever held the composited result. That matches Xorg, where an occluded
+window's pixels are not stored anywhere either.
+
+**Tests, both proven red first:**
+`window_storage_init_covers_the_whole_allocation` (existing, was the
+"pre-existing failure"), plus
+`unredirect_restores_the_window_leaf_from_the_backing` and
+`unredirect_restores_a_reparented_child_leaf_not_just_the_frame`. The last
+one was checked for discrimination, not just greenness: narrowing the plan
+back to W alone leaves the frame test green and fails the child test with
+`[0,0,0,0]: 64`. Suite 155/155, libs 1294 + 1248, clippy `-D warnings` and
+nightly fmt clean.
+
+### OPEN — Plasma panel restores to its top half only (intermittent)
+
+Seen once on HW after fix 2: dolphin correct, panel painted in its top half
+only, and after a few fullscreen/windowed cycles it stayed fully drawn for
+the rest of the session. Then it stopped reproducing — including on a fresh
+session with the diagnostic built in, and at `warn`. Self-healing,
+first-cycle, cosmetic.
+
+A horizontal split at half height is what a copy clamped in Y looks like:
+the restore can only hand back `min(B, leaf)`, so a short B leaves the
+bottom without a source. The leading suspect is
+`allocate_redirected_backing`'s idempotent early-return, which hands back
+an existing backing WITHOUT comparing the requested size to it — Xorg
+deliberately does the opposite (`compReallocPixmap` reallocates iff the
+bordered extent changed, keeping the old pixmap "so bits can be
+recovered"). That would also explain the self-healing. **Unverified.**
+
+`restore_leaves_from_backing` carries a debug-level coverage log for
+exactly this, flagging `SHORT-OF-LEAF`, so the next sighting is cheap to
+diagnose:
+
+```
+RUST_LOG=warn,yserver::kms::render::backend=debug just <session-recipe> 2>&1 | tee /tmp/panel.log
+grep restore_leaves_from_backing /tmp/panel.log
+```
+
+Read it as: `leaf_extent` taller than `b_extent` → B is stale, fix in
+`allocate_redirected_backing`. Rect shorter than both → the planner clips,
+fix in `push_inferior_rects`. No `SHORT-OF-LEAF` for the panel → the copy
+covered the leaf and something after the restore repaints only part of it.
+Whatever B genuinely cannot source is Xorg's Expose case, not a copy case.
+
+Note the prior art at `backend.rs` (the compiz `--replace`
+half-drawn-panel fix, 2026-06-11): same shape, opposite direction, fixed on
+the seed side. Worth reading before designing this one.
+
+**Not claimed:** that fix 2 fixed the panel. Dolphin is HW-confirmed; the
+panel either got fixed or moved out of reach on its own.
+
 ### Next
 
-Neither fix on this branch depends on the Plasma question; both stand on their
-own measured Xorg mismatches. Open work, in order:
-
-1. The white-content lead above — A/B first, then fix
-   `window_storage_init_covers_the_whole_allocation` if it is confirmed.
+1. The panel half-restore above, if it reappears — the diagnostic is
+   already in place, so capture the log before touching anything.
 2. The stale-drawable acceptance divergence in the table above (we accept
-   requests on drawables unredirect should have killed).
+   requests on drawables unredirect should have killed; Xorg emits 16 each
+   of BadPixmap / BadGC / BadDrawable and we emit none).
+3. `feat/cow-structural` is unmerged and touches `release_redirected_backing`
+   and `activate_redirect_backing_for`; the restore will need reconciling
+   when that lands.

--- a/docs/status.md
+++ b/docs/status.md
@@ -6902,7 +6902,8 @@ free, and diff their gates", not "read the site the bug was reported at".
 ## Handoff — `fix/redirect-backing-and-logical-depth` (2026-09-11)
 
 Branched off master `7c01c69a`. Three code/test commits plus this note,
-**unmerged, no HW smoke run**.
+**unmerged; HW-smoked on silence under Plasma and Cinnamon** (see the HW smoke
+section below).
 Everything below was measured in the vng harness against X.Org 1.21.1.24
 (Arch's `xorg-server 21.1.24`), never inferred from spec prose.
 
@@ -7046,10 +7047,32 @@ blocks (Xorg errors correctly and still shows them), but it is a real measured
 divergence on the same teardown path. The 64-vs-16 `CreatePixmap` BadValue is a
 second, separate lead.
 
+### HW smoke — done, on silence, 2026-09-11
+
+The binary that produced all three traces above reports
+`yserver 1.5.0 (282f0b10e324)` in its startup line, i.e. it was built from this
+branch with both fixes live. That is what makes the runs smoke evidence for the
+branch rather than for master.
+
+- **Cinnamon** — mpv fullscreen and back: correct throughout, nothing lost or
+  discoloured. This is the path the `PictOpOver` → raw-copy change touches, and
+  it is the desktop that redirects per-window and never tears compositing down,
+  so it exercises the reconstruction walk without the KWin teardown confusing
+  the result. No regression.
+- **Plasma** — mpv fullscreen and back: white/black blocks, matched by stock
+  Xorg on the same session, as above. Not attributable to the branch.
+
+Both sessions ran under xtrace, and the Plasma yserver/Xorg pair was traced
+identically, so the tracer is held constant across that comparison
+(it is a known confound otherwise).
+
+What this does NOT establish: it is smoke, not targeted verification. Neither
+fix was confirmed to produce its intended effect *on hardware* — that evidence
+is the vng A/B against Xorg 21.1.24, which is where both were measured. No
+desktop other than Plasma and Cinnamon was exercised.
+
 ### Next
 
-Neither fix on this branch depends on any of the above; both stand on their own
-measured Xorg mismatches. The open work is the stale-drawable acceptance
+Neither fix on this branch depends on the Plasma question; both stand on their
+own measured Xorg mismatches. The open work is the stale-drawable acceptance
 divergence in the table above, which wants its own branch.
-
-**Gate before this branch lands: HW smoke. None has been run on it.**

--- a/docs/status.md
+++ b/docs/status.md
@@ -7071,8 +7071,91 @@ fix was confirmed to produce its intended effect *on hardware* — that evidence
 is the vng A/B against Xorg 21.1.24, which is where both were measured. No
 desktop other than Plasma and Cinnamon was exercised.
 
+### LEAD — window content goes WHITE with compositing off, and Xorg does not
+
+Reported 2026-09-11 after the exoneration above, and **narrower than the
+symptom that was exonerated**. With compositing off, the window CONTENT of
+specific KDE apps (dolphin, systemsettings) turns white. Unlike the
+full-output/dock blocks, this does **not** reproduce on Xorg.
+
+This is not a revival of the refuted plan — it is a different symptom with the
+Xorg differential the refuted one lacked. Read the distinction before acting:
+
+| | exonerated | this lead |
+|---|---|---|
+| symptom | white/black blocks over output and dock | specific windows' content goes white |
+| on Xorg | identical | does NOT happen |
+| verdict | KWin suspend/resume, normal comp-off X11 | ours |
+
+#### Why the unredirect path is back in scope
+
+Xorg has no per-window storage: a window's pixels live in the screen pixmap, so
+"unredirect" hands back content that was never anywhere else and nothing can be
+lost. yserver keeps a per-window leaf, releases the redirect backing on
+unredirect (`teardown_redirect_for_window`,
+`process_disconnect.rs:543` — it releases the backing and restores scene
+participation, and does **neither** a content restore nor an Expose), and falls
+back to that leaf. For a window whose background is None, that leaf may never
+have been painted by anything.
+
+#### The evidence already on disk
+
+- **37 windows are created with `background-pixmap=None`** in `plasma.xtrace`,
+  and 37 in `plasma-xorg.xtrace` — the largest category by far, and the shape
+  Qt/KDE apps use because they paint every pixel themselves.
+- **`window_storage_init_covers_the_whole_allocation` has been failing all
+  along** with exactly that shape, and its failure text is the symptom:
+
+  ```
+  no background attribute, depth 24: expected [0,0,0,255], got [255,255,255,255]
+  no background attribute, depth 32: expected [0,0,0,0],   got [255,255,255,0]
+  ```
+
+  RGB reads `0xFF` — WHITE — while alpha is exactly the init colour's. Its doc
+  comment (`render_acceptance.rs:13890`) already concluded "something writes
+  the alpha channel and leaves RGB untouched". `fresh_pixmap_reads_back_zero`
+  covers the same invariant for PIXMAPS and PASSES, so the gap is windows only.
+
+This test has been reported as "pre-existing" in every run on this branch. It
+is pre-existing, and it may well be the bug.
+
+#### What is NOT yet established
+
+The link between that white storage and the on-screen symptom is a
+**hypothesis, not a measurement**. Specifically unverified: that the white
+survives because the client's paint went to the redirect backing and the leaf
+was never written; and whether Xorg's comp-off result differs because of
+storage or because of Expose. Do not write a fix against this paragraph — get
+the A/B first.
+
+#### The next measurement
+
+`tools/unredirect-restore-probe.c` + `tools/vng-scenarios/unredirect-restore.sh`
+exist **UNTRACKED and uncommitted**, deliberately. The probe reproduces KWin's
+cycle in the observed order (`UnredirectSubwindows` then
+`ReleaseOverlayWindow`), and now includes a `background-pixmap=None` window
+that is fully client-painted, so a white reading cannot be blamed on the client
+having left pixels undrawn. It grades content-after-unredirect and
+Expose-after-unredirect separately, passing if either route works, because a
+server that restores content needs no Expose and vice versa.
+
+Run it as an Xorg/yserver A/B:
+
+```
+tools/vng-shot.sh --server xorg --dump none --name ur-xorg \
+    --scenario tools/vng-scenarios/unredirect-restore.sh
+tools/vng-shot.sh --name ur-ys --dump scanout \
+    --scenario tools/vng-scenarios/unredirect-restore.sh
+```
+
+It has never been run. Commit it only once it produces a real difference.
+
 ### Next
 
 Neither fix on this branch depends on the Plasma question; both stand on their
-own measured Xorg mismatches. The open work is the stale-drawable acceptance
-divergence in the table above, which wants its own branch.
+own measured Xorg mismatches. Open work, in order:
+
+1. The white-content lead above — A/B first, then fix
+   `window_storage_init_covers_the_whole_allocation` if it is confirmed.
+2. The stale-drawable acceptance divergence in the table above (we accept
+   requests on drawables unredirect should have killed).

--- a/docs/status.md
+++ b/docs/status.md
@@ -6898,3 +6898,98 @@ through `destroy_zombie_resources`.
 The pattern worth remembering: **three of these four were the same omission at a
 different site.** The audit that finds them is "list every site that decides to
 free, and diff their gates", not "read the site the bug was reported at".
+
+## Handoff — `fix/redirect-backing-and-logical-depth` (2026-09-11)
+
+Branched off master `7c01c69a`. Three commits, **unmerged, no HW smoke run**.
+Everything below was measured in the vng harness against X.Org 1.21.1.24
+(Arch's `xorg-server 21.1.24`), never inferred from spec prose.
+
+### What is on the branch
+
+| commit | what |
+|---|---|
+| `cf7585f4` | `tools/depth32-bg-probe.c`, `tools/redirect-subtree-probe.c` + 3 vng scenarios |
+| `786c4c20` | redirect-backing reconstruction: `PictOpOver` → raw copy |
+| `b38302c0` | `GetImage` reply depth from the drawable, not the backing |
+
+Re-run either probe with:
+
+```
+tools/vng-shot.sh --server xorg --dump none --name X --scenario tools/vng-scenarios/depth32-bg-composited.sh
+tools/vng-shot.sh --name Y --dump none --scenario tools/vng-scenarios/depth32-bg-composited.sh
+```
+
+Both grade themselves and print a VERDICT line. `depth32-bg-probe` also runs
+inside a live desktop session (`cc -O1 -o /tmp/p tools/depth32-bg-probe.c -lX11
+-lXcomposite && /tmp/p --hold 15`) — it detects an existing compositor via
+`_NET_WM_CM_Sn` rather than redirecting, takes no grabs, and cleans up after
+itself.
+
+### State at the tip
+
+- `depth32-bg-probe`: 12/12 graded cells match Xorg. Reply depth root=24,
+  depth-32 window=32.
+- `redirect-subtree-probe`: 8/8. Proven RED on `cf7585f4` (three samples) and
+  green at `786c4c20`.
+- `cargo clippy --all-targets -- -D warnings` clean; `yserver` lib 1294 pass,
+  `yserver-core` lib 1248 pass, `render_acceptance --ignored` 152 pass with the
+  single pre-existing `window_storage_init_covers_the_whole_allocation`
+  failure (documented at `render_acceptance.rs:13890`, fails identically on
+  master — baseline re-measured, not assumed).
+
+### Three things that are REFUTED — do not revive them
+
+1. **The depth-32 background alpha rule is master-only.** `miPaintWindow`'s
+   `fill.pixel |= 0xff000000` ancestor-chain walk (`mi/miexpose.c:487-511`)
+   arrived in commit `2de50de56` (2023-07-20), *after* the 21.1 branch point.
+   It is absent from every 21.1 release, i.e. from the server every user runs.
+   Background painting must NOT be made to follow it, and it must not be
+   coupled to the border decision. `border_solid_pixel`
+   (`backend.rs:4451`) already implements it, which means we diverge from
+   distro Xorg on borders — a standing choice from #133 step 4, not a defect
+   to "fix" by making backgrounds match.
+
+2. **Xorg does not canonicalise the depth-24 pad byte, and neither may we.**
+   `fbGetImage` masks only `if (pm != FB_ALLONES)`, and `AllPlanes` on a 32-bpp
+   depth-24 drawable replicates to all-ones, so the mask step is skipped
+   entirely and the byte passes through verbatim (measured: fg `0x00ff0000` →
+   pad `00`, fg `0xffff0000` → pad `ff`). A change to clear it was written,
+   broke 7 acceptance tests, and was reverted — **those tests were right**.
+   The 8 pad bits are protocol-undefined; our `ff` where Xorg passes through
+   `00` on the depth-24 root is informational and deliberately kept out of the
+   probe's verdict.
+
+3. **The "depth-32 child under a depth-24 frame loses its alpha" finding was a
+   measurement artifact.** `XGetPixel` masks to the image's depth CLIENT-side,
+   which stripped the pad byte on both servers equally. Reading raw image bytes
+   instead, our stored words are byte-identical to Xorg's in all six background
+   cases. There is no content-reconstruction problem; item 3 was a reply-header
+   fix only. Both probes now read raw bytes — keep it that way.
+
+### The invariant this established
+
+> The X reply's depth and plane-mask semantics come from the requested
+> drawable, never from the redirected backing or scanout storage.
+
+Written up at `get_image` (`backend.rs:22258`) with both failure cases named.
+`PaintTarget::x11_depth` already carried the logical depth for exactly this;
+`get_image` was the one caller not using it. `resources::ROOT_DEPTH` is now the
+single source for the root's depth, used by both the setup reply and GetImage.
+
+### Next
+
+The Plasma white/black blocks, unchanged in priority and still unfixed:
+
+1. Split scene "preserve alpha while blending" from "may claim occlusion" at
+   `scene.rs:6685`. Depth 32 must preserve alpha and must NOT claim its whole
+   rectangle opaque. Actual pixel alpha is not a usable occlusion predicate.
+   `_NET_WM_OPAQUE_REGION` could later supply a conservative region hint but is
+   not needed for the correctness fix.
+2. On unredirect, restore from the backing before un-routing/freeing it where
+   Xorg's depth-compatible restore applies, then emit Expose for the formerly
+   redirected mapped subtree. The backing is gone only after release, so it IS
+   available at the point restoration must happen — an earlier "there is no
+   backing" caveat was wrong.
+
+**Gate before any of this lands: HW smoke. None has been run on this branch.**

--- a/docs/status.md
+++ b/docs/status.md
@@ -6901,7 +6901,8 @@ free, and diff their gates", not "read the site the bug was reported at".
 
 ## Handoff — `fix/redirect-backing-and-logical-depth` (2026-09-11)
 
-Branched off master `7c01c69a`. Three commits, **unmerged, no HW smoke run**.
+Branched off master `7c01c69a`. Three code/test commits plus this note,
+**unmerged, no HW smoke run**.
 Everything below was measured in the vng harness against X.Org 1.21.1.24
 (Arch's `xorg-server 21.1.24`), never inferred from spec prose.
 
@@ -6920,7 +6921,16 @@ tools/vng-shot.sh --server xorg --dump none --name X --scenario tools/vng-scenar
 tools/vng-shot.sh --name Y --dump none --scenario tools/vng-scenarios/depth32-bg-composited.sh
 ```
 
-Both grade themselves and print a VERDICT line. `depth32-bg-probe` also runs
+Both grade themselves and print a VERDICT line.
+
+A correction to `cf7585f4`'s commit message, which overstates this: only
+`depth32-bg-probe` reads raw image bytes. `redirect-subtree-probe` still uses
+`XGetPixel`, which is sound there because it grades only the defined low 24
+bits of a depth-24 frame pixmap — the bits `XGetPixel` would mask away carry no
+contract anyway. The distinction matters if either probe is ever extended to
+compare alpha.
+
+`depth32-bg-probe` also runs
 inside a live desktop session (`cc -O1 -o /tmp/p tools/depth32-bg-probe.c -lX11
 -lXcomposite && /tmp/p --hold 15`) — it detects an existing compositor via
 `_NET_WM_CM_Sn` rather than redirecting, takes no grabs, and cleans up after
@@ -6977,19 +6987,69 @@ Written up at `get_image` (`backend.rs:22258`) with both failure cases named.
 `get_image` was the one caller not using it. `resources::ROOT_DEPTH` is now the
 single source for the root's depth, used by both the setup reply and GetImage.
 
+### The Plasma white/black blocks are NOT a yserver bug
+
+Measured on HW the same afternoon these commits were written, and this
+supersedes every earlier plan in this section.
+
+The blocks appear when mpv goes fullscreen and back under Plasma. They appear
+**identically on stock Xorg** with the same KWin session and the same toggle.
+What KWin is doing is suspending and resuming compositing, and both servers get
+byte-for-byte the same request sequence for it:
+
+| | yserver (`plasma.xtrace`) | Xorg (`plasma-xorg.xtrace`) |
+|---|---|---|
+| `RedirectSubwindows` Manual | 4 | 4 |
+| `UnredirectSubwindows` Manual | 3 | 3 |
+| `ReleaseOverlayWindow` | 3 | 3 |
+| `GetOverlayWindow` | 8 | 8 |
+| `NameWindowPixmap` | 47 | 45 |
+
+Interleave is `Redirect → Unredirect → Release` three times over, then a final
+`Redirect`, in that order on both. With compositing off, an ARGB window drawn
+opaque is ordinary X11 behaviour, not a defect.
+
+**Two plans that were live before this measurement are now dead as Plasma
+fixes. Do not pick them up on this evidence:**
+
+- the `scene.rs:6685` alpha/occlusion split. The analysis may describe a real
+  latent defect and is kept on file, but it is not this symptom.
+- "restore from the backing on unredirect, then Expose". Xorg receives the same
+  global unredirect and produces the same visual result, so the premise that
+  Xorg's restore rescues this case is wrong.
+
+Also retracted: the Cinnamon/Plasma split (Muffin never unredirects; KWin does
+three times) was read as evidence that *we* broke KWin's path. It only ever
+showed that Muffin does not exercise that path.
+
+### The one real divergence the traces did surface
+
+Comparing CORE opcodes only — extension majors are numbered per server
+(Composite is 144 for us, 142 on Xorg) and cannot be compared across traces:
+
+| error | opcode | yserver | Xorg |
+|---|---|---|---|
+| BadPixmap | 54 `FreePixmap` | **0** | 16 |
+| BadGC | 60 `FreeGC` | **0** | 16 |
+| BadDrawable | 55 `CreateGC` | **0** | 16 |
+| BadDrawable | 72 `PutImage` | **0** | 16 |
+| BadValue | 53 `CreatePixmap` | **64** | 16 |
+| BadAtom | 20 `GetProperty` | 128 | 68 |
+| BadAtom | 17 `GetAtomName` | 66 | 16 |
+
+Xorg emits a coherent set of 16 errors: KWin keeps using `NameWindowPixmap`
+handles that unredirect has invalidated, and Xorg rejects them four different
+ways. We emit **none** of those, i.e. we accept requests on drawables that
+should be dead — the permissive direction, and exactly what would let a
+compositor keep painting into a freed backing. It is NOT the cause of the
+blocks (Xorg errors correctly and still shows them), but it is a real measured
+divergence on the same teardown path. The 64-vs-16 `CreatePixmap` BadValue is a
+second, separate lead.
+
 ### Next
 
-The Plasma white/black blocks, unchanged in priority and still unfixed:
+Neither fix on this branch depends on any of the above; both stand on their own
+measured Xorg mismatches. The open work is the stale-drawable acceptance
+divergence in the table above, which wants its own branch.
 
-1. Split scene "preserve alpha while blending" from "may claim occlusion" at
-   `scene.rs:6685`. Depth 32 must preserve alpha and must NOT claim its whole
-   rectangle opaque. Actual pixel alpha is not a usable occlusion predicate.
-   `_NET_WM_OPAQUE_REGION` could later supply a conservative region hint but is
-   not needed for the correctness fix.
-2. On unredirect, restore from the backing before un-routing/freeing it where
-   Xorg's depth-compatible restore applies, then emit Expose for the formerly
-   redirected mapped subtree. The backing is gone only after release, so it IS
-   available at the point restoration must happen — an earlier "there is no
-   backing" caveat was wrong.
-
-**Gate before any of this lands: HW smoke. None has been run on this branch.**
+**Gate before this branch lands: HW smoke. None has been run on it.**

--- a/tools/depth32-bg-probe.c
+++ b/tools/depth32-bg-probe.c
@@ -1,0 +1,533 @@
+/* depth32-bg-probe — a purpose-written client for Xorg's depth-32
+ * background-alpha rule. Runs against ANY X server, on a real desktop or in
+ * the vng harness, and grades itself, so a session on unfamiliar hardware
+ * answers the question without anyone relaying screenshots.
+ *
+ * THE RULE (mi/miexpose.c:487-511, under #ifdef COMPOSITE, comment verbatim
+ * "Make sure alpha will sample as 1.0 for opaque windows"):
+ *
+ *     if (drawable->depth == 32) {
+ *         int effective_depth = orig_pWin->drawable.depth;
+ *         if (effective_depth == 32) {
+ *             orig_pWin = orig_pWin->parent;
+ *             while (orig_pWin && orig_pWin->parent) {
+ *                 if (orig_pWin->drawable.depth == 24) {
+ *                     effective_depth = 24;
+ *                     break;
+ *                 }
+ *                 orig_pWin = orig_pWin->parent;
+ *             }
+ *         }
+ *         if (effective_depth == 24)
+ *             fill.pixel |= 0xff000000;
+ *     }
+ *
+ * The `if (solid)` block this sits in serves BOTH PW_BACKGROUND and PW_BORDER,
+ * so bg_pixel and border_pixel take the same treatment. Two details decide the
+ * outcome and neither is guessable from spec prose:
+ *
+ *   1. The gate is `drawable->depth`. For PW_BACKGROUND `drawable` is never
+ *      reassigned from `&pWin->drawable`, so the gate is the WINDOW's depth.
+ *      (For PW_BORDER it IS reassigned, to GetWindowPixmap's pixmap, so that
+ *      one gates on the BACKING depth. Different tests; don't copy one to the
+ *      other.)
+ *   2. The walk is `while (orig_pWin && orig_pWin->parent)` — it starts at the
+ *      parent and stops BEFORE the root, whose depth is therefore never
+ *      consulted. So "child of root" and "child of a depth-24 frame" land on
+ *      opposite sides of the rule.
+ *
+ * THE PREDICTION, for a depth-32 window with no client drawing at all, only a
+ * bg_pixel:
+ *
+ *   chain A, direct child of root  -> loop body never runs, effective_depth
+ *                                     stays 32, alpha PRESERVED as given
+ *   chain B, child of a depth-24
+ *            override-redirect frame -> loop finds depth 24, alpha FORCED to
+ *                                     0xff regardless of what the client asked
+ *
+ * so, per bg_pixel:
+ *
+ *     bg_pixel     chain A stored   chain B stored
+ *     0x00ffffff   0x00ffffff       0xffffffff
+ *     0x00000000   0x00000000       0xff000000
+ *     0xffffffff   0xffffffff       0xffffffff
+ *
+ * The backdrops are chosen so the SCANOUT reads the same fact independently of
+ * the readback: root is red, the depth-24 frames are blue. Anywhere alpha is
+ * preserved AND something blends it, the backdrop shows through; anywhere it is
+ * forced (or nothing blends), the window's own RGB shows as a solid block.
+ * Note the two are only expected to agree when a compositor is redirecting —
+ * this scenario deliberately runs none, so the scanout is the unblended case
+ * and the readback is the load-bearing half.
+ *
+ * Readback is taken twice per window, because they can disagree and the
+ * disagreement is itself informative: XGetImage on the WINDOW (which may mask
+ * to the drawable's depth) and XGetImage on the ROOT at the same absolute
+ * coordinates (the raw framebuffer word). Unredirected, a depth-32 window's
+ * pixels live in the screen pixmap, so the root read is the one that shows
+ * what byte actually sits in the alpha slot.
+ *
+ * Deliberately runs NO window manager and every window is override-redirect,
+ * so nothing reparents them — a reparenting WM would silently move chain A
+ * into chain B and destroy the whole experiment. Works unchanged on yserver
+ * and on Xorg (`--server xorg`), which is the entire point.
+ *
+ * WITH `--redirect`, the probe additionally turns on Composite automatic
+ * redirection for the root's children and reads the REDIRECTED PIXMAP — which
+ * is literally the buffer a compositor samples, so it answers the question the
+ * screen capture cannot answer on Xorg (under a compositor `import -window
+ * root` returns the root window, not the composited output; that is issue
+ * #135's whole symptom). Being pure protocol, it reads the same way on both
+ * servers with no capture path in the comparison at all.
+ *
+ * Note which windows that redirection reaches. XCompositeRedirectSubwindows on
+ * the root redirects the root's CHILDREN — chain A's windows and chain B's
+ * depth-24 frames — but NOT chain B's depth-32 children, which are one level
+ * further down and keep painting into their frame's pixmap. That is not a
+ * limitation, it is the real-world structure: a WM frame is what gets
+ * redirected and the ARGB client window paints inside it. So for chain B the
+ * probe reads the FRAME's pixmap at the child's offset, which asks the
+ * load-bearing question directly — does an alpha-zero child punch a
+ * transparent hole through its opaque parent's redirected pixmap?
+ *
+ * THE BASELINE IS MEASURED, NOT PREDICTED. X.Org 1.21.1.24 (Arch's
+ * xorg-server 21.1.24), vng harness, 2026-09-11, with `--redirect`:
+ *
+ *     bg_pixel            chain    win_read   pixmap_read
+ *     transparent-white   A-root   00ffffff   00ffffff
+ *     transparent-white   B-fr24   00ffffff   00ffffff
+ *     transparent-zero    A-root   00000000   00000000
+ *     transparent-zero    B-fr24   00000000   00000000
+ *     opaque-white        A-root   ffffffff   ffffffff
+ *     opaque-white        B-fr24   ffffffff   ffffffff
+ *
+ * Re-measured 2026-09-11 after `peek` switched from XGetPixel to raw image
+ * bytes. XGetPixel masks to the reply depth CLIENT-side, which had been
+ * hiding the pad byte on both servers and made B-fr24 opaque-white look like
+ * a content divergence when the stored words were in fact identical.
+ *
+ * That table is the compatibility contract: it is what the server our users
+ * actually run does, so it is what we match. It is printed as the `xorg_21.1`
+ * column and graded against automatically.
+ *
+ * Two readings of that baseline are load-bearing elsewhere:
+ *
+ *   - The alpha fixup never fires anywhere in it. 21.1.x does not carry commit
+ *     2de50de56 (2023-07-20), where that rule lives; it is master-only. It is
+ *     deliberately NOT part of what this probe grades, and background painting
+ *     must not be made to follow it.
+ *   - chain B's pixmap_read is the ARGB child's own bits, alpha and all,
+ *     sitting in its depth-24 parent's redirected pixmap. That is a
+ *     RAW COPY of the child into the parent, not an alpha composite of it —
+ *     which is what a redirected backing must be reconstructed with.
+ *
+ * Build:
+ *     cc -O1 -o depth32-bg-probe depth32-bg-probe.c -lX11 -lXcomposite
+ *
+ * Run (on a real desktop — Plasma, MATE, whatever is already logged in):
+ *     ./depth32-bg-probe
+ *
+ * It prints a table, holds its windows on screen for --hold seconds so they
+ * can be photographed or screenshotted, then tidies up and exits. It never
+ * takes a grab, never touches an existing window and never installs itself as
+ * a compositor, so it is safe to run inside a live session.
+ *
+ *     --hold N      seconds to stay on screen (default 10; 0 = until killed)
+ *     --redirect    force Composite automatic redirection on ourselves
+ *     --no-redirect never redirect, even if nothing else is compositing
+ *
+ * By default the probe REDIRECTS ONLY IF NOTHING ELSE IS. On a composited
+ * desktop the session's own compositor has already redirected everything, and
+ * a second redirecting client would be both rude and a confound; the probe
+ * detects that via the _NET_WM_CM_Sn manager selection and simply reads the
+ * pixmaps that are already there. On a bare server with no compositor it turns
+ * automatic redirection on itself, because otherwise there is no redirected
+ * pixmap to read and the interesting column would be empty.
+ */
+
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include <X11/extensions/Xcomposite.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define ROOT_BG   0x00ff0000u /* red    — root, visible only on a bare server */
+#define BACKDROP  0x0000ff00u /* green  — backdrop SIBLING beneath chain A */
+#define FRAME_BG  0x000000ffu /* blue   — depth-24 frame, parent of chain B */
+
+#define WIN_W 120
+#define WIN_H 120
+#define STEP  160
+#define ORIGIN_X 100
+#define ROW_A_Y  100
+#define ROW_B_Y  300
+#define INSET 10 /* chain B child is inset inside its frame, so the frame's
+                  * blue is visible around it even when the child is opaque */
+
+static const unsigned long BG[3] = { 0x00ffffffu, 0x00000000u, 0xffffffffu };
+static const char *BG_NAME[3] = { "transparent-white", "transparent-zero", "opaque-white" };
+
+/* Measured on X.Org 1.21.1.24 with --redirect; see the header. Indexed
+ * [bg][chain], chain 0 = A-root, chain 1 = B-fr24. */
+static const unsigned long XORG_WIN[3][2] = {
+    { 0x00ffffffu, 0x00ffffffu },
+    { 0x00000000u, 0x00000000u },
+    { 0xffffffffu, 0xffffffffu },
+};
+static const unsigned long XORG_PIXMAP[3][2] = {
+    { 0x00ffffffu, 0x00ffffffu },
+    { 0x00000000u, 0x00000000u },
+    { 0xffffffffu, 0xffffffffu },
+};
+
+static int failures;
+
+/* Grade one reading against the measured Xorg baseline. Only meaningful when
+ * the probe ran redirected, since that is the state the baseline was taken
+ * in; unredirected runs print the reading and grade nothing. */
+static const char *grade(unsigned long got, unsigned long want, int ok, int comparable)
+{
+    if (!ok)
+        return "-";
+    if (!comparable)
+        return "?";
+    if (got == want)
+        return "ok";
+    failures++;
+    return "DIFF";
+}
+
+/* Read one pixel out of `d` at drawable-relative (x,y). Returns 0 on failure
+ * and sets *ok, so a BadMatch on one read cannot take the whole probe down. */
+static unsigned long peek(Display *dpy, Drawable d, int x, int y, int *ok)
+{
+    XImage *img = XGetImage(dpy, d, x, y, 1, 1, AllPlanes, ZPixmap);
+    if (!img) {
+        *ok = 0;
+        return 0;
+    }
+    /* Read the RAW bytes, not XGetPixel. XGetPixel masks the value down to
+     * the image's depth, so on a depth-24 reply it silently zeroes the pad
+     * byte — client-side, on every server equally. That hides exactly the
+     * thing this probe exists to compare: what the server stored, and what
+     * depth it claimed the reply was. Byte order here is the server's
+     * image_byte_order; both ends of this comparison are little-endian
+     * LSBFirst, so B,G,R,A packs to 0xAARRGGBB. */
+    unsigned long px;
+    if (img->bits_per_pixel == 32 && img->byte_order == LSBFirst) {
+        unsigned char *b = (unsigned char *) img->data;
+        px = ((unsigned long) b[3] << 24) | ((unsigned long) b[2] << 16)
+             | ((unsigned long) b[1] << 8) | (unsigned long) b[0];
+    } else {
+        px = XGetPixel(img, 0, 0);
+    }
+    XDestroyImage(img);
+    *ok = 1;
+    return px;
+}
+
+/* Read one pixel out of the window's REDIRECTED pixmap — the buffer a
+ * compositor would sample. `win` of 0 means redirection is off, which is a
+ * skip, not a failure. The pixmap is named fresh each time because its id is
+ * invalidated by every resize and by unredirection. */
+static unsigned long peek_named_pixmap(Display *dpy, Window win, int x, int y, int *ok)
+{
+    if (!win) {
+        *ok = 0;
+        return 0;
+    }
+    Pixmap pm = XCompositeNameWindowPixmap(dpy, win);
+    if (!pm) {
+        *ok = 0;
+        return 0;
+    }
+    unsigned long px = peek(dpy, pm, x, y, ok);
+    XFreePixmap(dpy, pm);
+    return px;
+}
+
+int main(int argc, char **argv)
+{
+    int force_redirect = 0, never_redirect = 0, hold = 10;
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--redirect") == 0) {
+            force_redirect = 1;
+        } else if (strcmp(argv[i], "--no-redirect") == 0) {
+            never_redirect = 1;
+        } else if (strcmp(argv[i], "--hold") == 0 && i + 1 < argc) {
+            hold = atoi(argv[++i]);
+        } else {
+            fprintf(stderr,
+                    "usage: %s [--hold N] [--redirect|--no-redirect]\n", argv[0]);
+            return 2;
+        }
+    }
+
+    Display *dpy = XOpenDisplay(NULL);
+    if (!dpy) {
+        fprintf(stderr, "depth32-bg-client: cannot open display\n");
+        return 1;
+    }
+    int screen = DefaultScreen(dpy);
+    Window root = RootWindow(dpy, screen);
+
+    XVisualInfo vinfo;
+    if (!XMatchVisualInfo(dpy, screen, 32, TrueColor, &vinfo)) {
+        fprintf(stderr, "depth32-bg-client: no depth-32 TrueColor visual\n");
+        return 1;
+    }
+    Colormap cmap32 = XCreateColormap(dpy, root, vinfo.visual, AllocNone);
+
+    /* Is a compositing manager already running? The ICCCM/EWMH answer is the
+     * owner of the _NET_WM_CM_Sn manager selection, which every compositor
+     * (KWin, Mutter, picom, xfwm4 ...) claims. */
+    char sel[32];
+    snprintf(sel, sizeof sel, "_NET_WM_CM_S%d", screen);
+    int session_composited =
+        XGetSelectionOwner(dpy, XInternAtom(dpy, sel, False)) != None;
+
+    int ev, err;
+    int have_composite_ext = XCompositeQueryExtension(dpy, &ev, &err);
+    int we_redirect = 0;
+    if (!never_redirect && have_composite_ext
+        && (force_redirect || !session_composited)) {
+        /* Automatic, not manual: the server keeps painting to the screen, so
+         * what is on screen stays meaningful and no external compositor has to
+         * be trusted to draw. Redirect BEFORE creating the windows so they are
+         * born redirected and no unredirected fill can be mistaken for the
+         * redirected one. */
+        XCompositeRedirectSubwindows(dpy, root, CompositeRedirectAutomatic);
+        XSync(dpy, False);
+        we_redirect = 1;
+    }
+    /* Either route leaves the windows redirected, which is all the pixmap
+     * read needs. */
+    int have_composite = have_composite_ext && (we_redirect || session_composited);
+
+    /* Red root, so a preserved-alpha window over it blends to red. */
+    XSetWindowBackground(dpy, root, ROOT_BG);
+    XClearWindow(dpy, root);
+
+    Window a[3], b[3], frame[3], back[3];
+    XSetWindowAttributes attr;
+
+    for (int i = 0; i < 3; i++) {
+        /* A depth-24 backdrop for chain A. It is a SIBLING stacked beneath,
+         * never a parent: making it a parent would drag chain A into chain B's
+         * shape and there would be only one case left. The root's own red is
+         * no use on a real desktop, where the session paints a desktop window
+         * over the root and the root is never seen. */
+        XSetWindowAttributes battr;
+        battr.background_pixel = BACKDROP;
+        battr.override_redirect = True;
+        battr.event_mask = ExposureMask;
+        back[i] = XCreateWindow(dpy, root, ORIGIN_X + i * STEP - INSET, ROW_A_Y - INSET,
+                                WIN_W + 2 * INSET, WIN_H + 2 * INSET, 0,
+                                (int) DefaultDepth(dpy, screen), InputOutput,
+                                DefaultVisual(dpy, screen),
+                                CWBackPixel | CWOverrideRedirect | CWEventMask, &battr);
+
+        /* ---- chain A: depth-32 child of the root ---- */
+        attr.background_pixel = BG[i];
+        attr.border_pixel = 0; /* required: depth differs from the parent's */
+        attr.colormap = cmap32;
+        attr.override_redirect = True;
+        attr.event_mask = ExposureMask;
+        a[i] = XCreateWindow(dpy, root, ORIGIN_X + i * STEP, ROW_A_Y, WIN_W, WIN_H, 0,
+                             32, InputOutput, vinfo.visual,
+                             CWBackPixel | CWBorderPixel | CWColormap
+                                 | CWOverrideRedirect | CWEventMask,
+                             &attr);
+
+        /* ---- chain B: depth-32 child of a depth-24 frame ---- */
+        XSetWindowAttributes fattr;
+        fattr.background_pixel = FRAME_BG;
+        fattr.override_redirect = True;
+        fattr.event_mask = ExposureMask;
+        frame[i] = XCreateWindow(dpy, root, ORIGIN_X + i * STEP, ROW_B_Y, WIN_W, WIN_H, 0,
+                                 (int) DefaultDepth(dpy, screen), InputOutput,
+                                 DefaultVisual(dpy, screen),
+                                 CWBackPixel | CWOverrideRedirect | CWEventMask, &fattr);
+
+        attr.background_pixel = BG[i];
+        b[i] = XCreateWindow(dpy, frame[i], INSET, INSET,
+                             WIN_W - 2 * INSET, WIN_H - 2 * INSET, 0,
+                             32, InputOutput, vinfo.visual,
+                             CWBackPixel | CWBorderPixel | CWColormap
+                                 | CWOverrideRedirect | CWEventMask,
+                             &attr);
+    }
+
+    /* Backdrops first, so they are below their chain-A window in the stack. */
+    for (int i = 0; i < 3; i++)
+        XMapWindow(dpy, back[i]);
+    XSync(dpy, False);
+    for (int i = 0; i < 3; i++) {
+        XMapWindow(dpy, a[i]);
+        XMapWindow(dpy, frame[i]);
+        XMapWindow(dpy, b[i]);
+    }
+    XSync(dpy, False);
+
+    /* Let the server settle its background paint before reading it back. */
+    sleep(1);
+
+    printf("# depth32-bg-probe: root_bg=%08lx backdrop=%08lx frame_bg=%08lx\n",
+           (unsigned long) ROOT_BG, (unsigned long) BACKDROP,
+           (unsigned long) FRAME_BG);
+    printf("# on screen: chain A blended => GREEN shows; chain B blended => BLUE\n");
+    printf("# server=\"%s\" composite_ext=%s session_compositor=%s redirected_by=%s\n",
+           ServerVendor(dpy), have_composite_ext ? "yes" : "no",
+           session_composited ? "yes" : "no",
+           we_redirect ? "probe" : (session_composited ? "session" : "nothing"));
+    printf("# %-18s %-8s %-10s %-9s %-10s %-11s %-9s %s\n",
+           "bg_pixel", "chain", "win_read", "vs_xorg", "root_read", "pixmap_read",
+           "vs_xorg", "geometry");
+
+    for (int i = 0; i < 3; i++) {
+        int ax = ORIGIN_X + i * STEP, ay = ROW_A_Y;
+        int bx = ORIGIN_X + i * STEP + INSET, by = ROW_B_Y + INSET;
+        int ok_w, ok_r, ok_p;
+        unsigned long wa = peek(dpy, a[i], 2, 2, &ok_w);
+        unsigned long ra = peek(dpy, root, ax + 2, ay + 2, &ok_r);
+        /* chain A is a direct child of the root, so redirection reached it and
+         * its own pixmap is what a compositor samples. */
+        unsigned long pa = peek_named_pixmap(dpy, have_composite ? a[i] : 0, 2, 2, &ok_p);
+        printf("%-20s %-8s %08lx%s  %-9s %08lx%s  %08lx%s   %-9s %d,%d %dx%d\n",
+               BG_NAME[i], "A-root",
+               wa, ok_w ? " " : "!", grade(wa, XORG_WIN[i][0], ok_w, have_composite),
+               ra, ok_r ? " " : "!",
+               pa, ok_p ? " " : "!", grade(pa, XORG_PIXMAP[i][0], ok_p, have_composite),
+               ax, ay, WIN_W, WIN_H);
+
+        unsigned long wb = peek(dpy, b[i], 2, 2, &ok_w);
+        unsigned long rb = peek(dpy, root, bx + 2, by + 2, &ok_r);
+        /* chain B's depth-32 child is NOT redirected — its depth-24 FRAME is.
+         * Read the frame's pixmap where the child sits: that is the question. */
+        unsigned long pb = peek_named_pixmap(dpy, have_composite ? frame[i] : 0,
+                                             INSET + 2, INSET + 2, &ok_p);
+        printf("%-20s %-8s %08lx%s  %-9s %08lx%s  %08lx%s   %-9s %d,%d %dx%d\n",
+               BG_NAME[i], "B-fr24",
+               wb, ok_w ? " " : "!", grade(wb, XORG_WIN[i][1], ok_w, have_composite),
+               rb, ok_r ? " " : "!",
+               pb, ok_p ? " " : "!", grade(pb, XORG_PIXMAP[i][1], ok_p, have_composite),
+               bx, by, WIN_W - 2 * INSET, WIN_H - 2 * INSET);
+    }
+    /* A depth-24 PIXMAP's pad byte, read raw. The spec leaves the 8 pad bits
+     * of a 32-bits-per-pixel depth-24 ZPixmap undefined, so this is not a
+     * conformance question but a compatibility one: whatever Xorg puts there
+     * is what clients have been written against. Read the image bytes
+     * directly rather than through XGetPixel, which normalises. */
+    {
+        Pixmap p24 = XCreatePixmap(dpy, root, 4, 4, (unsigned) DefaultDepth(dpy, screen));
+        GC pgc = XCreateGC(dpy, p24, 0, NULL);
+        XSetForeground(dpy, pgc, 0x00ff0000u); /* opaque-ish red, X byte clear */
+        XFillRectangle(dpy, p24, pgc, 0, 0, 4, 4);
+        XSetForeground(dpy, pgc, 0xffff0000u); /* same red, X byte SET */
+        XFillRectangle(dpy, p24, pgc, 2, 0, 2, 4);
+        XSync(dpy, False);
+        XImage *pi = XGetImage(dpy, p24, 0, 0, 4, 1, AllPlanes, ZPixmap);
+        if (pi && pi->bits_per_pixel == 32) {
+            unsigned char *d = (unsigned char *) pi->data;
+            /* MEASURED on Xorg 21.1.24: 00 then ff — the pad byte is passed
+             * through verbatim, NOT canonicalised. `fbGetImage` masks only
+             * `if (pm != FB_ALLONES)` (fb/fbimage.c) and AllPlanes on a
+             * 32-bpp depth-24 drawable replicates to all-ones, so the mask
+             * step is skipped entirely. The 8 pad bits of a depth-24 ZPixmap
+             * are undefined by the protocol and Xorg does not define them. */
+            /* INFORMATIONAL — deliberately not part of the verdict. These 8
+             * bits are undefined by the protocol and Xorg does not define
+             * them either, so a difference here is a difference in a field
+             * no conforming client may read. Printed because it is cheap and
+             * it localises the "which byte moved" question, not because it
+             * is a defect. Promote it only if a real client is shown to
+             * depend on the byte. */
+            printf("# depth-24 pixmap pad byte (informational, protocol-undefined): "
+                   "fg=0x00ff0000 -> %02x, fg=0xffff0000 -> %02x"
+                   "  (xorg 21.1.24: 00 then ff = pass-through)\n",
+                   d[3], d[4 * 2 + 3]);
+        } else {
+            printf("# depth-24 pixmap pad byte: unavailable (bpp=%d)\n",
+                   pi ? pi->bits_per_pixel : -1);
+        }
+        if (pi)
+            XDestroyImage(pi);
+        XFreeGC(dpy, pgc);
+        XFreePixmap(dpy, p24);
+    }
+
+    /* The REPLY depth, not just the pixel. GetImage's reply carries a depth
+     * and the client believes it; if it comes from the server's internal
+     * storage rather than the drawable's X11 depth, every pixel above is
+     * being interpreted against the wrong contract. Xorg 21.1.24 answers 24
+     * for the depth-24 root and 32 for a depth-32 window. */
+    {
+        XImage *ri = XGetImage(dpy, root, ORIGIN_X, ROW_A_Y, 1, 1, AllPlanes, ZPixmap);
+        XImage *wi = XGetImage(dpy, a[0], 2, 2, 1, 1, AllPlanes, ZPixmap);
+        printf("# reply depth: root=%d (xorg 21.1.24: 24)  depth32 window=%d (xorg: 32)%s\n",
+               ri ? ri->depth : -1, wi ? wi->depth : -1,
+               (ri && ri->depth != 24) ? "   <-- DIFF" : "");
+        if (ri && ri->depth != 24)
+            failures++;
+        if (ri)
+            XDestroyImage(ri);
+        if (wi)
+            XDestroyImage(wi);
+    }
+    printf("# a trailing '!' marks a failed XGetImage, not a zero pixel\n");
+    printf("# win_read    = XGetImage on the window itself, read as RAW BYTES (not\n"
+           "#               XGetPixel, which masks to the reply depth)\n");
+    printf("# root_read   = XGetImage on the ROOT at the same absolute point. The\n");
+    printf("#               root is depth 24, so its alpha byte carries no\n");
+    printf("#               information; the column is here to expose plane-mask\n");
+    printf("#               differences, not to be read as stored alpha. Xorg\n");
+    printf("#               does NOT mask it: AllPlanes on a 32-bpp depth-24\n");
+    printf("#               drawable replicates to all-ones and fbGetImage\n");
+    printf("#               skips masking, so the byte is whatever storage\n");
+    printf("#               holds. Compare it as content, not as a mask test.\n");
+    printf("# pixmap_read = XGetImage on the redirected pixmap a compositor\n");
+    printf("#               samples. For chain B that is the depth-24 FRAME's\n");
+    printf("#               pixmap at the ARGB child's offset, so alpha 00 there\n");
+    printf("#               means the child punched a transparent hole through\n");
+    printf("#               its opaque parent.\n");
+    printf("# vs_xorg     = against the MEASURED X.Org 1.21.1.24 redirected table\n");
+    printf("#               in this file's header, which is the compatibility\n");
+    printf("#               contract. '?' = not comparable (ran unredirected),\n");
+    printf("#               '-' = the read itself failed.\n");
+    printf("# NOT graded  = the master-only alpha fixup (commit 2de50de56); it is\n");
+    printf("#               absent from every 21.1 release and out of scope here.\n");
+    printf("%s\n", have_composite
+           ? (failures ? "VERDICT: DIFFERS from Xorg 21.1" : "VERDICT: matches Xorg 21.1")
+           : "VERDICT: ungraded (ran unredirected; baseline is the redirected table)");
+    fflush(stdout);
+
+    /* The background is server-painted; the probe only has to stay alive so
+     * the connection is not dropped while the screen is being looked at. */
+    for (int elapsed = 0; hold <= 0 || elapsed < hold * 10; elapsed++) {
+        while (XPending(dpy)) {
+            XEvent xev;
+            XNextEvent(dpy, &xev);
+        }
+        usleep(100000);
+    }
+
+    /* Tidy up: this may be running inside someone's live session, and leaving
+     * six override-redirect windows welded over their desktop is not on. */
+    for (int i = 0; i < 3; i++) {
+        XDestroyWindow(dpy, a[i]);
+        XDestroyWindow(dpy, back[i]);
+        XDestroyWindow(dpy, frame[i]); /* takes b[i] with it */
+    }
+    if (we_redirect)
+        XCompositeUnredirectSubwindows(dpy, root, CompositeRedirectAutomatic);
+    /* Restore the root background we overwrote. Nothing records what it was,
+     * so hand it back to the session rather than guessing a colour: None means
+     * "undefined", and the desktop repaints its own wallpaper on the Expose. */
+    XSetWindowBackgroundPixmap(dpy, root, None);
+    XClearWindow(dpy, root);
+    XSync(dpy, False);
+    XCloseDisplay(dpy);
+    return 0;
+}

--- a/tools/redirect-subtree-probe.c
+++ b/tools/redirect-subtree-probe.c
@@ -1,0 +1,212 @@
+/* redirect-subtree-probe — does redirecting a window reconstruct its whole
+ * subtree correctly into the new backing?
+ *
+ * When a window W is redirected, Xorg allocates a pixmap and seeds it with
+ * `CopyArea(parent, …, IncludeInferiors)` (`composite/compalloc.c:562`). That
+ * single copy captures W AND everything inside it, because Xorg has no
+ * per-window storage — it is all one screen pixmap. yserver keeps a separate
+ * leaf per window, so it has to synthesize the same result by walking the
+ * subtree (`overlay_backing_inferiors`) — and a walk can get wrong what a
+ * single copy cannot: stacking order, nesting depth, and the compositing
+ * operator used to lay each leaf down.
+ *
+ * That last one was wrong until 2026-09-11: the walk used PictOpOver, so a
+ * child with alpha 0 blended as a no-op and left the seed showing through
+ * instead of replacing it. CopyArea has no notion of alpha; the walk must
+ * REPLACE. This probe is the regression test for that, and it deliberately
+ * exercises the three things a raw-copy walk can still get wrong:
+ *
+ *   overlap   C1 and C2 overlap; C2 is mapped later so it is ABOVE. The
+ *             overlap must read as C2. A walk in the wrong order reads C1.
+ *   nesting   G is a child of C1, not of F. It must appear at its accumulated
+ *             offset. A walk that only visits F's direct children loses it.
+ *   alpha     C3 (alpha 0) and C4 (alpha 0x80) must land as their exact
+ *             stored words. Under PictOpOver C3 vanished entirely and C4
+ *             came out blended with whatever was beneath.
+ *
+ * The subtree is built and painted FIRST and redirection is turned on only
+ * afterwards, so the reconstruction runs over an already-painted tree — the
+ * real ordering, and the one where a missed inferior is visible.
+ *
+ * Every window is override-redirect and no WM runs, so nothing reparents or
+ * restacks the tree under us.
+ *
+ * MEASURED BASELINE — filled in from X.Org 1.21.1.24 below; that table is the
+ * contract, exactly as in tools/depth32-bg-probe.c.
+ *
+ * Build: cc -O1 -o redirect-subtree-probe redirect-subtree-probe.c -lX11 -lXcomposite
+ * Run:   ./redirect-subtree-probe [--hold N]
+ */
+
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include <X11/extensions/Xcomposite.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define F_X 100
+#define F_Y 100
+#define F_W 200
+#define F_H 200
+
+#define F_BG  0x00202020u /* dark grey — the frame's own background   */
+#define C1_BG 0x00ff0000u /* red       — lower of the overlapping pair */
+#define C2_BG 0x000000ffu /* blue      — upper of the overlapping pair */
+#define G_BG  0x0000ff00u /* green     — nested one level deeper       */
+#define C3_BG 0x00000000u /* alpha 0   — must REPLACE, not blend away  */
+#define C4_BG 0x80ff0000u /* alpha 0x80 — must survive byte-exact      */
+
+struct sample {
+    const char *name;
+    int x, y;            /* frame-local */
+    unsigned long xorg;  /* measured on X.Org 1.21.1.24 */
+};
+
+/* Filled from the Xorg run; see MEASURED BASELINE above. */
+static struct sample SAMPLES[] = {
+    { "frame-bg",        5,   5,   0x00202020u },
+    { "nested-G",        20,  20,  0x0000ff00u },
+    { "C1-only",         50,  20,  0x00ff0000u },
+    { "C1-C2-overlap",   70,  70,  0x000000ffu },
+    { "C2-only",         110, 100, 0x000000ffu },
+    { "C2-C4-overlap",   120, 130, 0x00ff0000u },
+    { "C3-alpha0",       30,  150, 0x00000000u },
+    { "C4-alpha80",      120, 150, 0x00ff0000u },
+};
+#define NSAMPLES ((int) (sizeof SAMPLES / sizeof SAMPLES[0]))
+
+static int failures;
+
+static Window mkwin(Display *dpy, Window parent, int depth, Visual *vis, Colormap cmap,
+                    int x, int y, int w, int h, unsigned long bg)
+{
+    XSetWindowAttributes attr;
+    unsigned long mask = CWBackPixel | CWOverrideRedirect | CWEventMask;
+    attr.background_pixel = bg;
+    attr.override_redirect = True;
+    attr.event_mask = ExposureMask;
+    if (cmap) {
+        attr.colormap = cmap;
+        attr.border_pixel = 0; /* required when the depth differs from parent */
+        mask |= CWColormap | CWBorderPixel;
+    }
+    return XCreateWindow(dpy, parent, x, y, w, h, 0, depth, InputOutput, vis, mask, &attr);
+}
+
+int main(int argc, char **argv)
+{
+    int hold = 10;
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--hold") == 0 && i + 1 < argc) {
+            hold = atoi(argv[++i]);
+        } else {
+            fprintf(stderr, "usage: %s [--hold N]\n", argv[0]);
+            return 2;
+        }
+    }
+
+    Display *dpy = XOpenDisplay(NULL);
+    if (!dpy) {
+        fprintf(stderr, "redirect-subtree-probe: cannot open display\n");
+        return 1;
+    }
+    int screen = DefaultScreen(dpy);
+    Window root = RootWindow(dpy, screen);
+    Visual *vis24 = DefaultVisual(dpy, screen);
+    int depth24 = DefaultDepth(dpy, screen);
+
+    XVisualInfo vinfo;
+    if (!XMatchVisualInfo(dpy, screen, 32, TrueColor, &vinfo)) {
+        fprintf(stderr, "redirect-subtree-probe: no depth-32 TrueColor visual\n");
+        return 1;
+    }
+    Colormap cmap32 = XCreateColormap(dpy, root, vinfo.visual, AllocNone);
+
+    int ev, err;
+    if (!XCompositeQueryExtension(dpy, &ev, &err)) {
+        fprintf(stderr, "redirect-subtree-probe: no Composite extension\n");
+        return 1;
+    }
+
+    Window f  = mkwin(dpy, root, depth24, vis24, 0, F_X, F_Y, F_W, F_H, F_BG);
+    Window c1 = mkwin(dpy, f, depth24, vis24, 0, 10, 10, 80, 80, C1_BG);
+    Window g  = mkwin(dpy, c1, depth24, vis24, 0, 5, 5, 30, 30, G_BG);
+    Window c2 = mkwin(dpy, f, depth24, vis24, 0, 60, 60, 80, 80, C2_BG);
+    Window c3 = mkwin(dpy, f, 32, vinfo.visual, cmap32, 10, 120, 60, 60, C3_BG);
+    Window c4 = mkwin(dpy, f, 32, vinfo.visual, cmap32, 100, 120, 60, 60, C4_BG);
+
+    /* Map the frame and C1 (with its nested G) first, then C2 — so C2 is
+     * ABOVE C1 in the stack and the overlap has a defined winner. */
+    XMapWindow(dpy, f);
+    XMapWindow(dpy, c1);
+    XMapWindow(dpy, g);
+    XSync(dpy, False);
+    XMapWindow(dpy, c2);
+    XMapWindow(dpy, c3);
+    XMapWindow(dpy, c4);
+    XSync(dpy, False);
+    sleep(1); /* let the tree actually paint before it gets reconstructed */
+
+    /* NOW redirect. The reconstruction walk runs against a painted subtree,
+     * which is the case a fresh-window path would never exercise. */
+    XCompositeRedirectSubwindows(dpy, root, CompositeRedirectAutomatic);
+    XSync(dpy, False);
+    sleep(1);
+
+    Pixmap pm = XCompositeNameWindowPixmap(dpy, f);
+    if (!pm) {
+        fprintf(stderr, "redirect-subtree-probe: NameWindowPixmap failed\n");
+        return 1;
+    }
+
+    printf("# redirect-subtree-probe: frame=%d,%d %dx%d, read via NameWindowPixmap\n",
+           F_X, F_Y, F_W, F_H);
+    printf("# comparison is over the 24 defined bits; the frame pixmap's pad\n");
+    printf("# byte is protocol-undefined and is shown but not graded.\n");
+    printf("# %-16s %-8s %-10s %-10s %s\n", "sample", "at", "got", "xorg_21.1", "verdict");
+    for (int i = 0; i < NSAMPLES; i++) {
+        XImage *img = XGetImage(dpy, pm, SAMPLES[i].x, SAMPLES[i].y, 1, 1, AllPlanes, ZPixmap);
+        if (!img) {
+            printf("%-18s %3d,%-4d %-10s %08lx   READ-FAILED\n",
+                   SAMPLES[i].name, SAMPLES[i].x, SAMPLES[i].y, "-", SAMPLES[i].xorg);
+            failures++;
+            continue;
+        }
+        unsigned long got = XGetPixel(img, 0, 0);
+        XDestroyImage(img);
+        /* Compare the 24 DEFINED bits only. Every sample is read out of the
+         * frame's depth-24 pixmap, whose 8 pad bits are undefined by the
+         * protocol; Xorg passes them through rather than normalising them
+         * (fb/fbimage.c masks only when the replicated plane mask is not
+         * all-ones), so they carry no contract. This still catches the bug
+         * the probe exists for: under PictOpOver the alpha-0 child C3 blended
+         * as a no-op and the frame's own grey showed through, which differs
+         * in the RGB bits, not merely in the pad. */
+        int ok = (got & 0x00ffffffu) == (SAMPLES[i].xorg & 0x00ffffffu);
+        if (!ok)
+            failures++;
+        printf("%-18s %3d,%-4d %08lx   %08lx   %s\n",
+               SAMPLES[i].name, SAMPLES[i].x, SAMPLES[i].y, got, SAMPLES[i].xorg,
+               ok ? "ok" : "DIFF");
+    }
+    printf("%s\n", failures ? "VERDICT: subtree reconstruction DIFFERS from Xorg 21.1"
+                            : "VERDICT: subtree reconstruction matches Xorg 21.1");
+    fflush(stdout);
+
+    for (int e = 0; hold <= 0 || e < hold * 10; e++) {
+        while (XPending(dpy)) {
+            XEvent xev;
+            XNextEvent(dpy, &xev);
+        }
+        usleep(100000);
+    }
+
+    XFreePixmap(dpy, pm);
+    XDestroyWindow(dpy, f); /* takes the whole subtree */
+    XCompositeUnredirectSubwindows(dpy, root, CompositeRedirectAutomatic);
+    XSync(dpy, False);
+    XCloseDisplay(dpy);
+    return failures ? 1 : 0;
+}

--- a/tools/redirect-subtree-probe.c
+++ b/tools/redirect-subtree-probe.c
@@ -34,6 +34,14 @@
  * MEASURED BASELINE — filled in from X.Org 1.21.1.24 below; that table is the
  * contract, exactly as in tools/depth32-bg-probe.c.
  *
+ * Note this probe reads through XGetPixel, NOT raw image bytes as
+ * depth32-bg-probe does. That is sound here only because every sample is
+ * graded on the defined low 24 bits of a depth-24 frame pixmap, and XGetPixel
+ * masks to exactly that depth — the bits it drops are the protocol-undefined
+ * pad, which carries no contract. Anyone extending this probe to compare
+ * ALPHA must switch to raw bytes first, or the comparison will silently
+ * succeed against a masked value.
+ *
  * Build: cc -O1 -o redirect-subtree-probe redirect-subtree-probe.c -lX11 -lXcomposite
  * Run:   ./redirect-subtree-probe [--hold N]
  */

--- a/tools/vng-scenarios/depth32-bg-composited.sh
+++ b/tools/vng-scenarios/depth32-bg-composited.sh
@@ -1,0 +1,30 @@
+# Sourced by tools/vng-shot.sh INSIDE the guest, with DISPLAY=:7 exported and
+# the artifact directory as cwd. The composited twin of depth32-bg.sh: same
+# probe, same two ancestor chains, but with Composite automatic redirection on,
+# so the depth-32 windows are sampled and BLENDED instead of scanned out raw.
+#
+# This is the half that speaks to the Plasma white/black blocks. Non-composited,
+# a depth-32 window is just opaque bytes and every server agrees; the divergence
+# can only appear once something actually multiplies by alpha.
+#
+# The probe redirects itself rather than running picom. An external compositor
+# would add its own shadows, fading and opacity rules to every pixel, and then
+# nothing in the capture could be attributed to the window's own alpha; with
+# automatic redirection the server is the only thing blending.
+#
+# Still NO window manager: a reparenting WM would move the chain-A windows
+# under a frame and collapse the two chains the probe exists to tell apart.
+set -u
+src=$(dirname "$0")/../depth32-bg-probe.c
+[ -r "$src" ] || src=/home/jos/Projects/yserver/tools/depth32-bg-probe.c
+
+cc -O1 -o depth32-bg-probe "$src" -lX11 -lXcomposite > cc.log 2>&1 || {
+    echo "depth32-bg-composited: compile failed" >&2
+    cat cc.log >&2
+}
+if [ -x ./depth32-bg-probe ]; then
+    ./depth32-bg-probe --redirect --hold 0 > client.log 2>&1 &
+    sleep 4
+fi
+
+xwininfo -root -tree > tree.txt 2>&1 || true

--- a/tools/vng-scenarios/depth32-bg.sh
+++ b/tools/vng-scenarios/depth32-bg.sh
@@ -1,0 +1,27 @@
+# Sourced by tools/vng-shot.sh INSIDE the guest, with DISPLAY=:7 exported and
+# the artifact directory as cwd. Xorg's depth-32 background-alpha rule
+# (mi/miexpose.c:487-511) — does bg_pixel's alpha survive into storage, and
+# does that depend on the ancestor chain?
+#
+# Deliberately runs NO window manager: a reparenting WM would move the
+# "direct child of root" windows under a frame and collapse the two chains
+# the probe is built to tell apart. Works unchanged on yserver and on Xorg
+# (`--server xorg`), which makes it a parity check.
+#
+# The load-bearing artifact is client.log (the per-window readback table),
+# not the scanout — nothing composites here, so the scanout only shows the
+# unblended case.
+set -u
+src=$(dirname "$0")/../depth32-bg-probe.c
+[ -r "$src" ] || src=/home/jos/Projects/yserver/tools/depth32-bg-probe.c
+
+cc -O1 -o depth32-bg-probe "$src" -lX11 -lXcomposite > cc.log 2>&1 || {
+    echo "depth32-bg: compile failed" >&2
+    cat cc.log >&2
+}
+if [ -x ./depth32-bg-probe ]; then
+    ./depth32-bg-probe --no-redirect --hold 0 > client.log 2>&1 &
+    sleep 4
+fi
+
+xwininfo -root -tree > tree.txt 2>&1 || true

--- a/tools/vng-scenarios/redirect-subtree.sh
+++ b/tools/vng-scenarios/redirect-subtree.sh
@@ -1,0 +1,21 @@
+# Sourced by tools/vng-shot.sh INSIDE the guest, with DISPLAY=:7 exported and
+# the artifact directory as cwd. Regression cover for the redirect-backing
+# subtree reconstruction (`overlay_backing_inferiors`): overlap, nesting and
+# alpha in one redirected frame. See tools/redirect-subtree-probe.c.
+#
+# No window manager, every window override-redirect: the probe depends on its
+# own stacking order and on nothing reparenting the tree.
+set -u
+src=$(dirname "$0")/../redirect-subtree-probe.c
+[ -r "$src" ] || src=/home/jos/Projects/yserver/tools/redirect-subtree-probe.c
+
+cc -O1 -o redirect-subtree-probe "$src" -lX11 -lXcomposite > cc.log 2>&1 || {
+    echo "redirect-subtree: compile failed" >&2
+    cat cc.log >&2
+}
+if [ -x ./redirect-subtree-probe ]; then
+    ./redirect-subtree-probe --hold 0 > client.log 2>&1 &
+    sleep 6
+fi
+
+xwininfo -root -tree > tree.txt 2>&1 || true


### PR DESCRIPTION
Two measured Xorg divergences, found chasing KDE windows blanking when mpv goes fullscreen.

**1. background None painted white.** CreateWindow with no background attribute means the server paints nothing. We recorded that correctly (`background_none`, honoured by `window_resolved_background`), then overrode it with a fallback to the stored `background_pixel` — which holds a `0x00ffffff` placeholder — so every such window's fresh storage was filled white.

**2. Unredirect dropped window content.** Xorg's `compSetParentPixmap` points a window back at the screen pixmap, which already holds what the compositor painted, so it copies nothing; the copy is on the redirect side (`compNewPixmap`). We hand over a private per-window leaf, stale since the redirect, and re-initialise it from the background on the way out. Now restored from the backing, walking the subtree — a compositor redirects the WM's *frames*, so the client's own window is a grandchild whose pixels live in the frame's backing.

HW trigger: mpv sets `_NET_WM_BYPASS_COMPOSITOR` going fullscreen and KWin suspends compositing screen-wide. `--x11-bypass-compositor=no` suppresses it; totem never triggers it. The blank tracked the leaf's init colour across fix 1 (white → black), which is what identified the leaf rather than a missing Expose.

Three tests, each proven red first. 155/155 acceptance, libs 1294 + 1248, clippy `-D warnings` and nightly fmt clean. Dolphin HW-confirmed on bee.

Open, not claimed fixed: a Plasma panel restoring to its top half only — intermittent, self-healing, suspect and debug-log recipe in `docs/status.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)