### PR TITLE
fix: an XI2 selection absorbs the core press, stopping propagation (#141)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -784,38 +784,6 @@ yserver-openbox-hw log="info":
         kill -TERM $yserver_pid 2>/dev/null;\
         wait $yserver_pid 2>/dev/null;'
 
-# Issue #141 — OpenBox windows spontaneously enter Move/Resize.
-# Client-side ground truth (what OpenBox actually RECEIVED) plus the
-# trace-level pointer paths, which is where QUEUE-WHILE-FROZEN and the
-# grab-delivery decisions live. A debug-level capture cannot show either:
-# the core fanout log line is gated on `!handled_core_via_grab`, so an
-# implicit grab's ButtonRelease never reaches it.
-#
-# Release build on purpose — the bug needs 1-2 minutes of ordinary use to
-# show up, and a debug build's pacing is not that. Only the pointer module
-# is raised to trace, so the log stays readable across that long a session.
-#
-# After a runaway, in openbox-141.xtrace find the last ButtonPress before
-# it and compare its root-x/root-y against the MotionNotify coordinates
-# around it — OpenBox moves by (motion_pos - press_pos), so a warp means
-# those disagree. Then check whether a ButtonRelease for that press ever
-# arrived.
-yserver-openbox-141-trace log="warn,yserver_core::core_loop::pointer_fanout=trace":
-    cargo build --release --bin yserver
-    rm -f openbox-141.xtrace
-    bash -c '\
-        RUST_LOG="{{log}}" RUST_BACKTRACE=1 target/release/yserver > yserver-hw-openbox-141.log 2>&1 &\
-        yserver_pid=$!;\
-        sleep 2;\
-        x11trace -d :7 -D :8 -n -o openbox-141.xtrace &\
-        xtrace_pid=$!;\
-        sleep 1;\
-        env -u WAYLAND_DISPLAY -u WAYLAND_SOCKET DISPLAY=:8 GDK_BACKEND=x11 \
-            XDG_SESSION_TYPE=x11 \
-            openbox > openbox-141.log 2>&1;\
-        kill -TERM $xtrace_pid $yserver_pid 2>/dev/null;\
-        wait $yserver_pid 2>/dev/null;'
-
 yserver-openbox-picom-hw log="info":
     cargo build ---release -bin yserver
     bash -c '\

--- a/Justfile
+++ b/Justfile
@@ -784,6 +784,38 @@ yserver-openbox-hw log="info":
         kill -TERM $yserver_pid 2>/dev/null;\
         wait $yserver_pid 2>/dev/null;'
 
+# Issue #141 — OpenBox windows spontaneously enter Move/Resize.
+# Client-side ground truth (what OpenBox actually RECEIVED) plus the
+# trace-level pointer paths, which is where QUEUE-WHILE-FROZEN and the
+# grab-delivery decisions live. A debug-level capture cannot show either:
+# the core fanout log line is gated on `!handled_core_via_grab`, so an
+# implicit grab's ButtonRelease never reaches it.
+#
+# Release build on purpose — the bug needs 1-2 minutes of ordinary use to
+# show up, and a debug build's pacing is not that. Only the pointer module
+# is raised to trace, so the log stays readable across that long a session.
+#
+# After a runaway, in openbox-141.xtrace find the last ButtonPress before
+# it and compare its root-x/root-y against the MotionNotify coordinates
+# around it — OpenBox moves by (motion_pos - press_pos), so a warp means
+# those disagree. Then check whether a ButtonRelease for that press ever
+# arrived.
+yserver-openbox-141-trace log="warn,yserver_core::core_loop::pointer_fanout=trace":
+    cargo build --release --bin yserver
+    rm -f openbox-141.xtrace
+    bash -c '\
+        RUST_LOG="{{log}}" RUST_BACKTRACE=1 target/release/yserver > yserver-hw-openbox-141.log 2>&1 &\
+        yserver_pid=$!;\
+        sleep 2;\
+        x11trace -d :7 -D :8 -n -o openbox-141.xtrace &\
+        xtrace_pid=$!;\
+        sleep 1;\
+        env -u WAYLAND_DISPLAY -u WAYLAND_SOCKET DISPLAY=:8 GDK_BACKEND=x11 \
+            XDG_SESSION_TYPE=x11 \
+            openbox > openbox-141.log 2>&1;\
+        kill -TERM $xtrace_pid $yserver_pid 2>/dev/null;\
+        wait $yserver_pid 2>/dev/null;'
+
 yserver-openbox-picom-hw log="info":
     cargo build ---release -bin yserver
     bash -c '\

--- a/crates/yserver-core/src/core_loop/fanout.rs
+++ b/crates/yserver-core/src/core_loop/fanout.rs
@@ -143,6 +143,38 @@ pub fn subscribers_by_id(state: &ServerState, window: ResourceId, mask_bits: u32
         .collect()
 }
 
+/// XI2 device ids whose selection ABSORBS a core pointer event: the
+/// master pointer plus the `XIAllMasterDevices(1)` / `XIAllDevices(0)`
+/// wildcards.
+///
+/// The SLAVE pointer id is deliberately ABSENT. Core events are generated
+/// from the master device and a slave-device XI2 selection is matched in
+/// its own delivery pass, so it does not suppress the core form: a client
+/// selecting core AND slave-XI2 on one window legitimately receives BOTH.
+/// Hardware-measured, not inferred — see
+/// `implicit_grab_core_release_survives_dual_core_and_slave_xi2_selection_e27`,
+/// whose Xorg baseline delivers core 3/3 and XI2 3/3 on the same clicks.
+/// Including the slave id here silently dropped E27's core press.
+const XI2_ABSORBING_POINTER_DEVICES: [u16; 3] = [2, 1, 0];
+
+/// Does any client hold an XI2 selection for `evtype` on this window?
+///
+/// Xorg's `DeliverDeviceEvents` (`dix/events.c:2895-2916`) tries XI2, then
+/// XI1, then CORE **per window**, returning as soon as any flavour
+/// delivers — so an XI2 selection ABSORBS the event and the core
+/// propagation walk stops there, whoever selected core further up.
+fn xi2_pointer_selected_on(state: &ServerState, window: ResourceId, evtype: u16) -> bool {
+    let bit = 1u32 << evtype;
+    state.clients.values().any(|client| {
+        XI2_ABSORBING_POINTER_DEVICES.iter().any(|device| {
+            client
+                .xi2_masks
+                .get(&(window, *device))
+                .is_some_and(|mask| mask & bit != 0)
+        })
+    })
+}
+
 /// Walk up the parent chain from `start`, returning the first window
 /// with any client subscribed to `mask_bits`, the (event_x, event_y)
 /// translated to be relative to that window, and the subscriber list.
@@ -171,12 +203,25 @@ pub fn pointer_propagation_target_by_id(
     start_x: i16,
     start_y: i16,
     mask_bits: u32,
+    xi2_evtype: Option<u16>,
 ) -> Option<(ResourceId, i16, i16, Vec<ClientId>, ResourceId)> {
     let mut current = start;
     let mut x = start_x;
     let mut y = start_y;
     let mut child: Option<ResourceId> = None;
     for _ in 0..256 {
+        // XI2 FIRST, per Xorg's per-window flavour order. A window whose
+        // XI2 selection matches consumes the event: no core delivery here,
+        // and crucially no walk past it. Without this a GTK client — XI2,
+        // no core mask — let the press climb to the reparenting WM's
+        // frame, handing the WM a press Xorg never sends. That armed
+        // OpenBox's drag state, so a later bare MotionNotify started a
+        // Move/Resize with no button held (#141).
+        if let Some(evtype) = xi2_evtype
+            && xi2_pointer_selected_on(state, current, evtype)
+        {
+            return None;
+        }
         let subs = subscribers_by_id(state, current, mask_bits);
         if !subs.is_empty() {
             return Some((current, x, y, subs, child.unwrap_or(ResourceId(0))));
@@ -793,6 +838,115 @@ mod tests {
         let client = make_client(a, mask);
         state.clients.insert(id, client);
         b
+    }
+
+    /// Issue #141 — a reparenting WM must not be handed a core press that
+    /// an XI2 client absorbed. Xorg's `DeliverDeviceEvents`
+    /// (`dix/events.c:2895-2916`) tries XI2, then XI1, then core PER
+    /// WINDOW and returns as soon as any flavour delivers, so a GTK-style
+    /// child selecting XI2 and no core mask consumes the event and the
+    /// walk stops — the frame above it sees nothing.
+    ///
+    /// Oracle is measured, not read off the source:
+    /// `tools/replay-propagation-probe.c` run under
+    /// `tools/vng-scenarios/replay-propagation.sh` against Xorg 21.1 and
+    /// yserver in the same harness. Xorg gave the WM 1 core press (its own
+    /// grab activation) and no propagated second one; yserver gave 2, the
+    /// second on the PARENT. That second press armed OpenBox's drag state,
+    /// so a later bare MotionNotify started a Move/Resize with no button
+    /// held — windows following the pointer once every minute or two.
+    ///
+    /// The slave half is the E27 carve-out and is asserted here too: a
+    /// SLAVE-device XI2 selection must NOT absorb, because core events come
+    /// from the master and the slave form is a separate delivery pass. See
+    /// `implicit_grab_core_release_survives_dual_core_and_slave_xi2_selection_e27`,
+    /// whose Xorg baseline delivers both forms 3/3.
+    #[test]
+    fn xi2_master_selection_absorbs_core_propagation_but_slave_does_not() {
+        use yserver_protocol::x11::CreateWindowRequest;
+        const WM: u32 = 1;
+        const APP: u32 = 2;
+        const XI_BUTTON_PRESS: u16 = 4;
+        const FRAME: ResourceId = ResourceId(0x0010_0001);
+        const CHILD: ResourceId = ResourceId(0x0020_0001);
+
+        let build = |xi2_device: u16| {
+            let mut state = ServerState::new();
+            let _wm_peer = install(&mut state, WM, 0);
+            let _app_peer = install(&mut state, APP, 0);
+            for (window, parent) in [(FRAME, ROOT_WINDOW), (CHILD, FRAME)] {
+                state.resources.create_window(
+                    ClientId(if window == FRAME { WM } else { APP }),
+                    CreateWindowRequest {
+                        depth: 24,
+                        window,
+                        parent,
+                        x: 0,
+                        y: 0,
+                        width: 100,
+                        height: 100,
+                        border_width: 0,
+                        class: 1,
+                        visual: crate::resources::ROOT_VISUAL,
+                        ..Default::default()
+                    },
+                );
+                let _ = state.resources.map_window(window);
+            }
+            // The frame selects core ButtonPress, as a reparenting WM does.
+            state
+                .clients
+                .get_mut(&WM)
+                .unwrap()
+                .event_masks
+                .insert(FRAME, 0x0000_0004);
+            // The child selects XI2 ButtonPress and NO core mask.
+            state
+                .clients
+                .get_mut(&APP)
+                .unwrap()
+                .xi2_masks
+                .insert((CHILD, xi2_device), 1 << XI_BUTTON_PRESS);
+            state
+        };
+
+        // XIAllMasterDevices: absorbed, nothing propagates to the frame.
+        let state = build(1);
+        assert!(
+            pointer_propagation_target_by_id(
+                &state,
+                CHILD,
+                5,
+                5,
+                0x0000_0004,
+                Some(XI_BUTTON_PRESS)
+            )
+            .is_none(),
+            "an XI2 master-device selection must absorb the core press, \
+             leaving the WM's frame nothing to receive",
+        );
+
+        // Slave device: NOT absorbed — core still propagates to the frame.
+        let state = build(4);
+        let (win, _, _, subs, _) = pointer_propagation_target_by_id(
+            &state,
+            CHILD,
+            5,
+            5,
+            0x0000_0004,
+            Some(XI_BUTTON_PRESS),
+        )
+        .expect("a slave-device XI2 selection must not absorb the core press");
+        assert_eq!(win, FRAME);
+        assert_eq!(subs, vec![ClientId(WM)]);
+
+        // And with no XI2 evtype in play (crossing events) the walk is
+        // unchanged: Enter/Leave are not routed by the flavour-ordered loop.
+        let state = build(1);
+        let (win, _, _, _, _) =
+            pointer_propagation_target_by_id(&state, CHILD, 5, 5, 0x0000_0004, None)
+                .expect("without an absorbing evtype the walk still finds the frame");
+        assert_eq!(win, FRAME);
     }
 
     #[test]

--- a/crates/yserver-core/src/core_loop/pointer_fanout.rs
+++ b/crates/yserver-core/src/core_loop/pointer_fanout.rs
@@ -696,10 +696,16 @@ fn pointer_event_fanout_to_state_inner(
             },
         );
         let mask_bit = pointer_mask_bit(event.kind, event.state);
-        let core_clients =
-            pointer_propagation_target_by_id(state, target, target_x, target_y, mask_bit)
-                .map(|(_, _, _, c, _)| c)
-                .unwrap_or_default();
+        let core_clients = pointer_propagation_target_by_id(
+            state,
+            target,
+            target_x,
+            target_y,
+            mask_bit,
+            xi2_absorbing_evtype(event.kind),
+        )
+        .map(|(_, _, _, c, _)| c)
+        .unwrap_or_default();
         let xi2_evt = xi2_evtype(event.kind);
         let (xi2_clients, _) = compute_xi2_targets(state, target, top_level_id, xi2_evt, None);
         let label_clients = |cs: &[ClientId]| -> String {
@@ -1083,8 +1089,15 @@ fn pointer_event_fanout_to_state_inner(
             (target, target_x, target_y)
         };
         let (nested_id, event_x, event_y, mut core_targets, propagation_child) =
-            pointer_propagation_target_by_id(state, cross_start, cross_x, cross_y, mask_bit)
-                .unwrap_or((cross_start, cross_x, cross_y, Vec::new(), ResourceId(0)));
+            pointer_propagation_target_by_id(
+                state,
+                cross_start,
+                cross_x,
+                cross_y,
+                mask_bit,
+                xi2_absorbing_evtype(event.kind),
+            )
+            .unwrap_or((cross_start, cross_x, cross_y, Vec::new(), ResourceId(0)));
 
         // XI2 shadows core per client (Xorg behaviour, mirrors
         // `deliver_key_to_window`): a client that receives the XI2
@@ -2827,6 +2840,22 @@ fn xi2_evtype(kind: PointerEventKind) -> u16 {
         PointerEventKind::MotionNotify => 6,
         PointerEventKind::EnterNotify => 7,
         PointerEventKind::LeaveNotify => 8,
+    }
+}
+
+/// The XI2 evtype whose selection ABSORBS this event during the core
+/// propagation walk, or None when the absorb rule does not apply.
+///
+/// Device events only. Crossing events are NOT routed by
+/// `DeliverDeviceEvents`' flavour-ordered loop in Xorg — they are
+/// delivered per window along the crossing chain — so an XI_Enter /
+/// XI_Leave selection must not suppress core Enter/Leave anywhere.
+fn xi2_absorbing_evtype(kind: PointerEventKind) -> Option<u16> {
+    match kind {
+        PointerEventKind::ButtonPress
+        | PointerEventKind::ButtonRelease
+        | PointerEventKind::MotionNotify => Some(xi2_evtype(kind)),
+        PointerEventKind::EnterNotify | PointerEventKind::LeaveNotify => None,
     }
 }
 

--- a/tools/replay-propagation-probe.c
+++ b/tools/replay-propagation-probe.c
@@ -1,0 +1,261 @@
+/*
+ * replay-propagation-probe — where does AllowEvents(ReplayPointer) put the
+ * press, when the window under the pointer selected XI2 but not core?
+ *
+ * Issue #141: under OpenBox, a window spontaneously starts following the
+ * pointer (sometimes resizing instead), a click stops it, and it never
+ * happens on Xorg. The xtrace capture (2026-09-11, air) showed OpenBox
+ * re-entering interactive moveresize with NO triggering X event at all —
+ * no ButtonPress, no _NET_WM_MOVERESIZE, no key event, no modifier. The
+ * only mechanism that fits is OpenBox's mouse.c firing its Drag binding
+ * from a bare MotionNotify while its internal `button` is still set,
+ * using the press position it remembers — which is also why the window
+ * warps ~1000px before it starts tracking.
+ *
+ * What could double-arm that state: in the capture OpenBox saw the SAME
+ * press twice — once on the client window (its own passive grab
+ * activating) and once on the frame (the replay propagating up, because
+ * the GTK client selected XI2 and not core). So this probe asks the one
+ * question that decides whether that second delivery is ours to fix:
+ *
+ *   after AllowEvents(ReplayPointer), who receives the replayed press
+ *   for each combination of core/XI2 selection on the child?
+ *
+ * Layout, mirroring OpenBox: a "wm" connection owns parent P (selects
+ * core ButtonPress, like a frame) and holds a passive button grab on the
+ * child with pointer_mode=Sync — Sync is what makes ReplayPointer mean
+ * anything. A separate "client" connection owns child C inside P and
+ * selects core and/or XI2 per case.
+ *
+ * Run the SAME binary against Xorg and against yserver and diff the
+ * table. Any row where they differ is the bug; a fully matching table
+ * refutes this hypothesis and the hunt moves elsewhere.
+ *
+ *   cc -O1 -o /tmp/rpp tools/replay-propagation-probe.c -lX11 -lXi -lXtst
+ *   DISPLAY=:19 /tmp/rpp
+ *
+ * Uses XTEST to place the pointer and click, so it needs no human. It
+ * warps the pointer, so prefer a nested server (Xephyr) over a live
+ * desktop.
+ */
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include <X11/extensions/XInput2.h>
+#include <X11/extensions/XTest.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define P_W 400
+#define P_H 300
+#define C_X 40
+#define C_Y 40
+#define C_W 200
+#define C_H 150
+
+enum { SEL_XI2_ONLY, SEL_CORE_ONLY, SEL_BOTH, SEL_NEITHER, N_CASES };
+
+static const char *case_name(int c)
+{
+    switch (c) {
+    case SEL_XI2_ONLY:  return "child selects XI2 only  ";
+    case SEL_CORE_ONLY: return "child selects core only ";
+    case SEL_BOTH:      return "child selects both      ";
+    default:            return "child selects neither   ";
+    }
+}
+
+struct result {
+    int wm_presses;        /* core presses the "wm" connection saw */
+    Window wm_first_win;   /* event window of the 1st (grab activation) */
+    Window wm_second_win;  /* event window of the 2nd (the replay), if any */
+    int client_core;       /* core presses the client connection saw */
+    int client_xi2;        /* XI2 presses the client connection saw */
+};
+
+/* Drain both connections for `ms`, tallying presses. */
+static void collect(Display *wm, Display *cl, int xi_opcode, int ms,
+                    struct result *r)
+{
+    for (int i = 0; i < ms; i++) {
+        while (XPending(wm)) {
+            XEvent e;
+            XNextEvent(wm, &e);
+            if (e.type == ButtonPress) {
+                if (r->wm_presses == 0)
+                    r->wm_first_win = e.xbutton.window;
+                else if (r->wm_presses == 1)
+                    r->wm_second_win = e.xbutton.window;
+                r->wm_presses++;
+            }
+        }
+        while (XPending(cl)) {
+            XEvent e;
+            XNextEvent(cl, &e);
+            if (e.type == ButtonPress) {
+                r->client_core++;
+            } else if (e.type == GenericEvent) {
+                XGenericEventCookie *ck = &e.xcookie;
+                if (ck->extension == xi_opcode && XGetEventData(cl, ck)) {
+                    if (ck->evtype == XI_ButtonPress)
+                        r->client_xi2++;
+                    XFreeEventData(cl, ck);
+                }
+            }
+        }
+        usleep(1000);
+    }
+}
+
+/* Non-fatal: a diagnostic must print its table even if cleanup errors,
+ * and the two servers may well disagree about which requests error —
+ * that is data, not a reason to abort. */
+static int x_errors;
+static int swallow_error(Display *d, XErrorEvent *e)
+{
+    char buf[128];
+    XGetErrorText(d, e->error_code, buf, sizeof buf);
+    fprintf(stderr, "  [x-error] %s on major %d (resource 0x%lx)\n", buf,
+            e->request_code, e->resourceid);
+    x_errors++;
+    return 0;
+}
+
+int main(void)
+{
+    XSetErrorHandler(swallow_error);
+    Display *wm = XOpenDisplay(NULL);
+    if (!wm) {
+        fprintf(stderr, "cannot open display\n");
+        return 2;
+    }
+    Display *cl = XOpenDisplay(NULL);
+    if (!cl) {
+        fprintf(stderr, "cannot open second connection\n");
+        return 2;
+    }
+
+    int xi_opcode, ev, err;
+    if (!XQueryExtension(cl, "XInputExtension", &xi_opcode, &ev, &err)) {
+        fprintf(stderr, "no XInputExtension\n");
+        return 2;
+    }
+    int xi_major = 2, xi_minor = 0;
+    if (XIQueryVersion(cl, &xi_major, &xi_minor) != Success) {
+        fprintf(stderr, "no XI2\n");
+        return 2;
+    }
+    int t_ev, t_err, t_major, t_minor;
+    if (!XTestQueryExtension(wm, &t_ev, &t_err, &t_major, &t_minor)) {
+        fprintf(stderr, "no XTEST — cannot drive input\n");
+        return 2;
+    }
+
+    printf("server vendor: %s (release %d)\n", ServerVendor(wm),
+           VendorRelease(wm));
+
+    struct result results[N_CASES];
+    memset(results, 0, sizeof results);
+
+    for (int c = 0; c < N_CASES; c++) {
+        /* Parent P, owned by the "wm" connection: selects core
+         * ButtonPress exactly as a reparenting WM's frame does. */
+        Window p = XCreateSimpleWindow(wm, DefaultRootWindow(wm), 0, 0,
+                                       P_W, P_H, 0, 0,
+                                       BlackPixel(wm, 0));
+        /* override-redirect so no WM reparents or moves P: the synthetic
+         * click is at fixed ROOT coordinates and has to land inside C.
+         * Also keeps the probe safe to run on a live desktop — the click
+         * cannot reach whatever was underneath. */
+        XSetWindowAttributes swa;
+        swa.override_redirect = True;
+        XChangeWindowAttributes(wm, p, CWOverrideRedirect, &swa);
+        XSelectInput(wm, p, ButtonPressMask | ButtonReleaseMask |
+                                ExposureMask | StructureNotifyMask);
+        XMapRaised(wm, p);
+        XSync(wm, False);
+
+        /* Child C, owned by the OTHER connection, created under P — the
+         * reparented-client shape. */
+        Window ch = XCreateSimpleWindow(cl, p, C_X, C_Y, C_W, C_H, 0, 0,
+                                        WhitePixel(cl, 0));
+        if (c == SEL_CORE_ONLY || c == SEL_BOTH)
+            XSelectInput(cl, ch, ButtonPressMask);
+        else
+            XSelectInput(cl, ch, 0);
+        if (c == SEL_XI2_ONLY || c == SEL_BOTH) {
+            unsigned char mask[XIMaskLen(XI_LASTEVENT)];
+            memset(mask, 0, sizeof mask);
+            XISetMask(mask, XI_ButtonPress);
+            XIEventMask em = { .deviceid = XIAllMasterDevices,
+                               .mask_len = sizeof mask,
+                               .mask = mask };
+            XISelectEvents(cl, ch, &em, 1);
+        }
+        XMapWindow(cl, ch);
+        XSync(cl, False);
+        XSync(wm, False);
+
+        /* The WM's passive grab on the CHILD, owner_events=False and
+         * pointer_mode=Sync — openbox's click-to-focus grab, and Sync is
+         * what ReplayPointer needs to have anything to replay. */
+        XGrabButton(wm, Button1, AnyModifier, ch, False, ButtonPressMask,
+                    GrabModeSync, GrabModeAsync, None, None);
+        XSync(wm, False);
+
+        /* Put the pointer inside C and click. */
+        int px = C_X + C_W / 2, py = C_Y + C_H / 2;
+        XTestFakeMotionEvent(wm, -1, px, py, 0);
+        XSync(wm, False);
+        usleep(20000);
+        XTestFakeButtonEvent(wm, Button1, True, 0);
+        XSync(wm, False);
+
+        /* Let the activation arrive, THEN replay. */
+        collect(wm, cl, xi_opcode, 120, &results[c]);
+        XAllowEvents(wm, ReplayPointer, CurrentTime);
+        XSync(wm, False);
+        collect(wm, cl, xi_opcode, 200, &results[c]);
+
+        XTestFakeButtonEvent(wm, Button1, False, 0);
+        XSync(wm, False);
+        collect(wm, cl, xi_opcode, 80, &results[c]);
+
+        XUngrabButton(wm, Button1, AnyModifier, ch);
+        XDestroyWindow(cl, ch);
+        XSync(cl, False);
+        XDestroyWindow(wm, p);
+        XSync(wm, False);
+        usleep(50000);
+
+        /* Record P/C identity for the report. */
+        printf("case %d: P=0x%lx C=0x%lx\n", c, p, ch);
+    }
+
+    printf("\n%-26s | wm core presses | 2nd to | client core | client XI2\n",
+           "case");
+    printf("---------------------------+-----------------+--------+-------------+-----------\n");
+    for (int c = 0; c < N_CASES; c++) {
+        struct result *r = &results[c];
+        const char *second = r->wm_presses < 2 ? "-"
+                             : (r->wm_second_win == r->wm_first_win ? "same win"
+                                                                    : "PARENT");
+        printf("%-26s | %15d | %-6s | %11d | %9d\n", case_name(c),
+               r->wm_presses, second, r->client_core, r->client_xi2);
+    }
+
+    /* The row that matters for #141: XI2-only child. A second core press
+     * to the WM there is the double-arming candidate. */
+    struct result *x = &results[SEL_XI2_ONLY];
+    printf("\nXI2-ONLY ROW: wm saw %d core press(es); client saw %d XI2, %d core.\n",
+           x->wm_presses, x->client_xi2, x->client_core);
+    printf("VERDICT: replayed press %s to the WM's parent window.\n",
+           x->wm_presses >= 2 ? "IS propagated" : "is NOT propagated");
+    printf("Compare this table between Xorg and yserver; a differing row is the bug.\n");
+    printf("x-errors during the run: %d\n", x_errors);
+
+    XCloseDisplay(cl);
+    XCloseDisplay(wm);
+    return 0;
+}

--- a/tools/vng-scenarios/replay-propagation.sh
+++ b/tools/vng-scenarios/replay-propagation.sh
@@ -1,0 +1,39 @@
+# Sourced by tools/vng-shot.sh INSIDE the guest, with DISPLAY=:7 exported and
+# the artifact directory as cwd. Issue #141 — after AllowEvents(ReplayPointer),
+# does a core press propagate past a child that selected XI2 but not core?
+#
+# Xorg stops the propagation walk as soon as ANY flavour delivers (XI2, then
+# XI1, then core, per window — dix/events.c:2895-2916), so an XI2-only child
+# absorbs the press and the WM's frame never sees it. yserver's
+# pointer_propagation_target_by_id consults core masks only, so it keeps
+# walking and hands the frame a press Xorg never sends — which arms OpenBox's
+# drag state and produces the spontaneous Move/Resize of #141.
+#
+# Deliberately runs NO window manager: the probe plays both roles itself (one
+# connection owns the parent + passive grab, another owns the XI2-only child)
+# and a WM would reparent the parent out from under the synthetic click. The
+# parent is override-redirect for the same reason.
+#
+# Pure protocol — no rendering involved — so `--dump none` is right and the
+# load-bearing artifact is client.log, which ends in a table to diff against
+# the same run with `--server xorg`.
+#
+#   tools/vng-shot.sh --server xorg --dump none --name rp-xorg \
+#       --scenario tools/vng-scenarios/replay-propagation.sh
+#   tools/vng-shot.sh --dump none --name rp-ys \
+#       --scenario tools/vng-scenarios/replay-propagation.sh
+set -u
+src=$(dirname "$0")/../replay-propagation-probe.c
+[ -r "$src" ] || src=/home/jos/Projects/yserver/tools/replay-propagation-probe.c
+
+cc -O1 -o replay-propagation-probe "$src" -lX11 -lXi -lXtst > cc.log 2>&1 || {
+    echo "replay-propagation: compile failed" >&2
+    cat cc.log >&2
+}
+if [ -x ./replay-propagation-probe ]; then
+    ./replay-propagation-probe > client.log 2>&1
+    echo "--- client.log ---"
+    cat client.log
+fi
+
+xwininfo -root -tree > tree.txt 2>&1 || true


### PR DESCRIPTION
Fixes #141 — under OpenBox, windows spontaneously started following the pointer (sometimes resizing) until a click stopped it, roughly once every 1-2 minutes. Never happened on Xorg.

**Cause.** Xorg's `DeliverDeviceEvents` (`dix/events.c:2895-2916`) tries XI2, then XI1, then core *per window* and returns as soon as any flavour delivers, so a window whose XI2 selection matches consumes the event and propagation stops there. `pointer_propagation_target_by_id` consulted core masks only, so a GTK client — XI2 selected, no core mask — let the press climb to the reparenting WM's frame. OpenBox armed its drag state from that press and later started a Move/Resize from a bare `MotionNotify` with no button held.

**Change.** The propagation walk now takes an absorbing XI2 evtype and stops at a matching window. Slave-device selections are excluded: core events come from the master, so a client selecting core *and* slave-XI2 on one window legitimately receives both (`implicit_grab_core_release_survives_dual_core_and_slave_xi2_selection_e27`, Xorg baseline core 3/3 XI2 3/3). Crossing events pass `None` — Enter/Leave aren't routed by that loop.

**Measured**, same harness and probe binary, only the server differs (`tools/replay-propagation-probe.c` via `tools/vng-scenarios/replay-propagation.sh`):

| child selects | Xorg | yserver before | yserver after |
|---|---|---|---|
| XI2 only | 1 press, no propagation | 2 presses, to PARENT | 1 press, no propagation |
| core only | 1, — | 1, — | 1, — |
| both | 1, — | 1, — | 1, — |
| neither | 2, PARENT | 2, PARENT | 2, PARENT |

**Verification.** New `xi2_master_selection_absorbs_core_propagation_but_slave_does_not`, proven red with the fix disabled. yserver-core 1249, yserver lib 1294, render_acceptance 155, clippy `-D warnings`, nightly fmt — all clean. Confirmed fixed on hardware; still reproduces on master.

Not OpenBox-specific: any reparenting WM with a GTK/Qt client was being handed presses Xorg never sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)